### PR TITLE
Authentication Security Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/formswim/teststream/auth/config/SecurityConfig.java
+++ b/src/main/java/com/formswim/teststream/auth/config/SecurityConfig.java
@@ -1,14 +1,48 @@
 package com.formswim.teststream.auth.config;
 
+import com.formswim.teststream.auth.service.AppUserDetailsService;
+import com.formswim.teststream.auth.service.LoginThrottleService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.FlashMap;
+import org.springframework.web.servlet.support.RequestContextUtils;
+
+import java.io.IOException;
 
 @Configuration
 public class SecurityConfig {
+
+    private static final String GENERIC_LOGIN_ERROR = "Invalid email or password";
+    private static final String CONTENT_SECURITY_POLICY =
+        "default-src 'self'; " +
+            "script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; " +
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+            "font-src 'self' https://fonts.gstatic.com data:; " +
+            "img-src 'self' data:; " +
+            "connect-src 'self'; " +
+            "base-uri 'self'; " +
+            "form-action 'self'; " +
+            "frame-ancestors 'none'; " +
+            "object-src 'none'";
+
+    private final LoginThrottleService loginThrottleService;
+    private final AppUserDetailsService appUserDetailsService;
+
+    public SecurityConfig(LoginThrottleService loginThrottleService,
+                          AppUserDetailsService appUserDetailsService) {
+        this.loginThrottleService = loginThrottleService;
+        this.appUserDetailsService = appUserDetailsService;
+    }
 
     // Keeps password hashing working
     @Bean
@@ -16,16 +50,84 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    // TODO: For later — enable CSRF for production and add CSRF tokens
-    // to all POST forms (login, register, logout, etc.) using Thymeleaf.
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())
+            .userDetailsService(appUserDetailsService)
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll()
+                .requestMatchers("/", "/login", "/register", "/error", "/test.html").permitAll()
+                .requestMatchers("/workspace/**", "/logout").authenticated()
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form
+                .loginPage("/login")
+                .loginProcessingUrl("/login")
+                .usernameParameter("email")
+                .successHandler(authenticationSuccessHandler())
+                .failureHandler(authenticationFailureHandler())
+                .permitAll()
+            )
+            .logout(logout -> logout
+                .logoutUrl("/logout")
+                .invalidateHttpSession(true)
+                .deleteCookies("JSESSIONID")
+                .logoutSuccessHandler(logoutSuccessHandler())
+            )
+            .sessionManagement(session -> session
+                .sessionFixation(sessionFixation -> sessionFixation.migrateSession())
+            )
+            .headers(headers -> headers
+                .contentSecurityPolicy(csp -> csp.policyDirectives(CONTENT_SECURITY_POLICY))
+                .frameOptions(frameOptions -> frameOptions.deny())
+                .contentTypeOptions(contentTypeOptions -> {})
+                .referrerPolicy(referrerPolicy -> referrerPolicy.policy(org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
             );
 
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationSuccessHandler authenticationSuccessHandler() {
+        return (request, response, authentication) -> {
+            loginThrottleService.resetFailures(authentication.getName());
+            response.sendRedirect(request.getContextPath() + "/workspace");
+        };
+    }
+
+    @Bean
+    public AuthenticationFailureHandler authenticationFailureHandler() {
+        return (request, response, exception) -> {
+            if (!(exception instanceof org.springframework.security.authentication.LockedException)
+                && !(exception instanceof org.springframework.security.authentication.DisabledException)) {
+                loginThrottleService.recordFailure(request.getParameter("email"));
+            }
+
+            addFlashMessage(request, response, "errorMessage", GENERIC_LOGIN_ERROR);
+            response.sendRedirect(request.getContextPath() + "/login");
+        };
+    }
+
+    @Bean
+    public LogoutSuccessHandler logoutSuccessHandler() {
+        return (request, response, authentication) -> {
+            addFlashMessage(request, response, "logoutMessage", "You have been logged out");
+            response.sendRedirect(request.getContextPath() + "/login");
+        };
+    }
+
+    private void addFlashMessage(HttpServletRequest request,
+                                 HttpServletResponse response,
+                                 String attributeName,
+                                 String attributeValue) {
+        FlashMap flashMap = RequestContextUtils.getOutputFlashMap(request);
+        var flashMapManager = RequestContextUtils.getFlashMapManager(request);
+
+        if (flashMap != null && flashMapManager != null) {
+            flashMap.put(attributeName, attributeValue);
+            flashMapManager.saveOutputFlashMap(flashMap, request, response);
+            return;
+        }
+
+        request.getSession(true).setAttribute(attributeName, attributeValue);
     }
 }

--- a/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
+++ b/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
@@ -1,28 +1,33 @@
 package com.formswim.teststream.auth.controller;
 
+import com.formswim.teststream.auth.dto.RegistrationForm;
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
-
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
-
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.validation.Valid;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @Controller
 public class AuthController {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    public AuthController(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
     // Shows landing page
     @GetMapping("/")
@@ -30,142 +35,84 @@ public class AuthController {
         return "landing";
     }
 
-    // Shows login page + displays any error/success/logout messages
     @GetMapping("/login")
-    public String getLogin(HttpSession session,
-                           Model model,
-                           @RequestParam(required = false) String error,
-                           @RequestParam(required = false) String success,
-                           @RequestParam(required = false) String logout) {
-
-        String sessionEmail = (String) session.getAttribute("session_user");
-
-        if (sessionEmail != null) {
+    public String getLogin(Authentication authentication, HttpSession session, Model model) {
+        if (isAuthenticated(authentication)) {
             return "redirect:/workspace";
         }
 
-        if (error != null) model.addAttribute("errorMessage", error);
-        if (success != null) model.addAttribute("successMessage", success);
-        if (logout != null) model.addAttribute("logoutMessage", logout);
+        moveSessionMessage(session, model, "errorMessage");
+        moveSessionMessage(session, model, "successMessage");
+        moveSessionMessage(session, model, "logoutMessage");
 
         return "login";
     }
 
-    // Shows register page + displays messages if needed
     @GetMapping("/register")
-    public String getRegister(HttpSession session,
-                              Model model,
-                              @RequestParam(required = false) String error,
-                              @RequestParam(required = false) String success) {
-        
-        String sessionEmail = (String) session.getAttribute("session_user");
-        if (sessionEmail != null) {
+    public String getRegister(Authentication authentication) {
+        if (isAuthenticated(authentication)) {
             return "redirect:/workspace";
         }
-
-        if (error != null) model.addAttribute("errorMessage", error);
-        if (success != null) model.addAttribute("successMessage", success);
 
         return "register";
     }
 
-    // Processes login: checks email + password and creates session
-    @PostMapping("/login")
-    public String login(@RequestParam String email,
-                        @RequestParam String password,
-                        HttpServletRequest request) {
-
-        Optional<AppUser> userOptional = userRepository.findByEmail(email);
-
-        if (userOptional.isEmpty()) {
-            return "redirect:/login?error=User not found";
-        }
-
-        AppUser user = userOptional.get();
-
-        if (!passwordEncoder.matches(password, user.getPasswordHash())) {
-            return "redirect:/login?error=Invalid email or password";
-        }
-
-        request.getSession().setAttribute("session_user", user.getEmail());
-
-        return "redirect:/workspace";
-    }
-
-    // Processes registration: creates new user with hashed password
     @PostMapping("/register")
-    public String register(@RequestParam String email,
-                           @RequestParam String password,
-                           @RequestParam String confirmPassword,
-                           @RequestParam(required = false, name = "teamCode") String teamCode) {
-        
-        if (email == null || email.isBlank()) {
-            return "redirect:/register?error=Email is required";
+    public String register(@Valid @ModelAttribute RegistrationForm registrationForm,
+                           BindingResult bindingResult,
+                           RedirectAttributes redirectAttributes) {
+        String normalizedEmail = AppUser.normalizeEmail(registrationForm.getEmail());
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+
+        if (bindingResult.hasErrors()) {
+            bindingResult.getFieldErrors().forEach(error -> fieldErrors.putIfAbsent(error.getField(), error.getDefaultMessage()));
         }
 
-        if (password == null || password.isBlank()) {
-            return "redirect:/register?error=Password is required";
+        if (!fieldErrors.containsKey("confirmPassword")
+            && registrationForm.getPassword() != null
+            && registrationForm.getConfirmPassword() != null
+            && !registrationForm.getPassword().equals(registrationForm.getConfirmPassword())) {
+            fieldErrors.put("confirmPassword", "Passwords do not match");
         }
 
-        if (password.length() < 8) {
-            return "redirect:/register?error=Password must be at least 8 characters";
+        if (normalizedEmail != null && userRepository.findByEmailIgnoreCase(normalizedEmail).isPresent()) {
+            fieldErrors.putIfAbsent("email", "An account with that email already exists");
         }
 
-        if (confirmPassword == null || confirmPassword.isBlank()) {
-            return "redirect:/register?error=Please confirm your password";
+        if (!fieldErrors.isEmpty()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Please correct the highlighted fields.");
+            redirectAttributes.addFlashAttribute("fieldErrors", fieldErrors);
+            redirectAttributes.addFlashAttribute("email", registrationForm.getEmail());
+            redirectAttributes.addFlashAttribute("teamCode", registrationForm.getTeamCode());
+            return "redirect:/register";
         }
 
-        if (!password.equals(confirmPassword)) {
-            return "redirect:/register?error=Passwords do not match";
-        }
-        
-        Optional<AppUser> existingUser = userRepository.findByEmail(email);
-
-        if (existingUser.isPresent()) {
-            return "redirect:/register?error=User already exists";
-        }
-
-        String hashedPassword = passwordEncoder.encode(password);
-
-        AppUser user = new AppUser(email, hashedPassword, teamCode);
+        String hashedPassword = passwordEncoder.encode(registrationForm.getPassword());
+        AppUser user = new AppUser(normalizedEmail, hashedPassword, registrationForm.getTeamCode());
         userRepository.save(user);
 
-        return "redirect:/login?success=Account created successfully";
+        redirectAttributes.addFlashAttribute("successMessage", "Account created successfully. Sign in to continue.");
+        return "redirect:/login";
     }
 
-    // Shows workspace page (only if logged in)
     @GetMapping("/workspace")
-    public String workspace(HttpSession session, Model model) {
-
-        String sessionEmail = (String) session.getAttribute("session_user");
-
-        if (sessionEmail == null) {
-            return "redirect:/login?error=Please log in first";
-        }
-
-        model.addAttribute("userEmail", sessionEmail);
+    public String workspace(Authentication authentication, Model model) {
+        model.addAttribute("userEmail", authentication.getName());
 
         return "workspace";
     }
 
-    // Returns current logged-in user's email (for testing/debugging)
-    @GetMapping("/me")
-    @ResponseBody
-    public String getCurrentUser(HttpSession session) {
-
-        String sessionEmail = (String) session.getAttribute("session_user");
-
-        if (sessionEmail == null) {
-            return "No user logged in";
-        }
-
-        return "Logged in user: " + sessionEmail;
+    private boolean isAuthenticated(Authentication authentication) {
+        return authentication != null
+            && authentication.isAuthenticated()
+            && !(authentication instanceof AnonymousAuthenticationToken);
     }
 
-    // Logs user out by destroying session
-    @PostMapping("/logout")
-    public String logout(HttpServletRequest request) {
-        request.getSession().invalidate();
-        return "redirect:/login?logout=You have been logged out";
+    private void moveSessionMessage(HttpSession session, Model model, String attributeName) {
+        Object value = session.getAttribute(attributeName);
+        if (value != null) {
+            model.addAttribute(attributeName, value);
+            session.removeAttribute(attributeName);
+        }
     }
 }

--- a/src/main/java/com/formswim/teststream/auth/dto/RegistrationForm.java
+++ b/src/main/java/com/formswim/teststream/auth/dto/RegistrationForm.java
@@ -1,0 +1,55 @@
+package com.formswim.teststream.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class RegistrationForm {
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Enter a valid email address")
+    @Size(max = 320, message = "Email must be 320 characters or fewer")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String password;
+
+    @NotBlank(message = "Please confirm your password")
+    private String confirmPassword;
+
+    @Size(max = 100, message = "Team code must be 100 characters or fewer")
+    private String teamCode;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+
+    public String getTeamCode() {
+        return teamCode;
+    }
+
+    public void setTeamCode(String teamCode) {
+        this.teamCode = teamCode;
+    }
+}

--- a/src/main/java/com/formswim/teststream/auth/model/AppUser.java
+++ b/src/main/java/com/formswim/teststream/auth/model/AppUser.java
@@ -1,6 +1,7 @@
 package com.formswim.teststream.auth.model;
 
 import java.time.Instant;
+import java.util.Locale;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Enumerated;
@@ -54,25 +56,32 @@ public class AppUser {
 	protected AppUser() { }
 
 	public AppUser(String email, String passwordHash, String teamKey, Role role) {
-		this.email = email;
+		this.email = normalizeEmail(email);
 		this.passwordHash = passwordHash;
 		this.teamKey = teamKey;
 		this.role = role != null ? role : Role.USER;
 	}	
 	public AppUser(String email, String passwordHash, String teamKey) {
-		this.email = email;
+		this.email = normalizeEmail(email);
 		this.passwordHash = passwordHash;
 		this.teamKey = teamKey;
 	}
 
 	@PrePersist
+	@PreUpdate
 	void prePersist() {
 		if (createdAt == null) {
 			createdAt = Instant.now();
 		}
-		if (email != null) {
-			email = email.trim().toLowerCase();
+		email = normalizeEmail(email);
+	}
+
+	public static String normalizeEmail(String email) {
+		if (email == null) {
+			return null;
 		}
+
+		return email.trim().toLowerCase(Locale.ROOT);
 	}
 
 	public Long getId() {
@@ -84,7 +93,7 @@ public class AppUser {
 	}
 
 	public void setEmail(String email) {
-		this.email = email;
+		this.email = normalizeEmail(email);
 	}
 
 	public String getPasswordHash() {

--- a/src/main/java/com/formswim/teststream/auth/repository/UserRepository.java
+++ b/src/main/java/com/formswim/teststream/auth/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<AppUser, Long> {
     Optional<AppUser> findByEmail(String email);
+
+    Optional<AppUser> findByEmailIgnoreCase(String email);
 }

--- a/src/main/java/com/formswim/teststream/auth/service/AppUserDetailsService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/AppUserDetailsService.java
@@ -1,0 +1,48 @@
+package com.formswim.teststream.auth.service;
+
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AppUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private final LoginThrottleService loginThrottleService;
+
+    public AppUserDetailsService(UserRepository userRepository, LoginThrottleService loginThrottleService) {
+        this.userRepository = userRepository;
+        this.loginThrottleService = loginThrottleService;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        String normalizedEmail = AppUser.normalizeEmail(username);
+
+        if (loginThrottleService.isBlocked(normalizedEmail)) {
+            throw new LockedException("Invalid email or password");
+        }
+
+        AppUser user = userRepository.findByEmailIgnoreCase(normalizedEmail)
+            .orElseThrow(() -> new UsernameNotFoundException("Invalid email or password"));
+
+        if (!user.isEnabled()) {
+            throw new DisabledException("Invalid email or password");
+        }
+
+        return User.withUsername(user.getEmail())
+            .password(user.getPasswordHash())
+            .authorities(List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())))
+            .disabled(!user.isEnabled())
+            .build();
+    }
+}

--- a/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
@@ -1,0 +1,85 @@
+package com.formswim.teststream.auth.service;
+
+import com.formswim.teststream.auth.model.AppUser;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class LoginThrottleService {
+
+    static final int MAX_FAILURES = 5;
+    static final Duration BLOCK_DURATION = Duration.ofMinutes(15);
+
+    private final Map<String, AttemptRecord> attempts = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    public LoginThrottleService() {
+        this(Clock.systemUTC());
+    }
+
+    LoginThrottleService(Clock clock) {
+        this.clock = clock;
+    }
+
+    public void recordFailure(String email) {
+        String normalizedEmail = AppUser.normalizeEmail(email);
+        if (normalizedEmail == null || normalizedEmail.isBlank()) {
+            return;
+        }
+
+        attempts.compute(normalizedEmail, (key, existing) -> {
+            Instant now = Instant.now(clock);
+            AttemptRecord record = existing;
+
+            if (record == null || record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
+                record = new AttemptRecord();
+            }
+
+            record.failureCount++;
+            if (record.failureCount >= MAX_FAILURES) {
+                record.blockExpiresAt = now.plus(BLOCK_DURATION);
+            }
+
+            return record;
+        });
+    }
+
+    public void resetFailures(String email) {
+        String normalizedEmail = AppUser.normalizeEmail(email);
+        if (normalizedEmail == null || normalizedEmail.isBlank()) {
+            return;
+        }
+
+        attempts.remove(normalizedEmail);
+    }
+
+    public boolean isBlocked(String email) {
+        String normalizedEmail = AppUser.normalizeEmail(email);
+        if (normalizedEmail == null || normalizedEmail.isBlank()) {
+            return false;
+        }
+
+        AttemptRecord record = attempts.get(normalizedEmail);
+        if (record == null) {
+            return false;
+        }
+
+        Instant now = Instant.now(clock);
+        if (record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
+            attempts.remove(normalizedEmail);
+            return false;
+        }
+
+        return record.blockExpiresAt != null && !now.isAfter(record.blockExpiresAt);
+    }
+
+    private static final class AttemptRecord {
+        private int failureCount;
+        private Instant blockExpiresAt;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=teststream
+server.servlet.session.timeout=30m

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -18,10 +18,11 @@
             </div>
 
             <form th:action="@{/login}" method="POST" class="space-y-6">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 
-                <div th:if="${param.error}" class="p-3 bg-red-500/10 border border-red-500 text-red-500 text-sm rounded text-center">
-                    Invalid email or password.
-                </div>
+                <div th:if="${errorMessage}" class="p-3 bg-red-500/10 border border-red-500 text-red-500 text-sm rounded text-center" th:text="${errorMessage}"></div>
+                <div th:if="${successMessage}" class="p-3 bg-emerald-500/10 border border-emerald-500 text-emerald-400 text-sm rounded text-center" th:text="${successMessage}"></div>
+                <div th:if="${logoutMessage}" class="p-3 bg-white/10 border border-white/20 text-white text-sm rounded text-center" th:text="${logoutMessage}"></div>
 
                 <div>
                     <label for="email" class="block text-white mb-2 font-semibold">
@@ -32,6 +33,7 @@
                         id="email"
                         name="email" 
                         required
+                        autocomplete="email"
                         class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
                         placeholder="your@email.com"
                     />
@@ -46,6 +48,7 @@
                         id="password"
                         name="password"
                         required
+                        autocomplete="current-password"
                         class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
                         placeholder="••••••••"
                     />

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -23,18 +23,10 @@
 			</div>
 
 			<form th:action="@{/register}" method="POST" class="space-y-6">
+				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 
-				<!-- Generic message blocks (set these in the model in your controller) -->
 				<div th:if="${successMessage}" class="p-3 bg-emerald-500/10 border border-emerald-500 text-emerald-400 text-sm rounded text-center" th:text="${successMessage}"></div>
 				<div th:if="${errorMessage}" class="p-3 bg-red-500/10 border border-red-500 text-red-500 text-sm rounded text-center" th:text="${errorMessage}"></div>
-
-				<!-- If you prefer querystring-based messages (e.g., redirect:/register?error), this works too -->
-				<div th:if="${param.error}" class="p-3 bg-red-500/10 border border-red-500 text-red-500 text-sm rounded text-center">
-					Something went wrong. Please check the form and try again.
-				</div>
-				<div th:if="${param.success}" class="p-3 bg-emerald-500/10 border border-emerald-500 text-emerald-400 text-sm rounded text-center">
-					Account created. You can sign in now.
-				</div>
 
 				<div>
 					<label for="email" class="block text-white mb-2 font-semibold">
@@ -50,7 +42,7 @@
 						class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
 						placeholder="your@email.com"
 					/>
-					<p th:if="${fieldErrors != null and fieldErrors.email != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors.email}"></p>
+					<p th:if="${fieldErrors != null and fieldErrors['email'] != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors['email']}"></p>
 				</div>
 
 				<div>
@@ -67,7 +59,7 @@
 						placeholder="••••••••"
 					/>
 					<p class="text-white/50 text-xs mt-2">Use at least 8 characters.</p>
-					<p th:if="${fieldErrors != null and fieldErrors.password != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors.password}"></p>
+					<p th:if="${fieldErrors != null and fieldErrors['password'] != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors['password']}"></p>
 				</div>
 
 				<div>
@@ -83,7 +75,7 @@
 						class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
 						placeholder="••••••••"
 					/>
-					<p th:if="${fieldErrors != null and fieldErrors.confirmPassword != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors.confirmPassword}"></p>
+					<p th:if="${fieldErrors != null and fieldErrors['confirmPassword'] != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors['confirmPassword']}"></p>
 				</div>
 
 				<!-- MVP team/workspace hook: optional team code (leave blank to create a new team) -->
@@ -100,7 +92,7 @@
 						placeholder="ABC123"
 					/>
 					<p class="text-white/50 text-xs mt-2">Leave blank to create a new team.</p>
-					<p th:if="${fieldErrors != null and fieldErrors.teamCode != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors.teamCode}"></p>
+					<p th:if="${fieldErrors != null and fieldErrors['teamCode'] != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors['teamCode']}"></p>
 				</div>
 
 				<button

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -61,6 +61,7 @@
 				<div class="shrink-0 flex flex-wrap items-start justify-between lg:justify-end gap-3 lg:pt-6">
 					<div class="flex items-center gap-2">
 						<form id="importForm" th:action="@{/workspace/import}" method="post" enctype="multipart/form-data" class="flex items-center">
+							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 							<input id="importFile" type="file" name="file" accept=".xlsx,.xls,.csv" class="hidden" />
 							<button type="button" id="importBtn" class="px-4 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-sm">
 								Import
@@ -77,6 +78,7 @@
 							<p class="text-sm text-white/70 truncate" th:text="${userEmail != null ? userEmail : 'Signed in'}">Signed in</p>
 						</div>
 						<form th:action="@{/logout}" method="post">
+							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 							<button type="submit" class="px-4 py-2 text-black font-bold hover:opacity-80 transition-opacity text-sm" style="background-color: #E7FF02;">
 								Logout
 							</button>

--- a/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
@@ -1,0 +1,173 @@
+package com.formswim.teststream;
+
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.auth.service.LoginThrottleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthSecurityIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private LoginThrottleService loginThrottleService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        loginThrottleService.resetFailures("user@example.com");
+        loginThrottleService.resetFailures("disabled@example.com");
+        loginThrottleService.resetFailures("missing@example.com");
+
+        userRepository.save(new AppUser("user@example.com", passwordEncoder.encode("Password123"), "TEAM1"));
+
+        AppUser disabledUser = new AppUser("disabled@example.com", passwordEncoder.encode("Password123"), "TEAM2");
+        disabledUser.setEnabled(false);
+        userRepository.save(disabledUser);
+    }
+
+    @Test
+    void unauthenticatedWorkspaceRedirectsToLogin() throws Exception {
+        mockMvc.perform(get("/workspace"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/login"));
+    }
+
+    @Test
+    void loginRequiresCsrfToken() throws Exception {
+        mockMvc.perform(post("/login")
+                .param("email", "user@example.com")
+                .param("password", "Password123"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void loginAcceptsCaseInsensitiveEmailAndUsesAuthenticatedPrincipal() throws Exception {
+        mockMvc.perform(post("/login")
+                .with(csrf())
+                .param("email", "USER@EXAMPLE.COM")
+                .param("password", "Password123"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/workspace"))
+            .andExpect(authenticated().withUsername("user@example.com"));
+
+        mockMvc.perform(get("/workspace").with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("userEmail", "user@example.com"));
+    }
+
+    @Test
+    void unknownUserAndWrongPasswordShareTheSameFailureMessage() throws Exception {
+        mockMvc.perform(post("/login")
+                .with(csrf())
+                .param("email", "missing@example.com")
+                .param("password", "Password123"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/login"));
+
+        mockMvc.perform(post("/login")
+                .with(csrf())
+                .param("email", "user@example.com")
+                .param("password", "WrongPassword"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/login"));
+    }
+
+    @Test
+    void disabledUsersCannotLogIn() throws Exception {
+        mockMvc.perform(post("/login")
+                .with(csrf())
+                .param("email", "disabled@example.com")
+                .param("password", "Password123"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/login"));
+    }
+
+    @Test
+    void registerRejectsInvalidEmailWithoutLeakingMessagesIntoUrl() throws Exception {
+        mockMvc.perform(post("/register")
+                .with(csrf())
+                .param("email", "not-an-email")
+                .param("password", "Password123")
+                .param("confirmPassword", "Password123")
+                .param("teamCode", "TEAM1"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/register"))
+            .andExpect(flash().attribute("errorMessage", "Please correct the highlighted fields."))
+            .andExpect(flash().attributeExists("fieldErrors"));
+    }
+
+    @Test
+    void logoutRequiresCsrfToken() throws Exception {
+        mockMvc.perform(post("/logout").with(user("user@example.com").roles("USER")))
+            .andExpect(status().isForbidden());
+    }
+    @Test
+    void repeatedFailuresTemporarilyBlockSubsequentLogins() throws Exception {
+        for (int attempt = 0; attempt < 5; attempt++) {
+            mockMvc.perform(post("/login")
+                    .with(csrf())
+                    .param("email", "user@example.com")
+                    .param("password", "WrongPassword"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/login"));
+        }
+
+        assertThat(loginThrottleService.isBlocked("user@example.com")).isTrue();
+        mockMvc.perform(post("/login")
+                .with(csrf())
+                .param("email", "user@example.com")
+                .param("password", "Password123"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/login"));
+    }
+
+
+    @Test
+    void registerExistingEmailShowsError() throws Exception {
+        MvcResult result = mockMvc.perform(post("/register")
+                .with(csrf())
+                .param("email", "user@example.com")
+                .param("password", "Password123")
+                .param("confirmPassword", "Password123")
+                .param("teamCode", "TEAM1"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/register"))
+            .andExpect(flash().attribute("errorMessage", "Please correct the highlighted fields."))
+            .andReturn();
+
+        mockMvc.perform(get("/register").flashAttrs(result.getFlashMap()))
+            .andExpect(status().isOk())
+            .andExpect(view().name("register"))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Create your account")));
+    }
+}


### PR DESCRIPTION
Moved over to Spring Security managed authentication, CRSF, removed the /me endpoint, and updated html forms that now include the token's for POST, while the login/register pages render messages without query leakage. A 30 minute timeout is set (can be updated later).
Test coverage for authentication added, with all passing tests.