### PR TITLE
Improve duplicate file upload handling and upload review flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,10 @@
 			<artifactId>spring-boot-starter-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/formswim/teststream/etl/config/JacksonConfig.java
+++ b/src/main/java/com/formswim/teststream/etl/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package com.formswim.teststream.etl.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return JsonMapper.builder()
+                .findAndAddModules()
+                .build();
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/controller/TestCaseController.java
+++ b/src/main/java/com/formswim/teststream/etl/controller/TestCaseController.java
@@ -3,23 +3,31 @@ package com.formswim.teststream.etl.controller;
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
 import com.formswim.teststream.etl.dto.EtlResultSummary;
+import com.formswim.teststream.etl.dto.ReviewApplyResult;
+import com.formswim.teststream.etl.dto.UploadReviewSessionView;
 import com.formswim.teststream.etl.model.TestCase;
 import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.etl.service.ExcelExportService;
 import com.formswim.teststream.etl.service.TestIngestionService;
-
+import com.formswim.teststream.etl.service.UploadReviewService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
-
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.formswim.teststream.etl.service.ExcelExportService;
-
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -27,53 +35,55 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Controller
+@RequestMapping
 public class TestCaseController {
 
-    private final TestIngestionService testIngestionService;
     private final TestCaseRepository testCaseRepository;
     private final ExcelExportService excelExportService;
+    private final TestIngestionService testIngestionService;
+    private final UploadReviewService uploadReviewService;
     private final UserRepository userRepository;
 
-    public TestCaseController(TestIngestionService testIngestionService,
-                              TestCaseRepository testCaseRepository,
+    public TestCaseController(TestCaseRepository testCaseRepository,
                               ExcelExportService excelExportService,
+                              TestIngestionService testIngestionService,
+                              UploadReviewService uploadReviewService,
                               UserRepository userRepository) {
-        this.testIngestionService = testIngestionService;
         this.testCaseRepository = testCaseRepository;
         this.excelExportService = excelExportService;
+        this.testIngestionService = testIngestionService;
+        this.uploadReviewService = uploadReviewService;
         this.userRepository = userRepository;
     }
 
-    /**
-     * GET /workspace
-     * Loads all test cases from DB, applies optional search/filter params, renders workspace view.
-     */
     @GetMapping("/workspace")
     public String workspace(HttpSession session,
                             Authentication authentication,
-                            Model model,
                             @RequestParam(required = false) String search,
                             @RequestParam(required = false) String status,
-                            @RequestParam(required = false) String component) {
+                            @RequestParam(required = false) String component,
+                            @RequestParam(required = false) String importError,
+                            @RequestParam(required = false) String importSuccess,
+                            Model model) {
 
         Optional<AppUser> currentUser = resolveCurrentUser(session, authentication);
         if (currentUser.isEmpty()) {
-            return "redirect:/login?error=Please log in first";
+            return "redirect:/login?error=Please+log+in+first";
         }
         AppUser user = currentUser.get();
         if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
-            return "redirect:/login?error=User+is+missing+team+assignment";
+            return "redirect:/login?error=No+team+assigned";
         }
 
         String teamKey = user.getTeamKey();
-        List<TestCase> cases = testCaseRepository.findByTeamKey(teamKey);
+        List<TestCase> cases = testCaseRepository.findAllWithStepsByTeamKey(teamKey);
 
         if (search != null && !search.isBlank()) {
             String q = search.trim().toLowerCase();
             cases = cases.stream()
-                .filter(tc -> (tc.getWorkKey()   != null && tc.getWorkKey().toLowerCase().contains(q))
-                           || (tc.getSummary()   != null && tc.getSummary().toLowerCase().contains(q))
-                           || (tc.getComponents()!= null && tc.getComponents().toLowerCase().contains(q)))
+                .filter(tc -> (tc.getWorkKey() != null && tc.getWorkKey().toLowerCase().contains(q))
+                    || (tc.getSummary() != null && tc.getSummary().toLowerCase().contains(q))
+                    || (tc.getComponents() != null && tc.getComponents().toLowerCase().contains(q)))
                 .collect(Collectors.toList());
         }
         if (status != null && !status.isBlank()) {
@@ -93,14 +103,12 @@ public class TestCaseController {
         model.addAttribute("search", search != null ? search : "");
         model.addAttribute("filterStatus", status != null ? status : "");
         model.addAttribute("filterComponent", component != null ? component : "");
+        model.addAttribute("importErrorMessage", importError);
+        model.addAttribute("importSuccessMessage", importSuccess);
 
         return "workspace";
     }
 
-    /**
-     * POST /workspace/import
-     * Accepts a multipart .xlsx file, parses and saves to DB, then redirects back to /workspace.
-     */
     @PostMapping("/workspace/import")
     public String importFile(@RequestParam("file") MultipartFile file,
                              HttpSession session,
@@ -108,31 +116,97 @@ public class TestCaseController {
 
         Optional<AppUser> currentUser = resolveCurrentUser(session, authentication);
         if (currentUser.isEmpty()) {
-            return "redirect:/login?error=Please log in first";
+            return "redirect:/login?error=Please+log+in+first";
         }
         AppUser user = currentUser.get();
         if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
-            return "redirect:/workspace?importError=User+is+missing+team+assignment";
+            return "redirect:/workspace?importError=" + encodeMessage("User is missing team assignment");
         }
-
         if (file == null || file.isEmpty()) {
-            return "redirect:/workspace?importError=No+file+selected";
+            return "redirect:/workspace?importError=" + encodeMessage("No file selected");
         }
 
         EtlResultSummary result = testIngestionService.ingestFile(file, user.getTeamKey());
-
-        if (!result.getErrors().isEmpty()) {
-            String msg = result.getErrors().get(0).replace(" ", "+");
-            return "redirect:/workspace?importError=" + msg;
+        if (result.isReviewRequired() && result.getReviewUrl() != null) {
+            return "redirect:" + result.getReviewUrl();
         }
-
-        return "redirect:/workspace?importSuccess=" + result.getTestCasesParsed();
+        if (result.isExactDuplicateFile()) {
+            return "redirect:/workspace?importError=" + encodeMessage(result.getMessage());
+        }
+        if (!result.getErrors().isEmpty()) {
+            return "redirect:/workspace?importError=" + encodeMessage(result.getErrors().get(0));
+        }
+        return "redirect:/workspace?importSuccess=" + encodeMessage(result.getMessage());
     }
 
-    /**
-     * GET /api/testcases
-     * Returns all test cases as JSON for the front-end to load on page init.
-     */
+    @GetMapping("/workspace/import/review/{sessionId}")
+    public String reviewUpload(@PathVariable String sessionId,
+                               HttpSession session,
+                               Authentication authentication,
+                               Model model) {
+        Optional<AppUser> currentUser = resolveCurrentUser(session, authentication);
+        if (currentUser.isEmpty()) {
+            return "redirect:/login?error=Please+log+in+first";
+        }
+        AppUser user = currentUser.get();
+        if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
+            return "redirect:/workspace?importError=" + encodeMessage("User is missing team assignment");
+        }
+
+        Optional<UploadReviewSessionView> reviewSession = uploadReviewService.getReviewSessionView(sessionId, user.getTeamKey());
+        if (reviewSession.isEmpty()) {
+            return "redirect:/workspace?importError=" + encodeMessage("Upload review session not found or already closed");
+        }
+
+        model.addAttribute("userEmail", user.getEmail());
+        model.addAttribute("reviewSession", reviewSession.get());
+        return "upload-review";
+    }
+
+    @PostMapping("/workspace/import/review/{sessionId}/apply")
+    public String applyReview(@PathVariable String sessionId,
+                              HttpServletRequest request,
+                              HttpSession session,
+                              Authentication authentication) {
+        Optional<AppUser> currentUser = resolveCurrentUser(session, authentication);
+        if (currentUser.isEmpty()) {
+            return "redirect:/login?error=Please+log+in+first";
+        }
+        AppUser user = currentUser.get();
+        if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
+            return "redirect:/workspace?importError=" + encodeMessage("User is missing team assignment");
+        }
+
+        try {
+            ReviewApplyResult result = uploadReviewService.applyReview(sessionId, user.getTeamKey(), request.getParameterMap());
+            String message = "Upload applied. Imported " + result.getImportedNewCount() + " new, merged " + result.getMergedCount() + ", skipped " + result.getSkippedCount() + ".";
+            return "redirect:/workspace?importSuccess=" + encodeMessage(message);
+        } catch (IllegalArgumentException exception) {
+            return "redirect:/workspace?importError=" + encodeMessage(exception.getMessage());
+        }
+    }
+
+    @PostMapping("/workspace/import/review/{sessionId}/cancel")
+    public String cancelReview(@PathVariable String sessionId,
+                               HttpSession session,
+                               Authentication authentication) {
+        Optional<AppUser> currentUser = resolveCurrentUser(session, authentication);
+        if (currentUser.isEmpty()) {
+            return "redirect:/login?error=Please+log+in+first";
+        }
+        AppUser user = currentUser.get();
+        if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
+            return "redirect:/workspace?importError=" + encodeMessage("User is missing team assignment");
+        }
+
+        try {
+            uploadReviewService.cancelReview(sessionId, user.getTeamKey());
+            return "redirect:/workspace?importSuccess=" + encodeMessage("Upload review discarded.");
+        } catch (IllegalArgumentException exception) {
+            return "redirect:/workspace?importError=" + encodeMessage(exception.getMessage());
+        }
+    }
+
     @GetMapping("/api/testcases")
     @ResponseBody
     public ResponseEntity<List<TestCase>> apiGetTestCases(HttpSession session,
@@ -172,11 +246,6 @@ public class TestCaseController {
         return excelExportService.buildDownloadResponse(testCases, filename);
     }
 
-    /**
-     * POST /api/upload
-     * Accepts a multipart CSV or XLSX file, parses and saves to DB, returns JSON summary.
-     * Used by the workspace import button via fetch().
-     */
     @PostMapping("/api/upload")
     @ResponseBody
     public ResponseEntity<EtlResultSummary> apiUpload(@RequestParam("file") MultipartFile file,
@@ -192,8 +261,7 @@ public class TestCaseController {
         }
         if (file == null || file.isEmpty()) {
             return ResponseEntity.badRequest()
-                    .body(new EtlResultSummary(0, 0,
-                            List.of("No file selected."), List.of()));
+                .body(new EtlResultSummary(0, 0, List.of("No file selected."), List.of()));
         }
         EtlResultSummary result = testIngestionService.ingestFile(file, user.getTeamKey());
         return ResponseEntity.ok(result);
@@ -227,4 +295,8 @@ public class TestCaseController {
         return null;
     }
 
+    private String encodeMessage(String message) {
+        String value = message == null ? "" : message;
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
 }

--- a/src/main/java/com/formswim/teststream/etl/dto/EtlResultSummary.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/EtlResultSummary.java
@@ -1,36 +1,148 @@
 package com.formswim.teststream.etl.dto;
 
 import com.formswim.teststream.etl.model.TestCase;
+
+import java.util.ArrayList;
 import java.util.List;
 
-// Returned to the client after a parse attempt.
+// Returned to the client after a parse/import attempt.
 public class EtlResultSummary {
 
     private int testCasesParsed;
     private int totalStepsParsed;
-    private List<String> errors;
-    private List<TestCase> testCases;
+    private int importedCount;
+    private int duplicateUnchangedCount;
+    private int duplicateChangedCount;
+    private int stagedNewCount;
+    private boolean exactDuplicateFile;
+    private boolean reviewRequired;
+    private String reviewSessionId;
+    private String reviewUrl;
+    private String message;
+    private List<String> errors = new ArrayList<>();
+    private List<TestCase> testCases = new ArrayList<>();
+
+    public EtlResultSummary() {
+    }
 
     public EtlResultSummary(int testCasesParsed, int totalStepsParsed, List<String> errors, List<TestCase> testCases) {
         this.testCasesParsed = testCasesParsed;
         this.totalStepsParsed = totalStepsParsed;
-        this.errors = errors;
-        this.testCases = testCases;
+        this.errors = errors == null ? new ArrayList<>() : new ArrayList<>(errors);
+        this.testCases = testCases == null ? new ArrayList<>() : new ArrayList<>(testCases);
     }
 
-    public int getTestCasesParsed() { 
-        return testCasesParsed; 
+    public int getTestCasesParsed() {
+        return testCasesParsed;
+    }
+
+    public void setTestCasesParsed(int testCasesParsed) {
+        this.testCasesParsed = testCasesParsed;
     }
 
     public int getTotalStepsParsed() {
-        return totalStepsParsed; 
+        return totalStepsParsed;
     }
 
-    public List<String> getErrors() { 
-        return errors; 
+    public void setTotalStepsParsed(int totalStepsParsed) {
+        this.totalStepsParsed = totalStepsParsed;
     }
 
-    public List<TestCase> getTestCases() { 
-        return testCases; 
+    public int getImportedCount() {
+        return importedCount;
+    }
+
+    public void setImportedCount(int importedCount) {
+        this.importedCount = importedCount;
+    }
+
+    public int getDuplicateUnchangedCount() {
+        return duplicateUnchangedCount;
+    }
+
+    public void setDuplicateUnchangedCount(int duplicateUnchangedCount) {
+        this.duplicateUnchangedCount = duplicateUnchangedCount;
+    }
+
+    public int getDuplicateChangedCount() {
+        return duplicateChangedCount;
+    }
+
+    public void setDuplicateChangedCount(int duplicateChangedCount) {
+        this.duplicateChangedCount = duplicateChangedCount;
+    }
+
+    public int getStagedNewCount() {
+        return stagedNewCount;
+    }
+
+    public void setStagedNewCount(int stagedNewCount) {
+        this.stagedNewCount = stagedNewCount;
+    }
+
+    public boolean isExactDuplicateFile() {
+        return exactDuplicateFile;
+    }
+
+    public void setExactDuplicateFile(boolean exactDuplicateFile) {
+        this.exactDuplicateFile = exactDuplicateFile;
+    }
+
+    public boolean isReviewRequired() {
+        return reviewRequired;
+    }
+
+    public void setReviewRequired(boolean reviewRequired) {
+        this.reviewRequired = reviewRequired;
+    }
+
+    public String getReviewSessionId() {
+        return reviewSessionId;
+    }
+
+    public void setReviewSessionId(String reviewSessionId) {
+        this.reviewSessionId = reviewSessionId;
+    }
+
+    public String getReviewUrl() {
+        return reviewUrl;
+    }
+
+    public void setReviewUrl(String reviewUrl) {
+        this.reviewUrl = reviewUrl;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public List<String> getErrors() {
+        if (errors == null) {
+            errors = new ArrayList<>();
+        }
+        return errors;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors == null ? new ArrayList<>() : new ArrayList<>(errors);
+    }
+
+    public List<TestCase> getTestCases() {
+        if (testCases == null) {
+            testCases = new ArrayList<>();
+        }
+        return testCases;
+    }
+
+    public void setTestCases(List<TestCase> testCases) {
+        this.testCases = testCases == null ? new ArrayList<>() : new ArrayList<>(testCases);
+    }
+
+    public void addError(String error) {
+        getErrors().add(error);
     }
 }

--- a/src/main/java/com/formswim/teststream/etl/dto/FieldDifference.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/FieldDifference.java
@@ -1,0 +1,51 @@
+package com.formswim.teststream.etl.dto;
+
+public class FieldDifference {
+
+    private String fieldKey;
+    private String displayName;
+    private String existingValue;
+    private String incomingValue;
+
+    public FieldDifference() {
+    }
+
+    public FieldDifference(String fieldKey, String displayName, String existingValue, String incomingValue) {
+        this.fieldKey = fieldKey;
+        this.displayName = displayName;
+        this.existingValue = existingValue;
+        this.incomingValue = incomingValue;
+    }
+
+    public String getFieldKey() {
+        return fieldKey;
+    }
+
+    public void setFieldKey(String fieldKey) {
+        this.fieldKey = fieldKey;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getExistingValue() {
+        return existingValue;
+    }
+
+    public void setExistingValue(String existingValue) {
+        this.existingValue = existingValue;
+    }
+
+    public String getIncomingValue() {
+        return incomingValue;
+    }
+
+    public void setIncomingValue(String incomingValue) {
+        this.incomingValue = incomingValue;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/dto/ReviewApplyResult.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/ReviewApplyResult.java
@@ -1,0 +1,26 @@
+package com.formswim.teststream.etl.dto;
+
+public class ReviewApplyResult {
+
+    private int importedNewCount;
+    private int mergedCount;
+    private int skippedCount;
+
+    public ReviewApplyResult(int importedNewCount, int mergedCount, int skippedCount) {
+        this.importedNewCount = importedNewCount;
+        this.mergedCount = mergedCount;
+        this.skippedCount = skippedCount;
+    }
+
+    public int getImportedNewCount() {
+        return importedNewCount;
+    }
+
+    public int getMergedCount() {
+        return mergedCount;
+    }
+
+    public int getSkippedCount() {
+        return skippedCount;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/dto/ReviewCaseSnapshot.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/ReviewCaseSnapshot.java
@@ -1,175 +1,76 @@
-package com.formswim.teststream.etl.model;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+package com.formswim.teststream.etl.dto;
 
 import java.util.ArrayList;
 import java.util.List;
 
-// Represents one QMetry test case, mapping to a test case block in the export.
-@Entity
-@Table(
-    name = "test_case",
-    uniqueConstraints = {
-        @UniqueConstraint(name = "uk_test_case_team_work_key", columnNames = { "team_key", "work_key" })
-    }
-)
-public class TestCase {
+public class ReviewCaseSnapshot {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(name = "team_key", length = 100)
-    private String teamKey;
-
-    @Column(name = "work_key", nullable = false, length = 100)
     private String workKey;
-
-    @Column(columnDefinition = "TEXT")
     private String summary;
-
-    @Column(columnDefinition = "TEXT")
     private String description;
-
-    @Column(columnDefinition = "TEXT")
     private String precondition;
-
-    @Column(length = 100)
     private String status;
-
-    @Column(length = 100)
     private String priority;
-
-    @Column(name = "assignee", length = 255)
     private String assignee;
-
-    @Column(name = "reporter", length = 255)
     private String reporter;
-
-    @Column(name = "estimated_time", length = 100)
     private String estimatedTime;
-
-    @Column(columnDefinition = "TEXT")
     private String labels;
-
-    @Column(name = "components", length = 255)
     private String components;
-
-    @Column(name = "sprint", length = 255)
     private String sprint;
-
-    @Column(name = "fix_versions", length = 255)
     private String fixVersions;
-
-    @Column(name = "version", length = 100)
     private String version;
-
-    @Column(columnDefinition = "TEXT")
     private String folder;
-
-    @Column(name = "test_case_type", length = 100)
     private String testCaseType;
-
-    @Column(name = "created_by", length = 255)
     private String createdBy;
-
-    @Column(name = "created_on", length = 100)
     private String createdOn;
-
-    @Column(name = "updated_by", length = 255)
     private String updatedBy;
-
-    @Column(name = "updated_on", length = 100)
     private String updatedOn;
-
-    @Column(columnDefinition = "TEXT")
     private String storyLinkages;
-
-    @Column(name = "is_sharable_step", length = 10)
     private String isSharableStep;
-
-    @Column(name = "flaky_score", length = 50)
     private String flakyScore;
+    private List<ReviewStepSnapshot> steps = new ArrayList<>();
 
-    @OneToMany(mappedBy = "testCase", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("stepNumber ASC")
-    private List<TestStep> steps = new ArrayList<>();
-
-    protected TestCase() {
+    public ReviewCaseSnapshot() {
     }
 
-    public TestCase(String teamKey, String workKey, String summary, String description,
-                    String precondition, String status, String priority,
-                    String assignee, String reporter, String estimatedTime,
-                    String labels, String components, String sprint,
-                    String fixVersions, String version, String folder,
-                    String testCaseType, String createdBy, String createdOn,
-                    String updatedBy, String updatedOn, String storyLinkages,
-                    String isSharableStep, String flakyScore) {
-        this.teamKey = teamKey;
-        this.workKey = workKey;
-        this.summary = summary;
-        this.description = description;
-        this.precondition = precondition;
-        this.status = status;
-        this.priority = priority;
-        this.assignee = assignee;
-        this.reporter = reporter;
-        this.estimatedTime = estimatedTime;
-        this.labels = labels;
-        this.components = components;
-        this.sprint = sprint;
-        this.fixVersions = fixVersions;
-        this.version = version;
-        this.folder = folder;
-        this.testCaseType = testCaseType;
-        this.createdBy = createdBy;
-        this.createdOn = createdOn;
-        this.updatedBy = updatedBy;
-        this.updatedOn = updatedOn;
-        this.storyLinkages = storyLinkages;
-        this.isSharableStep = isSharableStep;
-        this.flakyScore = flakyScore;
-    }
-
-    public void addStep(TestStep step) {
-        step.setTestCase(this);
-        steps.add(step);
-    }
-
-    public void replaceSteps(List<TestStep> replacement) {
-        this.steps.clear();
-        if (replacement == null) {
-            return;
+    public ReviewCaseSnapshot copy() {
+        ReviewCaseSnapshot copy = new ReviewCaseSnapshot();
+        copy.workKey = workKey;
+        copy.summary = summary;
+        copy.description = description;
+        copy.precondition = precondition;
+        copy.status = status;
+        copy.priority = priority;
+        copy.assignee = assignee;
+        copy.reporter = reporter;
+        copy.estimatedTime = estimatedTime;
+        copy.labels = labels;
+        copy.components = components;
+        copy.sprint = sprint;
+        copy.fixVersions = fixVersions;
+        copy.version = version;
+        copy.folder = folder;
+        copy.testCaseType = testCaseType;
+        copy.createdBy = createdBy;
+        copy.createdOn = createdOn;
+        copy.updatedBy = updatedBy;
+        copy.updatedOn = updatedOn;
+        copy.storyLinkages = storyLinkages;
+        copy.isSharableStep = isSharableStep;
+        copy.flakyScore = flakyScore;
+        copy.steps = new ArrayList<>();
+        for (ReviewStepSnapshot step : steps) {
+            copy.steps.add(new ReviewStepSnapshot(step.getStepNumber(), step.getStepSummary(), step.getTestData(), step.getExpectedResult()));
         }
-        for (TestStep step : replacement) {
-            addStep(step);
-        }
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getTeamKey() {
-        return teamKey;
-    }
-
-    public void setTeamKey(String teamKey) {
-        this.teamKey = teamKey;
+        return copy;
     }
 
     public String getWorkKey() {
         return workKey;
+    }
+
+    public void setWorkKey(String workKey) {
+        this.workKey = workKey;
     }
 
     public String getSummary() {
@@ -348,7 +249,14 @@ public class TestCase {
         this.flakyScore = flakyScore;
     }
 
-    public List<TestStep> getSteps() {
+    public List<ReviewStepSnapshot> getSteps() {
+        if (steps == null) {
+            steps = new ArrayList<>();
+        }
         return steps;
+    }
+
+    public void setSteps(List<ReviewStepSnapshot> steps) {
+        this.steps = steps == null ? new ArrayList<>() : new ArrayList<>(steps);
     }
 }

--- a/src/main/java/com/formswim/teststream/etl/dto/ReviewConflictCandidate.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/ReviewConflictCandidate.java
@@ -1,0 +1,41 @@
+package com.formswim.teststream.etl.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReviewConflictCandidate {
+
+    private String workKey;
+    private ReviewCaseSnapshot existingSnapshot;
+    private ReviewCaseSnapshot incomingSnapshot;
+    private List<FieldDifference> fieldDifferences = new ArrayList<>();
+
+    public ReviewConflictCandidate() {
+    }
+
+    public ReviewConflictCandidate(String workKey,
+                                   ReviewCaseSnapshot existingSnapshot,
+                                   ReviewCaseSnapshot incomingSnapshot,
+                                   List<FieldDifference> fieldDifferences) {
+        this.workKey = workKey;
+        this.existingSnapshot = existingSnapshot;
+        this.incomingSnapshot = incomingSnapshot;
+        this.fieldDifferences = fieldDifferences == null ? new ArrayList<>() : new ArrayList<>(fieldDifferences);
+    }
+
+    public String getWorkKey() {
+        return workKey;
+    }
+
+    public ReviewCaseSnapshot getExistingSnapshot() {
+        return existingSnapshot;
+    }
+
+    public ReviewCaseSnapshot getIncomingSnapshot() {
+        return incomingSnapshot;
+    }
+
+    public List<FieldDifference> getFieldDifferences() {
+        return fieldDifferences;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/dto/ReviewItemView.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/ReviewItemView.java
@@ -1,0 +1,62 @@
+package com.formswim.teststream.etl.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReviewItemView {
+
+    private Long itemId;
+    private String workKey;
+    private String chosenAction;
+    private List<FieldDifference> changedFields = new ArrayList<>();
+    private ReviewCaseSnapshot existingSnapshot;
+    private ReviewCaseSnapshot incomingSnapshot;
+    private ReviewCaseSnapshot editableSnapshot;
+
+    public ReviewItemView() {
+    }
+
+    public ReviewItemView(Long itemId,
+                          String workKey,
+                          String chosenAction,
+                          List<FieldDifference> changedFields,
+                          ReviewCaseSnapshot existingSnapshot,
+                          ReviewCaseSnapshot incomingSnapshot,
+                          ReviewCaseSnapshot editableSnapshot) {
+        this.itemId = itemId;
+        this.workKey = workKey;
+        this.chosenAction = chosenAction;
+        this.changedFields = changedFields == null ? new ArrayList<>() : new ArrayList<>(changedFields);
+        this.existingSnapshot = existingSnapshot;
+        this.incomingSnapshot = incomingSnapshot;
+        this.editableSnapshot = editableSnapshot;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public String getWorkKey() {
+        return workKey;
+    }
+
+    public String getChosenAction() {
+        return chosenAction;
+    }
+
+    public List<FieldDifference> getChangedFields() {
+        return changedFields;
+    }
+
+    public ReviewCaseSnapshot getExistingSnapshot() {
+        return existingSnapshot;
+    }
+
+    public ReviewCaseSnapshot getIncomingSnapshot() {
+        return incomingSnapshot;
+    }
+
+    public ReviewCaseSnapshot getEditableSnapshot() {
+        return editableSnapshot;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/dto/ReviewStepSnapshot.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/ReviewStepSnapshot.java
@@ -1,0 +1,51 @@
+package com.formswim.teststream.etl.dto;
+
+public class ReviewStepSnapshot {
+
+    private int stepNumber;
+    private String stepSummary;
+    private String testData;
+    private String expectedResult;
+
+    public ReviewStepSnapshot() {
+    }
+
+    public ReviewStepSnapshot(int stepNumber, String stepSummary, String testData, String expectedResult) {
+        this.stepNumber = stepNumber;
+        this.stepSummary = stepSummary;
+        this.testData = testData;
+        this.expectedResult = expectedResult;
+    }
+
+    public int getStepNumber() {
+        return stepNumber;
+    }
+
+    public void setStepNumber(int stepNumber) {
+        this.stepNumber = stepNumber;
+    }
+
+    public String getStepSummary() {
+        return stepSummary;
+    }
+
+    public void setStepSummary(String stepSummary) {
+        this.stepSummary = stepSummary;
+    }
+
+    public String getTestData() {
+        return testData;
+    }
+
+    public void setTestData(String testData) {
+        this.testData = testData;
+    }
+
+    public String getExpectedResult() {
+        return expectedResult;
+    }
+
+    public void setExpectedResult(String expectedResult) {
+        this.expectedResult = expectedResult;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/dto/UploadReviewSessionView.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/UploadReviewSessionView.java
@@ -1,0 +1,69 @@
+package com.formswim.teststream.etl.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UploadReviewSessionView {
+
+    private String sessionId;
+    private String originalFilename;
+    private int parsedTestCaseCount;
+    private int parsedStepCount;
+    private int newItemCount;
+    private int changedItemCount;
+    private int duplicateUnchangedCount;
+    private List<ReviewItemView> conflictItems = new ArrayList<>();
+
+    public UploadReviewSessionView() {
+    }
+
+    public UploadReviewSessionView(String sessionId,
+                                   String originalFilename,
+                                   int parsedTestCaseCount,
+                                   int parsedStepCount,
+                                   int newItemCount,
+                                   int changedItemCount,
+                                   int duplicateUnchangedCount,
+                                   List<ReviewItemView> conflictItems) {
+        this.sessionId = sessionId;
+        this.originalFilename = originalFilename;
+        this.parsedTestCaseCount = parsedTestCaseCount;
+        this.parsedStepCount = parsedStepCount;
+        this.newItemCount = newItemCount;
+        this.changedItemCount = changedItemCount;
+        this.duplicateUnchangedCount = duplicateUnchangedCount;
+        this.conflictItems = conflictItems == null ? new ArrayList<>() : new ArrayList<>(conflictItems);
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    public int getParsedTestCaseCount() {
+        return parsedTestCaseCount;
+    }
+
+    public int getParsedStepCount() {
+        return parsedStepCount;
+    }
+
+    public int getNewItemCount() {
+        return newItemCount;
+    }
+
+    public int getChangedItemCount() {
+        return changedItemCount;
+    }
+
+    public int getDuplicateUnchangedCount() {
+        return duplicateUnchangedCount;
+    }
+
+    public List<ReviewItemView> getConflictItems() {
+        return conflictItems;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/model/UploadHistory.java
+++ b/src/main/java/com/formswim/teststream/etl/model/UploadHistory.java
@@ -1,5 +1,74 @@
 package com.formswim.teststream.etl.model;
-// Use this to track the history of uploads, using metadata or created hash to block duplicate uploads.
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "upload_history",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_upload_history_team_hash", columnNames = { "team_key", "file_hash" })
+    }
+)
 public class UploadHistory {
-    
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "team_key", nullable = false, length = 100)
+    private String teamKey;
+
+    @Column(name = "original_filename", nullable = false, length = 255)
+    private String originalFilename;
+
+    @Column(name = "file_hash", nullable = false, length = 64)
+    private String fileHash;
+
+    @Column(name = "uploaded_at", nullable = false, updatable = false)
+    private Instant uploadedAt;
+
+    protected UploadHistory() {
+    }
+
+    public UploadHistory(String teamKey, String originalFilename, String fileHash) {
+        this.teamKey = teamKey;
+        this.originalFilename = originalFilename;
+        this.fileHash = fileHash;
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (uploadedAt == null) {
+            uploadedAt = Instant.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTeamKey() {
+        return teamKey;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    public String getFileHash() {
+        return fileHash;
+    }
+
+    public Instant getUploadedAt() {
+        return uploadedAt;
+    }
 }

--- a/src/main/java/com/formswim/teststream/etl/model/UploadReviewItem.java
+++ b/src/main/java/com/formswim/teststream/etl/model/UploadReviewItem.java
@@ -1,0 +1,115 @@
+package com.formswim.teststream.etl.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "upload_review_item")
+public class UploadReviewItem {
+
+    public static final String TYPE_NEW = "NEW";
+    public static final String TYPE_CHANGED_DUPLICATE = "CHANGED_DUPLICATE";
+
+    public static final String ACTION_PENDING = "PENDING";
+    public static final String ACTION_SKIP = "SKIP";
+    public static final String ACTION_MERGE = "MERGE";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private UploadReviewSession session;
+
+    @Column(name = "work_key", nullable = false, length = 100)
+    private String workKey;
+
+    @Column(name = "conflict_type", nullable = false, length = 30)
+    private String conflictType;
+
+    @Column(name = "chosen_action", nullable = false, length = 20)
+    private String chosenAction = ACTION_PENDING;
+
+    @Column(name = "existing_snapshot_json", columnDefinition = "TEXT")
+    private String existingSnapshotJson;
+
+    @Column(name = "incoming_snapshot_json", nullable = false, columnDefinition = "TEXT")
+    private String incomingSnapshotJson;
+
+    @Column(name = "edited_snapshot_json", columnDefinition = "TEXT")
+    private String editedSnapshotJson;
+
+    @Column(name = "changed_fields_json", columnDefinition = "TEXT")
+    private String changedFieldsJson;
+
+    protected UploadReviewItem() {
+    }
+
+    public UploadReviewItem(String workKey,
+                            String conflictType,
+                            String existingSnapshotJson,
+                            String incomingSnapshotJson,
+                            String changedFieldsJson) {
+        this.workKey = workKey;
+        this.conflictType = conflictType;
+        this.existingSnapshotJson = existingSnapshotJson;
+        this.incomingSnapshotJson = incomingSnapshotJson;
+        this.changedFieldsJson = changedFieldsJson;
+    }
+
+    void setSession(UploadReviewSession session) {
+        this.session = session;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public UploadReviewSession getSession() {
+        return session;
+    }
+
+    public String getWorkKey() {
+        return workKey;
+    }
+
+    public String getConflictType() {
+        return conflictType;
+    }
+
+    public String getChosenAction() {
+        return chosenAction;
+    }
+
+    public void setChosenAction(String chosenAction) {
+        this.chosenAction = chosenAction;
+    }
+
+    public String getExistingSnapshotJson() {
+        return existingSnapshotJson;
+    }
+
+    public String getIncomingSnapshotJson() {
+        return incomingSnapshotJson;
+    }
+
+    public String getEditedSnapshotJson() {
+        return editedSnapshotJson;
+    }
+
+    public void setEditedSnapshotJson(String editedSnapshotJson) {
+        this.editedSnapshotJson = editedSnapshotJson;
+    }
+
+    public String getChangedFieldsJson() {
+        return changedFieldsJson;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/model/UploadReviewSession.java
+++ b/src/main/java/com/formswim/teststream/etl/model/UploadReviewSession.java
@@ -1,0 +1,160 @@
+package com.formswim.teststream.etl.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "upload_review_session")
+public class UploadReviewSession {
+
+    public static final String STATUS_OPEN = "OPEN";
+    public static final String STATUS_APPLIED = "APPLIED";
+    public static final String STATUS_CANCELLED = "CANCELLED";
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "team_key", nullable = false, length = 100)
+    private String teamKey;
+
+    @Column(name = "original_filename", nullable = false, length = 255)
+    private String originalFilename;
+
+    @Column(name = "file_hash", nullable = false, length = 64)
+    private String fileHash;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "parsed_test_case_count", nullable = false)
+    private int parsedTestCaseCount;
+
+    @Column(name = "parsed_step_count", nullable = false)
+    private int parsedStepCount;
+
+    @Column(name = "new_item_count", nullable = false)
+    private int newItemCount;
+
+    @Column(name = "changed_item_count", nullable = false)
+    private int changedItemCount;
+
+    @Column(name = "duplicate_unchanged_count", nullable = false)
+    private int duplicateUnchangedCount;
+
+    @OneToMany(mappedBy = "session", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("id ASC")
+    private List<UploadReviewItem> items = new ArrayList<>();
+
+    protected UploadReviewSession() {
+    }
+
+    public UploadReviewSession(String teamKey,
+                               String originalFilename,
+                               String fileHash,
+                               int parsedTestCaseCount,
+                               int parsedStepCount,
+                               int newItemCount,
+                               int changedItemCount,
+                               int duplicateUnchangedCount) {
+        this.id = UUID.randomUUID().toString();
+        this.teamKey = teamKey;
+        this.originalFilename = originalFilename;
+        this.fileHash = fileHash;
+        this.status = STATUS_OPEN;
+        this.parsedTestCaseCount = parsedTestCaseCount;
+        this.parsedStepCount = parsedStepCount;
+        this.newItemCount = newItemCount;
+        this.changedItemCount = changedItemCount;
+        this.duplicateUnchangedCount = duplicateUnchangedCount;
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+        if (id == null || id.isBlank()) {
+            id = UUID.randomUUID().toString();
+        }
+        if (status == null || status.isBlank()) {
+            status = STATUS_OPEN;
+        }
+    }
+
+    public void addItem(UploadReviewItem item) {
+        item.setSession(this);
+        items.add(item);
+    }
+
+    public void markApplied() {
+        this.status = STATUS_APPLIED;
+    }
+
+    public void markCancelled() {
+        this.status = STATUS_CANCELLED;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTeamKey() {
+        return teamKey;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    public String getFileHash() {
+        return fileHash;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public int getParsedTestCaseCount() {
+        return parsedTestCaseCount;
+    }
+
+    public int getParsedStepCount() {
+        return parsedStepCount;
+    }
+
+    public int getNewItemCount() {
+        return newItemCount;
+    }
+
+    public int getChangedItemCount() {
+        return changedItemCount;
+    }
+
+    public int getDuplicateUnchangedCount() {
+        return duplicateUnchangedCount;
+    }
+
+    public List<UploadReviewItem> getItems() {
+        return items;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/repository/UploadHistoryRepository.java
+++ b/src/main/java/com/formswim/teststream/etl/repository/UploadHistoryRepository.java
@@ -1,5 +1,11 @@
 package com.formswim.teststream.etl.repository;
 
-public class UploadHistoryRepository {
-    
+import com.formswim.teststream.etl.model.UploadHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UploadHistoryRepository extends JpaRepository<UploadHistory, Long> {
+
+    boolean existsByTeamKeyAndFileHash(String teamKey, String fileHash);
 }

--- a/src/main/java/com/formswim/teststream/etl/repository/UploadReviewItemRepository.java
+++ b/src/main/java/com/formswim/teststream/etl/repository/UploadReviewItemRepository.java
@@ -1,0 +1,9 @@
+package com.formswim.teststream.etl.repository;
+
+import com.formswim.teststream.etl.model.UploadReviewItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UploadReviewItemRepository extends JpaRepository<UploadReviewItem, Long> {
+}

--- a/src/main/java/com/formswim/teststream/etl/repository/UploadReviewSessionRepository.java
+++ b/src/main/java/com/formswim/teststream/etl/repository/UploadReviewSessionRepository.java
@@ -1,0 +1,15 @@
+package com.formswim.teststream.etl.repository;
+
+import com.formswim.teststream.etl.model.UploadReviewSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UploadReviewSessionRepository extends JpaRepository<UploadReviewSession, String> {
+
+    Optional<UploadReviewSession> findByIdAndTeamKey(String id, String teamKey);
+
+    boolean existsByTeamKeyAndFileHashAndStatus(String teamKey, String fileHash, String status);
+}

--- a/src/main/java/com/formswim/teststream/etl/service/FileHashService.java
+++ b/src/main/java/com/formswim/teststream/etl/service/FileHashService.java
@@ -1,0 +1,25 @@
+package com.formswim.teststream.etl.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+@Service
+public class FileHashService {
+
+    public String sha256(MultipartFile file) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+            byte[] digest = messageDigest.digest(file.getBytes());
+            return HexFormat.of().formatHex(digest);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to read uploaded file for hashing", exception);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is not available", exception);
+        }
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/service/TestIngestionService.java
+++ b/src/main/java/com/formswim/teststream/etl/service/TestIngestionService.java
@@ -1,14 +1,23 @@
 package com.formswim.teststream.etl.service;
-// Transactional creater (Load & Hash Check)
-
-// Potentiall should be moved ot test?
 
 import com.formswim.teststream.etl.dto.EtlResultSummary;
+import com.formswim.teststream.etl.dto.ReviewCaseSnapshot;
+import com.formswim.teststream.etl.dto.ReviewConflictCandidate;
 import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.model.UploadHistory;
+import com.formswim.teststream.etl.model.UploadReviewSession;
 import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.etl.repository.UploadHistoryRepository;
+import com.formswim.teststream.etl.repository.UploadReviewSessionRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class TestIngestionService {
@@ -16,15 +25,31 @@ public class TestIngestionService {
     private final ExcelParserService excelParserService;
     private final CsvParserService csvParserService;
     private final TestCaseRepository testCaseRepository;
+    private final UploadHistoryRepository uploadHistoryRepository;
+    private final UploadReviewSessionRepository uploadReviewSessionRepository;
+    private final FileHashService fileHashService;
+    private final UploadDiffService uploadDiffService;
+    private final UploadReviewService uploadReviewService;
 
     public TestIngestionService(ExcelParserService excelParserService,
-            CsvParserService csvParserService,
-            TestCaseRepository testCaseRepository) {
+                                CsvParserService csvParserService,
+                                TestCaseRepository testCaseRepository,
+                                UploadHistoryRepository uploadHistoryRepository,
+                                UploadReviewSessionRepository uploadReviewSessionRepository,
+                                FileHashService fileHashService,
+                                UploadDiffService uploadDiffService,
+                                UploadReviewService uploadReviewService) {
         this.excelParserService = excelParserService;
         this.csvParserService = csvParserService;
         this.testCaseRepository = testCaseRepository;
+        this.uploadHistoryRepository = uploadHistoryRepository;
+        this.uploadReviewSessionRepository = uploadReviewSessionRepository;
+        this.fileHashService = fileHashService;
+        this.uploadDiffService = uploadDiffService;
+        this.uploadReviewService = uploadReviewService;
     }
 
+    @Transactional
     public EtlResultSummary ingestFile(MultipartFile file, String teamKey) {
         String filename = file.getOriginalFilename() == null ? "" : file.getOriginalFilename().toLowerCase();
 
@@ -39,26 +64,107 @@ public class TestIngestionService {
             return new EtlResultSummary(0, 0, List.of("Only .xlsx and .csv files are supported."), List.of());
         }
 
+        String fileHash;
+        try {
+            fileHash = fileHashService.sha256(file);
+        } catch (IllegalStateException exception) {
+            return new EtlResultSummary(0, 0, List.of("Failed to hash uploaded file."), List.of());
+        }
+
+        if (uploadHistoryRepository.existsByTeamKeyAndFileHash(teamKey, fileHash)
+            || uploadReviewSessionRepository.existsByTeamKeyAndFileHashAndStatus(teamKey, fileHash, UploadReviewSession.STATUS_OPEN)) {
+            EtlResultSummary result = new EtlResultSummary(0, 0, List.of(), List.of());
+            result.setExactDuplicateFile(true);
+            result.setMessage("This exact file was already uploaded for your workspace.");
+            result.addError("This exact file was already uploaded for your workspace.");
+            return result;
+        }
+
         EtlResultSummary parsed = filename.endsWith(".csv")
             ? csvParserService.parse(file, teamKey)
             : excelParserService.parse(file, teamKey);
 
+        if (!parsed.getErrors().isEmpty() || parsed.getTestCases().isEmpty()) {
+            return parsed;
+        }
+
         try {
-            if (!parsed.getErrors().isEmpty() || parsed.getTestCases().isEmpty()) {
-                return parsed; // If parsing has errors, do not save
+            List<TestCase> parsedCases = parsed.getTestCases();
+            Map<String, Long> uploadWorkKeyCounts = parsedCases.stream()
+                .collect(Collectors.groupingBy(TestCase::getWorkKey, LinkedHashMap::new, Collectors.counting()));
+            List<String> repeatedUploadKeys = uploadWorkKeyCounts.entrySet().stream()
+                .filter(entry -> entry.getValue() > 1)
+                .map(Map.Entry::getKey)
+                .toList();
+            if (!repeatedUploadKeys.isEmpty()) {
+                parsed.addError("Upload contains duplicate workKey values: " + String.join(", ", repeatedUploadKeys));
+                return parsed;
             }
 
-            for (TestCase testcase : parsed.getTestCases()) {
-                if (testCaseRepository.existsByTeamKeyAndWorkKey(teamKey, testcase.getWorkKey())) {
-                    parsed.getErrors().add("Skipped duplicate test case with workKey: " + testcase.getWorkKey());
+            Map<String, TestCase> existingByWorkKey = testCaseRepository
+                .findAllWithStepsByTeamKeyAndWorkKeyIn(teamKey, parsedCases.stream().map(TestCase::getWorkKey).collect(Collectors.toSet()))
+                .stream()
+                .collect(Collectors.toMap(TestCase::getWorkKey, testCase -> testCase, (left, right) -> left, LinkedHashMap::new));
+
+            List<TestCase> newCasesToSave = new ArrayList<>();
+            List<ReviewCaseSnapshot> stagedNewCases = new ArrayList<>();
+            List<ReviewConflictCandidate> changedConflicts = new ArrayList<>();
+            int unchangedDuplicates = 0;
+
+            for (TestCase testCase : parsedCases) {
+                TestCase existing = existingByWorkKey.get(testCase.getWorkKey());
+                if (existing == null) {
+                    newCasesToSave.add(testCase);
+                    stagedNewCases.add(uploadDiffService.toSnapshot(testCase));
                     continue;
                 }
-                testCaseRepository.save(testcase);
+
+                if (uploadDiffService.isEquivalent(existing, testCase)) {
+                    unchangedDuplicates++;
+                    continue;
+                }
+
+                changedConflicts.add(uploadDiffService.buildConflict(existing, testCase));
             }
+
+            parsed.setDuplicateUnchangedCount(unchangedDuplicates);
+            parsed.setDuplicateChangedCount(changedConflicts.size());
+            parsed.setStagedNewCount(stagedNewCases.size());
+
+            if (changedConflicts.isEmpty()) {
+                testCaseRepository.saveAll(newCasesToSave);
+                uploadHistoryRepository.save(new UploadHistory(teamKey, file.getOriginalFilename() == null ? "upload" : file.getOriginalFilename(), fileHash));
+                parsed.setImportedCount(newCasesToSave.size());
+                parsed.setMessage(buildDirectImportMessage(newCasesToSave.size(), unchangedDuplicates));
+                return parsed;
+            }
+
+            UploadReviewSession session = uploadReviewService.createReviewSession(
+                teamKey,
+                file.getOriginalFilename() == null ? "upload" : file.getOriginalFilename(),
+                fileHash,
+                parsed.getTestCasesParsed(),
+                parsed.getTotalStepsParsed(),
+                stagedNewCases,
+                unchangedDuplicates,
+                changedConflicts
+            );
+
+            parsed.setReviewRequired(true);
+            parsed.setReviewSessionId(session.getId());
+            parsed.setReviewUrl("/workspace/import/review/" + session.getId());
+            parsed.setMessage("Upload needs review before saving. " + stagedNewCases.size() + " new test case(s) staged and " + changedConflicts.size() + " duplicate conflict(s) found.");
             return parsed;
 
-        } catch (Exception e) {
-            return new EtlResultSummary(0, 0, List.of("Unexpected error: " + e.getMessage()), List.of());
+        } catch (Exception exception) {
+            return new EtlResultSummary(0, 0, List.of("Unexpected error: " + exception.getMessage()), List.of());
         }
+    }
+
+    private String buildDirectImportMessage(int importedCount, int unchangedDuplicates) {
+        if (unchangedDuplicates > 0) {
+            return "Imported " + importedCount + " new test case(s). Skipped " + unchangedDuplicates + " unchanged duplicate(s).";
+        }
+        return "Imported " + importedCount + " test case(s).";
     }
 }

--- a/src/main/java/com/formswim/teststream/etl/service/UploadDiffService.java
+++ b/src/main/java/com/formswim/teststream/etl/service/UploadDiffService.java
@@ -1,0 +1,142 @@
+package com.formswim.teststream.etl.service;
+
+import com.formswim.teststream.etl.dto.FieldDifference;
+import com.formswim.teststream.etl.dto.ReviewCaseSnapshot;
+import com.formswim.teststream.etl.dto.ReviewConflictCandidate;
+import com.formswim.teststream.etl.dto.ReviewStepSnapshot;
+import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.model.TestStep;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class UploadDiffService {
+
+    public ReviewCaseSnapshot toSnapshot(TestCase testCase) {
+        ReviewCaseSnapshot snapshot = new ReviewCaseSnapshot();
+        snapshot.setWorkKey(testCase.getWorkKey());
+        snapshot.setSummary(testCase.getSummary());
+        snapshot.setDescription(testCase.getDescription());
+        snapshot.setPrecondition(testCase.getPrecondition());
+        snapshot.setStatus(testCase.getStatus());
+        snapshot.setPriority(testCase.getPriority());
+        snapshot.setAssignee(testCase.getAssignee());
+        snapshot.setReporter(testCase.getReporter());
+        snapshot.setEstimatedTime(testCase.getEstimatedTime());
+        snapshot.setLabels(testCase.getLabels());
+        snapshot.setComponents(testCase.getComponents());
+        snapshot.setSprint(testCase.getSprint());
+        snapshot.setFixVersions(testCase.getFixVersions());
+        snapshot.setVersion(testCase.getVersion());
+        snapshot.setFolder(testCase.getFolder());
+        snapshot.setTestCaseType(testCase.getTestCaseType());
+        snapshot.setCreatedBy(testCase.getCreatedBy());
+        snapshot.setCreatedOn(testCase.getCreatedOn());
+        snapshot.setUpdatedBy(testCase.getUpdatedBy());
+        snapshot.setUpdatedOn(testCase.getUpdatedOn());
+        snapshot.setStoryLinkages(testCase.getStoryLinkages());
+        snapshot.setIsSharableStep(testCase.getIsSharableStep());
+        snapshot.setFlakyScore(testCase.getFlakyScore());
+
+        List<ReviewStepSnapshot> steps = new ArrayList<>();
+        for (TestStep step : testCase.getSteps()) {
+            steps.add(new ReviewStepSnapshot(step.getStepNumber(), step.getStepSummary(), step.getTestData(), step.getExpectedResult()));
+        }
+        snapshot.setSteps(steps);
+        return snapshot;
+    }
+
+    public ReviewConflictCandidate buildConflict(TestCase existing, TestCase incoming) {
+        ReviewCaseSnapshot existingSnapshot = toSnapshot(existing);
+        ReviewCaseSnapshot incomingSnapshot = toSnapshot(incoming);
+        return new ReviewConflictCandidate(incoming.getWorkKey(), existingSnapshot, incomingSnapshot, diff(existingSnapshot, incomingSnapshot));
+    }
+
+    public boolean isEquivalent(TestCase existing, TestCase incoming) {
+        return diff(toSnapshot(existing), toSnapshot(incoming)).isEmpty();
+    }
+
+    public List<FieldDifference> diff(ReviewCaseSnapshot existing, ReviewCaseSnapshot incoming) {
+        List<FieldDifference> differences = new ArrayList<>();
+        addDifference(differences, "summary", "Summary", existing.getSummary(), incoming.getSummary());
+        addDifference(differences, "description", "Description", existing.getDescription(), incoming.getDescription());
+        addDifference(differences, "precondition", "Precondition", existing.getPrecondition(), incoming.getPrecondition());
+        addDifference(differences, "status", "Status", existing.getStatus(), incoming.getStatus());
+        addDifference(differences, "priority", "Priority", existing.getPriority(), incoming.getPriority());
+        addDifference(differences, "assignee", "Assignee", existing.getAssignee(), incoming.getAssignee());
+        addDifference(differences, "reporter", "Reporter", existing.getReporter(), incoming.getReporter());
+        addDifference(differences, "estimatedTime", "Estimated time", existing.getEstimatedTime(), incoming.getEstimatedTime());
+        addDifference(differences, "labels", "Labels", existing.getLabels(), incoming.getLabels());
+        addDifference(differences, "components", "Components", existing.getComponents(), incoming.getComponents());
+        addDifference(differences, "sprint", "Sprint", existing.getSprint(), incoming.getSprint());
+        addDifference(differences, "fixVersions", "Fix versions", existing.getFixVersions(), incoming.getFixVersions());
+        addDifference(differences, "version", "Version", existing.getVersion(), incoming.getVersion());
+        addDifference(differences, "folder", "Folder", existing.getFolder(), incoming.getFolder());
+        addDifference(differences, "testCaseType", "Test case type", existing.getTestCaseType(), incoming.getTestCaseType());
+        addDifference(differences, "createdBy", "Created by", existing.getCreatedBy(), incoming.getCreatedBy());
+        addDifference(differences, "createdOn", "Created on", existing.getCreatedOn(), incoming.getCreatedOn());
+        addDifference(differences, "updatedBy", "Updated by", existing.getUpdatedBy(), incoming.getUpdatedBy());
+        addDifference(differences, "updatedOn", "Updated on", existing.getUpdatedOn(), incoming.getUpdatedOn());
+        addDifference(differences, "storyLinkages", "Story linkages", existing.getStoryLinkages(), incoming.getStoryLinkages());
+        addDifference(differences, "isSharableStep", "Is shareable step", existing.getIsSharableStep(), incoming.getIsSharableStep());
+        addDifference(differences, "flakyScore", "Flaky score", existing.getFlakyScore(), incoming.getFlakyScore());
+        addStepDifferences(differences, existing.getSteps(), incoming.getSteps());
+        return differences;
+    }
+
+    private void addDifference(List<FieldDifference> differences,
+                               String fieldKey,
+                               String displayName,
+                               String existingValue,
+                               String incomingValue) {
+        if (!normalize(existingValue).equals(normalize(incomingValue))) {
+            differences.add(new FieldDifference(fieldKey, displayName, safe(existingValue), safe(incomingValue)));
+        }
+    }
+
+    private void addStepDifferences(List<FieldDifference> differences,
+                                    List<ReviewStepSnapshot> existingSteps,
+                                    List<ReviewStepSnapshot> incomingSteps) {
+        int max = Math.max(existingSteps == null ? 0 : existingSteps.size(), incomingSteps == null ? 0 : incomingSteps.size());
+        for (int index = 0; index < max; index++) {
+            ReviewStepSnapshot existingStep = index < (existingSteps == null ? 0 : existingSteps.size()) ? existingSteps.get(index) : null;
+            ReviewStepSnapshot incomingStep = index < (incomingSteps == null ? 0 : incomingSteps.size()) ? incomingSteps.get(index) : null;
+
+            String existingFormatted = formatStep(existingStep);
+            String incomingFormatted = formatStep(incomingStep);
+            if (!normalize(existingFormatted).equals(normalize(incomingFormatted))) {
+                differences.add(new FieldDifference(
+                    "step_" + (index + 1),
+                    "Step " + (index + 1),
+                    existingFormatted,
+                    incomingFormatted
+                ));
+            }
+        }
+    }
+
+    private String formatStep(ReviewStepSnapshot step) {
+        if (step == null) {
+            return "";
+        }
+        return "Action: " + safe(step.getStepSummary())
+            + "\nData: " + safe(step.getTestData())
+            + "\nExpected: " + safe(step.getExpectedResult());
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+            .trim();
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/service/UploadReviewService.java
+++ b/src/main/java/com/formswim/teststream/etl/service/UploadReviewService.java
@@ -1,0 +1,359 @@
+package com.formswim.teststream.etl.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.formswim.teststream.etl.dto.FieldDifference;
+import com.formswim.teststream.etl.dto.ReviewApplyResult;
+import com.formswim.teststream.etl.dto.ReviewCaseSnapshot;
+import com.formswim.teststream.etl.dto.ReviewConflictCandidate;
+import com.formswim.teststream.etl.dto.ReviewItemView;
+import com.formswim.teststream.etl.dto.ReviewStepSnapshot;
+import com.formswim.teststream.etl.dto.UploadReviewSessionView;
+import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.model.TestStep;
+import com.formswim.teststream.etl.model.UploadHistory;
+import com.formswim.teststream.etl.model.UploadReviewItem;
+import com.formswim.teststream.etl.model.UploadReviewSession;
+import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.etl.repository.UploadHistoryRepository;
+import com.formswim.teststream.etl.repository.UploadReviewSessionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class UploadReviewService {
+
+    private final ObjectMapper objectMapper;
+    private final UploadDiffService uploadDiffService;
+    private final UploadReviewSessionRepository uploadReviewSessionRepository;
+    private final UploadHistoryRepository uploadHistoryRepository;
+    private final TestCaseRepository testCaseRepository;
+
+    public UploadReviewService(ObjectMapper objectMapper,
+                               UploadDiffService uploadDiffService,
+                               UploadReviewSessionRepository uploadReviewSessionRepository,
+                               UploadHistoryRepository uploadHistoryRepository,
+                               TestCaseRepository testCaseRepository) {
+        this.objectMapper = objectMapper;
+        this.uploadDiffService = uploadDiffService;
+        this.uploadReviewSessionRepository = uploadReviewSessionRepository;
+        this.uploadHistoryRepository = uploadHistoryRepository;
+        this.testCaseRepository = testCaseRepository;
+    }
+
+    @Transactional
+    public UploadReviewSession createReviewSession(String teamKey,
+                                                   String originalFilename,
+                                                   String fileHash,
+                                                   int parsedTestCaseCount,
+                                                   int parsedStepCount,
+                                                   List<ReviewCaseSnapshot> newSnapshots,
+                                                   int duplicateUnchangedCount,
+                                                   List<ReviewConflictCandidate> changedConflicts) {
+        UploadReviewSession session = new UploadReviewSession(
+            teamKey,
+            originalFilename,
+            fileHash,
+            parsedTestCaseCount,
+            parsedStepCount,
+            newSnapshots == null ? 0 : newSnapshots.size(),
+            changedConflicts == null ? 0 : changedConflicts.size(),
+            duplicateUnchangedCount
+        );
+
+        if (newSnapshots != null) {
+            for (ReviewCaseSnapshot snapshot : newSnapshots) {
+                session.addItem(new UploadReviewItem(
+                    snapshot.getWorkKey(),
+                    UploadReviewItem.TYPE_NEW,
+                    null,
+                    writeJson(snapshot),
+                    "[]"
+                ));
+            }
+        }
+
+        if (changedConflicts != null) {
+            for (ReviewConflictCandidate conflict : changedConflicts) {
+                session.addItem(new UploadReviewItem(
+                    conflict.getWorkKey(),
+                    UploadReviewItem.TYPE_CHANGED_DUPLICATE,
+                    writeJson(conflict.getExistingSnapshot()),
+                    writeJson(conflict.getIncomingSnapshot()),
+                    writeJson(conflict.getFieldDifferences())
+                ));
+            }
+        }
+
+        return uploadReviewSessionRepository.save(session);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<UploadReviewSessionView> getReviewSessionView(String sessionId, String teamKey) {
+        return uploadReviewSessionRepository.findByIdAndTeamKey(sessionId, teamKey)
+            .filter(session -> UploadReviewSession.STATUS_OPEN.equals(session.getStatus()))
+            .map(this::toView);
+    }
+
+    @Transactional
+    public ReviewApplyResult applyReview(String sessionId, String teamKey, Map<String, String[]> parameters) {
+        UploadReviewSession session = findRequiredOpenSession(sessionId, teamKey);
+
+        int importedNewCount = 0;
+        int mergedCount = 0;
+        int skippedCount = session.getDuplicateUnchangedCount();
+
+        for (UploadReviewItem item : session.getItems()) {
+            if (UploadReviewItem.TYPE_NEW.equals(item.getConflictType())) {
+                ReviewCaseSnapshot newSnapshot = readSnapshot(item.getIncomingSnapshotJson());
+                testCaseRepository.save(toEntity(teamKey, newSnapshot));
+                importedNewCount++;
+                continue;
+            }
+
+            String action = param(parameters, "action_" + item.getId(), UploadReviewItem.ACTION_SKIP);
+            item.setChosenAction(action);
+
+            if (UploadReviewItem.ACTION_MERGE.equals(action)) {
+                ReviewCaseSnapshot editedSnapshot = buildEditedSnapshot(readSnapshot(item.getIncomingSnapshotJson()), parameters, item.getId());
+                item.setEditedSnapshotJson(writeJson(editedSnapshot));
+                mergeIntoExisting(teamKey, editedSnapshot);
+                mergedCount++;
+            } else {
+                skippedCount++;
+            }
+        }
+
+        session.markApplied();
+        uploadReviewSessionRepository.save(session);
+        uploadHistoryRepository.save(new UploadHistory(session.getTeamKey(), session.getOriginalFilename(), session.getFileHash()));
+
+        return new ReviewApplyResult(importedNewCount, mergedCount, skippedCount);
+    }
+
+    @Transactional
+    public void cancelReview(String sessionId, String teamKey) {
+        UploadReviewSession session = findRequiredOpenSession(sessionId, teamKey);
+        session.markCancelled();
+        uploadReviewSessionRepository.save(session);
+    }
+
+    private UploadReviewSessionView toView(UploadReviewSession session) {
+        List<ReviewItemView> conflictItems = new ArrayList<>();
+        for (UploadReviewItem item : session.getItems()) {
+            if (!UploadReviewItem.TYPE_CHANGED_DUPLICATE.equals(item.getConflictType())) {
+                continue;
+            }
+
+            ReviewCaseSnapshot existingSnapshot = readSnapshot(item.getExistingSnapshotJson());
+            ReviewCaseSnapshot incomingSnapshot = readSnapshot(item.getIncomingSnapshotJson());
+            ReviewCaseSnapshot editableSnapshot = item.getEditedSnapshotJson() == null || item.getEditedSnapshotJson().isBlank()
+                ? incomingSnapshot.copy()
+                : readSnapshot(item.getEditedSnapshotJson());
+
+            conflictItems.add(new ReviewItemView(
+                item.getId(),
+                item.getWorkKey(),
+                item.getChosenAction(),
+                readDifferences(item.getChangedFieldsJson()),
+                existingSnapshot,
+                incomingSnapshot,
+                editableSnapshot
+            ));
+        }
+
+        return new UploadReviewSessionView(
+            session.getId(),
+            session.getOriginalFilename(),
+            session.getParsedTestCaseCount(),
+            session.getParsedStepCount(),
+            session.getNewItemCount(),
+            session.getChangedItemCount(),
+            session.getDuplicateUnchangedCount(),
+            conflictItems
+        );
+    }
+
+    private UploadReviewSession findRequiredOpenSession(String sessionId, String teamKey) {
+        return uploadReviewSessionRepository.findByIdAndTeamKey(sessionId, teamKey)
+            .filter(session -> UploadReviewSession.STATUS_OPEN.equals(session.getStatus()))
+            .orElseThrow(() -> new IllegalArgumentException("Review session not found or no longer available."));
+    }
+
+    private ReviewCaseSnapshot buildEditedSnapshot(ReviewCaseSnapshot base, Map<String, String[]> parameters, Long itemId) {
+        ReviewCaseSnapshot edited = base.copy();
+        edited.setSummary(param(parameters, "summary_" + itemId, edited.getSummary()));
+        edited.setDescription(param(parameters, "description_" + itemId, edited.getDescription()));
+        edited.setPrecondition(param(parameters, "precondition_" + itemId, edited.getPrecondition()));
+        edited.setStatus(param(parameters, "status_" + itemId, edited.getStatus()));
+        edited.setPriority(param(parameters, "priority_" + itemId, edited.getPriority()));
+        edited.setAssignee(param(parameters, "assignee_" + itemId, edited.getAssignee()));
+        edited.setReporter(param(parameters, "reporter_" + itemId, edited.getReporter()));
+        edited.setEstimatedTime(param(parameters, "estimatedTime_" + itemId, edited.getEstimatedTime()));
+        edited.setLabels(param(parameters, "labels_" + itemId, edited.getLabels()));
+        edited.setComponents(param(parameters, "components_" + itemId, edited.getComponents()));
+        edited.setSprint(param(parameters, "sprint_" + itemId, edited.getSprint()));
+        edited.setFixVersions(param(parameters, "fixVersions_" + itemId, edited.getFixVersions()));
+        edited.setVersion(param(parameters, "version_" + itemId, edited.getVersion()));
+        edited.setFolder(param(parameters, "folder_" + itemId, edited.getFolder()));
+        edited.setTestCaseType(param(parameters, "testCaseType_" + itemId, edited.getTestCaseType()));
+        edited.setCreatedBy(param(parameters, "createdBy_" + itemId, edited.getCreatedBy()));
+        edited.setCreatedOn(param(parameters, "createdOn_" + itemId, edited.getCreatedOn()));
+        edited.setUpdatedBy(param(parameters, "updatedBy_" + itemId, edited.getUpdatedBy()));
+        edited.setUpdatedOn(param(parameters, "updatedOn_" + itemId, edited.getUpdatedOn()));
+        edited.setStoryLinkages(param(parameters, "storyLinkages_" + itemId, edited.getStoryLinkages()));
+        edited.setIsSharableStep(param(parameters, "isSharableStep_" + itemId, edited.getIsSharableStep()));
+        edited.setFlakyScore(param(parameters, "flakyScore_" + itemId, edited.getFlakyScore()));
+
+        int stepCount = Integer.parseInt(param(parameters, "stepCount_" + itemId, String.valueOf(edited.getSteps().size())));
+        List<ReviewStepSnapshot> editedSteps = new ArrayList<>();
+        for (int index = 0; index < stepCount; index++) {
+            int stepNumber = Integer.parseInt(param(parameters, "stepNumber_" + itemId + "_" + index, String.valueOf(index + 1)));
+            editedSteps.add(new ReviewStepSnapshot(
+                stepNumber,
+                param(parameters, "stepSummary_" + itemId + "_" + index, ""),
+                param(parameters, "testData_" + itemId + "_" + index, ""),
+                param(parameters, "expectedResult_" + itemId + "_" + index, "")
+            ));
+        }
+        edited.setSteps(editedSteps);
+        return edited;
+    }
+
+    private void mergeIntoExisting(String teamKey, ReviewCaseSnapshot snapshot) {
+        TestCase existing = testCaseRepository.findByTeamKeyAndWorkKey(teamKey, snapshot.getWorkKey())
+            .orElseGet(() -> new TestCase(
+                teamKey,
+                snapshot.getWorkKey(),
+                snapshot.getSummary(),
+                snapshot.getDescription(),
+                snapshot.getPrecondition(),
+                snapshot.getStatus(),
+                snapshot.getPriority(),
+                snapshot.getAssignee(),
+                snapshot.getReporter(),
+                snapshot.getEstimatedTime(),
+                snapshot.getLabels(),
+                snapshot.getComponents(),
+                snapshot.getSprint(),
+                snapshot.getFixVersions(),
+                snapshot.getVersion(),
+                snapshot.getFolder(),
+                snapshot.getTestCaseType(),
+                snapshot.getCreatedBy(),
+                snapshot.getCreatedOn(),
+                snapshot.getUpdatedBy(),
+                snapshot.getUpdatedOn(),
+                snapshot.getStoryLinkages(),
+                snapshot.getIsSharableStep(),
+                snapshot.getFlakyScore()
+            ));
+
+        applySnapshot(existing, snapshot);
+        testCaseRepository.save(existing);
+    }
+
+    private TestCase toEntity(String teamKey, ReviewCaseSnapshot snapshot) {
+        TestCase testCase = new TestCase(
+            teamKey,
+            snapshot.getWorkKey(),
+            snapshot.getSummary(),
+            snapshot.getDescription(),
+            snapshot.getPrecondition(),
+            snapshot.getStatus(),
+            snapshot.getPriority(),
+            snapshot.getAssignee(),
+            snapshot.getReporter(),
+            snapshot.getEstimatedTime(),
+            snapshot.getLabels(),
+            snapshot.getComponents(),
+            snapshot.getSprint(),
+            snapshot.getFixVersions(),
+            snapshot.getVersion(),
+            snapshot.getFolder(),
+            snapshot.getTestCaseType(),
+            snapshot.getCreatedBy(),
+            snapshot.getCreatedOn(),
+            snapshot.getUpdatedBy(),
+            snapshot.getUpdatedOn(),
+            snapshot.getStoryLinkages(),
+            snapshot.getIsSharableStep(),
+            snapshot.getFlakyScore()
+        );
+        List<TestStep> steps = new ArrayList<>();
+        for (ReviewStepSnapshot step : snapshot.getSteps()) {
+            steps.add(new TestStep(step.getStepNumber(), step.getStepSummary(), step.getTestData(), step.getExpectedResult()));
+        }
+        testCase.replaceSteps(steps);
+        return testCase;
+    }
+
+    private void applySnapshot(TestCase testCase, ReviewCaseSnapshot snapshot) {
+        testCase.setSummary(snapshot.getSummary());
+        testCase.setDescription(snapshot.getDescription());
+        testCase.setPrecondition(snapshot.getPrecondition());
+        testCase.setStatus(snapshot.getStatus());
+        testCase.setPriority(snapshot.getPriority());
+        testCase.setAssignee(snapshot.getAssignee());
+        testCase.setReporter(snapshot.getReporter());
+        testCase.setEstimatedTime(snapshot.getEstimatedTime());
+        testCase.setLabels(snapshot.getLabels());
+        testCase.setComponents(snapshot.getComponents());
+        testCase.setSprint(snapshot.getSprint());
+        testCase.setFixVersions(snapshot.getFixVersions());
+        testCase.setVersion(snapshot.getVersion());
+        testCase.setFolder(snapshot.getFolder());
+        testCase.setTestCaseType(snapshot.getTestCaseType());
+        testCase.setCreatedBy(snapshot.getCreatedBy());
+        testCase.setCreatedOn(snapshot.getCreatedOn());
+        testCase.setUpdatedBy(snapshot.getUpdatedBy());
+        testCase.setUpdatedOn(snapshot.getUpdatedOn());
+        testCase.setStoryLinkages(snapshot.getStoryLinkages());
+        testCase.setIsSharableStep(snapshot.getIsSharableStep());
+        testCase.setFlakyScore(snapshot.getFlakyScore());
+
+        List<TestStep> steps = new ArrayList<>();
+        for (ReviewStepSnapshot step : snapshot.getSteps()) {
+            steps.add(new TestStep(step.getStepNumber(), step.getStepSummary(), step.getTestData(), step.getExpectedResult()));
+        }
+        testCase.replaceSteps(steps);
+    }
+
+    private ReviewCaseSnapshot readSnapshot(String json) {
+        try {
+            return objectMapper.readValue(json, ReviewCaseSnapshot.class);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to read staged review snapshot", exception);
+        }
+    }
+
+    private List<FieldDifference> readDifferences(String json) {
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<FieldDifference>>() { });
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to read staged field differences", exception);
+        }
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to store staged review data", exception);
+        }
+    }
+
+    private String param(Map<String, String[]> parameters, String name, String fallback) {
+        String[] values = parameters.get(name);
+        if (values == null || values.length == 0) {
+            return fallback == null ? "" : fallback;
+        }
+        return values[0] == null ? "" : values[0];
+    }
+}

--- a/src/main/resources/static/js/workspace/page.js
+++ b/src/main/resources/static/js/workspace/page.js
@@ -16,6 +16,11 @@ const filterTag = document.getElementById('wsFilterTag');
 const bulkBar = document.getElementById('bulkBar');
 const bulkCount = document.getElementById('bulkCount');
 const bulkExportSelected = document.getElementById('bulkExportSelected');
+const importNoticeContainer = document.getElementById('importNoticeContainer');
+const importNotice = document.getElementById('importNotice');
+const importNoticeBadge = document.getElementById('importNoticeBadge');
+const importNoticeMessage = document.getElementById('importNoticeMessage');
+const importNoticeClose = document.getElementById('importNoticeClose');
 
 const apiBaseUrl = document.querySelector('meta[name="workspace-api-base"]')?.content || '/api/testcases';
 const exportBaseUrl = document.querySelector('meta[name="workspace-export-base"]')?.content || '/workspace/export';
@@ -50,6 +55,10 @@ selection.setSelectionChangeHandler((selectedIds) => {
 
 drawer.bind(tbody);
 
+if (importNoticeClose) {
+    importNoticeClose.addEventListener('click', clearImportNotice);
+}
+
 if (tbody) {
     tbody.addEventListener('change', (event) => {
         const target = event.target;
@@ -59,6 +68,39 @@ if (tbody) {
 
         selection.toggleSelection(target.dataset.workKey || '', target.checked);
     });
+}
+
+function clearImportNotice() {
+    if (!importNoticeContainer) {
+        return;
+    }
+
+    importNoticeContainer.classList.add('hidden');
+    if (importNoticeMessage) {
+        importNoticeMessage.textContent = '';
+    }
+}
+
+function showImportNotice(type, message) {
+    if (!importNoticeContainer || !importNotice || !importNoticeBadge || !importNoticeMessage || !message) {
+        return;
+    }
+
+    const isSuccess = type === 'success';
+    importNoticeContainer.classList.remove('hidden');
+    importNoticeMessage.textContent = message;
+
+    if (isSuccess) {
+        importNotice.style.borderColor = 'rgba(231, 255, 2, 0.35)';
+        importNoticeBadge.textContent = 'OK';
+        importNoticeBadge.classList.remove('bg-white/70');
+        importNoticeBadge.style.backgroundColor = '#E7FF02';
+    } else {
+        importNotice.style.borderColor = 'rgba(255, 255, 255, 0.15)';
+        importNoticeBadge.textContent = 'Error';
+        importNoticeBadge.classList.add('bg-white/70');
+        importNoticeBadge.style.backgroundColor = '';
+    }
 }
 
 function applyFilters() {
@@ -126,6 +168,8 @@ if (importBtn && importFile) {
             return;
         }
 
+        clearImportNotice();
+
         const formData = new FormData();
         formData.append('file', importFile.files[0]);
 
@@ -149,15 +193,27 @@ if (importBtn && importFile) {
                 importBtn.disabled = false;
                 importFile.value = '';
 
-                if (json.errors && json.errors.length > 0) {
-                    window.alert('Import warnings:\n' + json.errors.join('\n'));
+                if (json.reviewRequired && json.reviewUrl) {
+                    window.location.href = json.reviewUrl;
+                    return;
+                }
+
+                if (json.exactDuplicateFile) {
+                    showImportNotice('error', json.message || 'This exact file was already uploaded.');
+                    return;
+                }
+
+                if (json.message) {
+                    showImportNotice('success', json.message);
+                } else if (json.errors && json.errors.length > 0) {
+                    showImportNotice('error', 'Import warnings\n' + json.errors.join('\n'));
                 }
 
                 loadAllTestCases();
             })
             .catch((error) => {
                 console.error('Upload failed', error);
-                window.alert('Import failed. Please try again.');
+                showImportNotice('error', 'Import failed. Please try again.');
                 importBtn.textContent = 'Import';
                 importBtn.disabled = false;
             });

--- a/src/main/resources/templates/upload-review.html
+++ b/src/main/resources/templates/upload-review.html
@@ -1,0 +1,484 @@
+
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Review Upload</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;700;900&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white" style="font-family: 'Work Sans', sans-serif;">
+<div class="min-h-screen">
+    <header class="border-b border-white/10">
+        <div class="w-full px-6 sm:px-8 py-5 flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+            <div class="flex-1 min-w-0">
+                <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Upload review</p>
+                <h1 class="mt-2 text-2xl font-semibold text-white/90">Resolve Duplicate Test Cases Before Saving</h1>
+                <p class="mt-2 text-sm text-white/55">
+                    Review the staged upload, compare the changed <span class="text-white/80">workKey</span> records,
+                    and decide which ones to skip or merge.
+                </p>
+            </div>
+            <div class="flex items-center gap-3">
+                <div class="hidden sm:block text-right min-w-0">
+                    <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Account</p>
+                    <p class="text-sm text-white/70 truncate" th:text="${userEmail != null ? userEmail : 'Signed in'}">Signed in</p>
+                </div>
+                <a th:href="@{/workspace}" class="px-4 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-sm">
+                    Back to workspace
+                </a>
+                <form th:action="@{/logout}" method="post">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                    <button type="submit" class="px-4 py-2 text-black font-bold hover:opacity-80 transition-opacity text-sm" style="background-color: #E7FF02;">
+                        Logout
+                    </button>
+                </form>
+            </div>
+        </div>
+    </header>
+
+    <main class="px-6 sm:px-8 py-6 space-y-6">
+        <section class="grid grid-cols-1 lg:grid-cols-4 gap-4">
+            <div class="border border-white/10 bg-black/95 p-4">
+                <p class="text-xs uppercase tracking-wider text-white/45 font-bold">File</p>
+                <p class="mt-2 text-sm text-white/80 break-all" th:text="${reviewSession.originalFilename}">upload.xlsx</p>
+            </div>
+            <div class="border border-white/10 bg-black/95 p-4">
+                <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Parsed</p>
+                <p class="mt-2 text-xl text-white/85"><span th:text="${reviewSession.parsedTestCaseCount}">0</span> cases</p>
+                <p class="text-sm text-white/45"><span th:text="${reviewSession.parsedStepCount}">0</span> steps</p>
+            </div>
+            <div class="border border-white/10 bg-black/95 p-4" style="border-color: rgba(231, 255, 2, 0.2);">
+                <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Ready to import</p>
+                <p class="mt-2 text-xl text-white/85"><span th:text="${reviewSession.newItemCount}">0</span> new</p>
+                <p class="text-sm text-white/45" th:if="${reviewSession.newItemCount > 0}">These are staged and will be saved when you apply this review.</p>
+                <p class="text-sm text-white/45" th:if="${reviewSession.newItemCount == 0}">No brand-new cases in this file. This review only applies your duplicate merge/skip decisions.</p>
+            </div>
+            <div class="border border-white/10 bg-black/95 p-4">
+                <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Duplicates</p>
+                <p class="mt-2 text-xl text-white/85"><span th:text="${reviewSession.changedItemCount}">0</span> changed</p>
+                <p class="text-sm text-white/45"><span th:text="${reviewSession.duplicateUnchangedCount}">0</span> unchanged duplicates will be skipped automatically.</p>
+            </div>
+        </section>
+
+        <section class="border border-white/10 bg-black/95 p-5" th:if="${#lists.isEmpty(reviewSession.conflictItems)}">
+            <p class="text-sm text-white/70">There are no changed duplicate items in this review session.</p>
+        </section>
+
+        <form th:if="${!#lists.isEmpty(reviewSession.conflictItems)}"
+              th:action="@{'/workspace/import/review/' + ${reviewSession.sessionId} + '/apply'}"
+              method="post"
+              class="space-y-6">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+
+            <section class="space-y-6">
+                <div th:each="item : ${reviewSession.conflictItems}"
+                     class="border border-white/10 bg-black/95 overflow-hidden"
+                     data-review-item="true"
+                     th:attr="data-item-id=${item.itemId}">
+                    <div class="px-5 py-4 border-b border-white/10 flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+                        <div>
+                            <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Duplicate workKey</p>
+                            <h2 class="mt-1 text-lg text-white/85" th:text="${item.workKey}">TC-101</h2>
+                            <p class="mt-2 text-sm text-white/45">
+                                <span data-diff-count th:text="${#lists.size(item.changedFields)}">0</span> changed field(s) detected.
+                            </p>
+                        </div>
+                        <div class="flex flex-wrap items-center gap-4">
+                            <label class="inline-flex items-center gap-2 text-sm text-white/75">
+                                <input type="radio"
+                                       class="accent-[#E7FF02]"
+                                       data-action-radio="SKIP"
+                                       th:name="${'action_' + item.itemId}"
+                                       value="SKIP"
+                                       th:checked="${item.chosenAction != 'MERGE'}" />
+                                Skip
+                            </label>
+                            <label class="inline-flex items-center gap-2 text-sm text-white/75">
+                                <input type="radio"
+                                       class="accent-[#E7FF02]"
+                                       data-action-radio="MERGE"
+                                       th:name="${'action_' + item.itemId}"
+                                       value="MERGE"
+                                       th:checked="${item.chosenAction == 'MERGE'}" />
+                                Merge edited upload version
+                            </label>
+                            <button type="button" data-toggle-details class="px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs">
+                                Show details
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 xl:grid-cols-2 gap-0 hidden" data-review-body>
+                        <div class="border-r border-white/10 p-5 space-y-4">
+                            <div>
+                                <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Detected differences</p>
+                                <div class="mt-3 space-y-3">
+                                    <div th:each="diff : ${item.changedFields}"
+                                         th:if="${diff.fieldKey == 'summary' or diff.fieldKey == 'description' or diff.fieldKey == 'status' or #strings.startsWith(diff.fieldKey, 'step_')}"
+                                         class="border border-white/10 p-3 bg-white/5"
+                                         data-diff-row
+                                         th:attr="data-field-key=${diff.fieldKey}">
+                                        <p class="text-xs uppercase tracking-wider text-white/45 font-bold"
+                                           th:text="${diff.fieldKey == 'summary' ? 'Title' : (diff.fieldKey == 'description' ? 'Summary' : diff.displayName)}">Summary</p>
+                                        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3 text-sm">
+                                            <div>
+                                                <p class="text-xs text-white/45">Current</p>
+                                                <div class="mt-1 whitespace-pre-wrap text-white/75 border border-white/10 p-3" data-current-value th:text="${#strings.isEmpty(diff.existingValue) ? '—' : diff.existingValue}">Current value</div>
+                                                <textarea class="hidden" data-current-raw th:text="${diff.existingValue}"></textarea>
+                                            </div>
+                                            <div>
+                                                <p class="text-xs text-white/45">Updated</p>
+                                                <div class="mt-1 whitespace-pre-wrap text-white/85 border border-white/10 p-3" data-updated-value th:text="${#strings.isEmpty(diff.incomingValue) ? '—' : diff.incomingValue}">Updated value</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <p class="hidden text-xs text-white/45" data-diff-empty>No remaining differences. Merge will keep the current values.</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="p-5 space-y-5" data-editable-section>
+                            <div>
+                                <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Editable uploaded version</p>
+                                <p class="mt-2 text-sm text-white/45">Select Merge to edit these values before applying them to the existing test case.</p>
+                                <div class="mt-3 flex flex-wrap items-center gap-2">
+                                    <button type="button" data-set-action="SKIP" class="px-3 py-2 border border-white/20 hover:border-white/60 transition-colors text-xs text-white/75">
+                                        Skip This Case
+                                    </button>
+                                    <button type="button" data-set-action="MERGE" class="px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs text-white/75">
+                                        Merge And Edit
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div class="space-y-5">
+                                <div>
+                                    <label class="block text-xs uppercase tracking-wider text-white/45 font-bold">Title</label>
+                                    <input type="text"
+                                           class="mt-2 w-full bg-black border border-white/15 px-4 py-3 text-sm text-white/85 focus:outline-none focus:border-[#E7FF02]"
+                                           th:name="${'summary_' + item.itemId}"
+                                           th:value="${item.editableSnapshot.summary}" />
+                                </div>
+
+                                <div>
+                                    <label class="block text-xs uppercase tracking-wider text-white/45 font-bold">Summary</label>
+                                    <textarea rows="3"
+                                              class="mt-2 w-full bg-black border border-white/15 px-4 py-3 text-sm text-white/85 focus:outline-none focus:border-[#E7FF02]"
+                                              th:name="${'description_' + item.itemId}"
+                                              th:text="${item.editableSnapshot.description}"></textarea>
+                                </div>
+
+                                <div>
+                                    <div class="flex items-center justify-between gap-4">
+                                        <label class="block text-xs uppercase tracking-wider text-white/45 font-bold">Steps</label>
+                                        <span class="text-xs text-white/45">Action • Data • Expected</span>
+                                    </div>
+
+                                    <input type="hidden"
+                                           th:name="${'stepCount_' + item.itemId}"
+                                           th:value="${#lists.size(item.editableSnapshot.steps)}" />
+
+                                    <div class="mt-3 space-y-3">
+                                        <div th:each="step, stepStat : ${item.editableSnapshot.steps}"
+                                             class="border border-white/10 p-4"
+                                             th:attr="data-step-index=${stepStat.index}">
+                                            <input type="hidden"
+                                                   th:name="${'stepNumber_' + item.itemId + '_' + stepStat.index}"
+                                                   th:value="${step.stepNumber}" />
+
+                                            <p class="text-xs text-white/45">Step <span th:text="${step.stepNumber}">1</span></p>
+
+                                            <div class="mt-3 grid grid-cols-1 gap-3">
+                                                <input type="text"
+                                                       class="bg-black border border-white/15 px-3 py-2 text-sm text-white/85 focus:outline-none focus:border-[#E7FF02]"
+                                                       placeholder="Action"
+                                                       th:name="${'stepSummary_' + item.itemId + '_' + stepStat.index}"
+                                                       th:value="${step.stepSummary}" />
+
+                                                <input type="text"
+                                                       class="bg-black border border-white/15 px-3 py-2 text-sm text-white/85 focus:outline-none focus:border-[#E7FF02]"
+                                                       placeholder="Data"
+                                                       th:name="${'testData_' + item.itemId + '_' + stepStat.index}"
+                                                       th:value="${step.testData}" />
+
+                                                <input type="text"
+                                                       class="bg-black border border-white/15 px-3 py-2 text-sm text-white/85 focus:outline-none focus:border-[#E7FF02]"
+                                                       placeholder="Expected"
+                                                       th:name="${'expectedResult_' + item.itemId + '_' + stepStat.index}"
+                                                       th:value="${step.expectedResult}" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="border border-white/10 bg-white/5 p-4">
+                                    <p class="text-xs uppercase tracking-wider text-white/45 font-bold">Context</p>
+
+                                    <div class="mt-2 grid grid-cols-2 gap-3 text-sm">
+                                        <div>
+                                            <p class="text-xs text-white/45">Status</p>
+                                            <select th:name="${'status_' + item.itemId}"
+                                                    class="mt-1 w-full bg-black border border-white/15 px-3 py-2 text-sm text-white/85 focus:outline-none focus:border-[#E7FF02]">
+                                                <option value="Draft" th:selected="${item.editableSnapshot.status == 'Draft'}">Draft</option>
+                                                <option value="Pass" th:selected="${item.editableSnapshot.status == 'Pass'}">Pass</option>
+                                                <option value="Fail" th:selected="${item.editableSnapshot.status == 'Fail'}">Fail</option>
+                                            </select>
+                                        </div>
+
+                                        <div>
+                                            <p class="text-xs text-white/45">Last updated</p>
+                                            <p class="text-white/75" th:text="${#strings.isEmpty(item.editableSnapshot.updatedOn) ? '—' : item.editableSnapshot.updatedOn}">—</p>
+                                        </div>
+                                    </div>
+
+                                    <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
+                                        <div>
+                                            <p class="text-xs text-white/45">Assignee</p>
+                                            <p class="text-white/75" th:text="${#strings.isEmpty(item.editableSnapshot.assignee) ? '—' : item.editableSnapshot.assignee}">—</p>
+                                        </div>
+                                        <div>
+                                            <p class="text-xs text-white/45">Reporter</p>
+                                            <p class="text-white/75" th:text="${#strings.isEmpty(item.editableSnapshot.reporter) ? '—' : item.editableSnapshot.reporter}">—</p>
+                                        </div>
+                                    </div>
+
+                                    <div class="mt-3">
+                                        <p class="text-xs text-white/45">Created on</p>
+                                        <p class="text-white/75" th:text="${#strings.isEmpty(item.editableSnapshot.createdOn) ? '—' : item.editableSnapshot.createdOn}">—</p>
+                                    </div>
+
+                                    <div class="mt-3">
+                                        <p class="text-xs text-white/45">Tags</p>
+                                        <p class="text-white/75"
+                                           th:text="${#strings.isEmpty(item.editableSnapshot.components) and #strings.isEmpty(item.editableSnapshot.testCaseType)
+                                                        ? '—'
+                                                        : (#strings.isEmpty(item.editableSnapshot.components)
+                                                            ? item.editableSnapshot.testCaseType
+                                                            : (#strings.isEmpty(item.editableSnapshot.testCaseType)
+                                                                ? item.editableSnapshot.components
+                                                                : item.editableSnapshot.components + ', ' + item.editableSnapshot.testCaseType))}">
+                                            —
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <div class="sticky bottom-0 z-40">
+                <div class="border border-white/10 bg-black/95 backdrop-blur p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3" style="border-color: rgba(231, 255, 2, 0.25);">
+                    <p class="text-sm text-white/70">Apply this review to import the staged new cases and any duplicate cases you marked for merge.</p>
+                    <div class="flex items-center gap-3">
+                        <button type="submit" class="px-5 py-2 text-black font-bold hover:opacity-80 transition-opacity text-sm" style="background-color: #E7FF02;">
+                            Apply review
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </form>
+
+        <form th:action="@{'/workspace/import/review/' + ${reviewSession.sessionId} + '/cancel'}" method="post" class="pt-2">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+            <button type="submit" class="px-4 py-2 border border-white/20 hover:border-white/60 transition-colors text-sm text-white/70">
+                Discard this review session
+            </button>
+        </form>
+    </main>
+
+    <script>
+        (function () {
+            function normalize(value) {
+                return value == null ? '' : String(value).trim();
+            }
+
+            function displayValue(value) {
+                return normalize(value) === '' ? '-' : String(value);
+            }
+
+            function selectedAction(itemCard, itemId) {
+                const selected = itemCard.querySelector('input[type="radio"][name="action_' + itemId + '"]:checked');
+                return selected ? selected.value : 'SKIP';
+            }
+
+            function setReviewBodyOpen(itemCard, isOpen) {
+                const body = itemCard.querySelector('[data-review-body]');
+                const toggle = itemCard.querySelector('[data-toggle-details]');
+                if (!body || !toggle) {
+                    return;
+                }
+
+                body.classList.toggle('hidden', !isOpen);
+                toggle.textContent = isOpen ? 'Hide details' : 'Show details';
+                toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            }
+
+            function setChosenAction(itemCard, itemId, action) {
+                const radio = itemCard.querySelector('input[type="radio"][name="action_' + itemId + '"][value="' + action + '"]');
+                if (!radio) {
+                    return;
+                }
+
+                if (!radio.checked) {
+                    radio.checked = true;
+                }
+                radio.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+
+            function syncActionButtons(itemCard, itemId) {
+                const action = selectedAction(itemCard, itemId);
+                itemCard.querySelectorAll('[data-set-action]').forEach(function (button) {
+                    const active = button.getAttribute('data-set-action') === action;
+                    button.classList.toggle('text-[#E7FF02]', active);
+                    button.classList.toggle('border-[#E7FF02]', active);
+                });
+            }
+
+            function buildStepPreview(itemCard, itemId, stepNumber) {
+                const stepIndex = stepNumber - 1;
+                if (stepIndex < 0) {
+                    return '';
+                }
+
+                const action = itemCard.querySelector('[name="stepSummary_' + itemId + '_' + stepIndex + '"]');
+                const testData = itemCard.querySelector('[name="testData_' + itemId + '_' + stepIndex + '"]');
+                const expected = itemCard.querySelector('[name="expectedResult_' + itemId + '_' + stepIndex + '"]');
+
+                const actionValue = action ? action.value : '';
+                const dataValue = testData ? testData.value : '';
+                const expectedValue = expected ? expected.value : '';
+
+                if (normalize(actionValue) === '' && normalize(dataValue) === '' && normalize(expectedValue) === '') {
+                    return '';
+                }
+
+                return 'Action: ' + actionValue + '\nData: ' + dataValue + '\nExpected: ' + expectedValue;
+            }
+
+            function editedValue(itemCard, itemId, fieldKey) {
+                if (fieldKey.indexOf('step_') === 0) {
+                    const stepNumber = Number(fieldKey.substring(5));
+                    if (!Number.isFinite(stepNumber)) {
+                        return '';
+                    }
+                    return buildStepPreview(itemCard, itemId, stepNumber);
+                }
+
+                const fieldInput = itemCard.querySelector('[name="' + fieldKey + '_' + itemId + '"]');
+                return fieldInput ? fieldInput.value : '';
+            }
+
+            function refreshDifferences(itemCard) {
+                const itemId = itemCard.getAttribute('data-item-id');
+                if (!itemId) {
+                    return;
+                }
+
+                const rows = itemCard.querySelectorAll('[data-diff-row]');
+                let visibleCount = 0;
+
+                rows.forEach(function (row) {
+                    const fieldKey = row.getAttribute('data-field-key') || '';
+                    const currentRaw = row.querySelector('[data-current-raw]') ? row.querySelector('[data-current-raw]').value : '';
+                    const updatedRaw = editedValue(itemCard, itemId, fieldKey);
+                    const updatedValue = row.querySelector('[data-updated-value]');
+                    if (updatedValue) {
+                        updatedValue.textContent = displayValue(updatedRaw);
+                    }
+
+                    const changed = normalize(currentRaw) !== normalize(updatedRaw);
+                    row.classList.toggle('hidden', !changed);
+                    if (changed) {
+                        visibleCount++;
+                    }
+                });
+
+                const count = itemCard.querySelector('[data-diff-count]');
+                if (count) {
+                    count.textContent = String(visibleCount);
+                }
+
+                const emptyState = itemCard.querySelector('[data-diff-empty]');
+                if (emptyState) {
+                    emptyState.classList.toggle('hidden', visibleCount !== 0);
+                }
+            }
+
+            function syncEditableState(itemCard) {
+                const itemId = itemCard.getAttribute('data-item-id');
+                if (!itemId) {
+                    return;
+                }
+
+                const mergeRadio = itemCard.querySelector('input[type="radio"][name="action_' + itemId + '"][value="MERGE"]');
+                const isMergeSelected = !!(mergeRadio && mergeRadio.checked);
+                const editableSection = itemCard.querySelector('[data-editable-section]');
+                if (!editableSection) {
+                    return;
+                }
+
+                editableSection.classList.toggle('opacity-60', !isMergeSelected);
+                editableSection.querySelectorAll('input[type="text"], textarea, select').forEach(function (field) {
+                    field.disabled = !isMergeSelected;
+                });
+                syncActionButtons(itemCard, itemId);
+            }
+
+            document.querySelectorAll('[data-review-item="true"]').forEach(function (itemCard) {
+                const itemId = itemCard.getAttribute('data-item-id');
+                if (!itemId) {
+                    return;
+                }
+
+                itemCard.querySelectorAll('input[type="radio"][name="action_' + itemId + '"]').forEach(function (radio) {
+                    radio.addEventListener('change', function () {
+                        syncEditableState(itemCard);
+                        refreshDifferences(itemCard);
+                        if (selectedAction(itemCard, itemId) === 'MERGE') {
+                            setReviewBodyOpen(itemCard, true);
+                        }
+                    });
+                });
+
+                const toggleDetails = itemCard.querySelector('[data-toggle-details]');
+                if (toggleDetails) {
+                    toggleDetails.addEventListener('click', function () {
+                        const body = itemCard.querySelector('[data-review-body]');
+                        if (!body) {
+                            return;
+                        }
+                        setReviewBodyOpen(itemCard, body.classList.contains('hidden'));
+                    });
+                }
+
+                itemCard.querySelectorAll('[data-set-action]').forEach(function (button) {
+                    button.addEventListener('click', function () {
+                        const action = button.getAttribute('data-set-action');
+                        if (!action) {
+                            return;
+                        }
+                        setChosenAction(itemCard, itemId, action);
+                    });
+                });
+
+                itemCard.querySelectorAll('[data-editable-section] input[type="text"], [data-editable-section] textarea, [data-editable-section] select').forEach(function (field) {
+                    field.addEventListener('input', function () {
+                        refreshDifferences(itemCard);
+                    });
+                    field.addEventListener('change', function () {
+                        refreshDifferences(itemCard);
+                    });
+                });
+
+                syncEditableState(itemCard);
+                refreshDifferences(itemCard);
+                setReviewBodyOpen(itemCard, selectedAction(itemCard, itemId) === 'MERGE');
+            });
+        })();
+    </script>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -90,6 +90,51 @@
 			</div>
 		</header>
 
+		<div id="workspaceFlashContainer" class="px-6 sm:px-8 pt-5 space-y-3" th:if="${importSuccessMessage != null or importErrorMessage != null}">
+			<div data-flash-item th:if="${importSuccessMessage != null}" class="border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80" style="border-color: rgba(231, 255, 2, 0.35);">
+				<div class="flex items-start justify-between gap-3">
+					<div class="min-w-0">
+						<span class="font-bold text-black px-2 py-1 mr-3" style="background-color: #E7FF02;">OK</span>
+						<span th:text="${importSuccessMessage}">Upload applied.</span>
+					</div>
+					<button type="button"
+						aria-label="Dismiss notification"
+						class="shrink-0 px-2 py-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs leading-none"
+						onclick="dismissWorkspaceFlash(this)">
+						x
+					</button>
+				</div>
+			</div>
+			<div data-flash-item th:if="${importErrorMessage != null}" class="border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80">
+				<div class="flex items-start justify-between gap-3">
+					<div class="min-w-0">
+						<span class="font-bold text-black px-2 py-1 mr-3 bg-white/70">Error</span>
+						<span th:text="${importErrorMessage}">Import failed.</span>
+					</div>
+					<button type="button"
+						aria-label="Dismiss notification"
+						class="shrink-0 px-2 py-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs leading-none"
+						onclick="dismissWorkspaceFlash(this)">
+						x
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<div id="importNoticeContainer" class="px-6 sm:px-8 pt-5 hidden" aria-live="polite">
+			<div id="importNotice" class="border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80">
+				<div class="flex items-start justify-between gap-3">
+					<div class="min-w-0">
+						<span id="importNoticeBadge" class="font-bold text-black px-2 py-1 mr-3 bg-white/70">Error</span>
+						<span id="importNoticeMessage" class="whitespace-pre-line">Import status.</span>
+					</div>
+					<button id="importNoticeClose" type="button" aria-label="Dismiss notification" class="shrink-0 px-2 py-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs leading-none">
+						x
+					</button>
+				</div>
+			</div>
+		</div>
+
 		<!-- Main view: high-density data grid -->
 		<main class="w-full px-0 sm:px-0">
 			<div class="px-6 sm:px-8 py-6 border-b border-white/10">
@@ -242,6 +287,25 @@
 			</div>
 		</aside>
 	</div>
+
+	<script>
+		function dismissWorkspaceFlash(button) {
+			const item = button.closest('[data-flash-item]');
+			if (item) {
+				item.classList.add('hidden');
+			}
+
+			const container = document.getElementById('workspaceFlashContainer');
+			if (!container) {
+				return;
+			}
+
+			const visibleItems = container.querySelectorAll('[data-flash-item]:not(.hidden)');
+			if (visibleItems.length === 0) {
+				container.classList.add('hidden');
+			}
+		}
+	</script>
 
 	<script type="module" th:src="@{/js/workspace/page.js}"></script>
 </body>

--- a/src/test/java/com/formswim/teststream/UploadReviewIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/UploadReviewIntegrationTests.java
@@ -1,0 +1,460 @@
+package com.formswim.teststream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.etl.dto.EtlResultSummary;
+import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.model.TestStep;
+import com.formswim.teststream.etl.model.UploadReviewItem;
+import com.formswim.teststream.etl.model.UploadReviewSession;
+import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.etl.repository.UploadHistoryRepository;
+import com.formswim.teststream.etl.repository.UploadReviewSessionRepository;
+import com.formswim.teststream.etl.service.ExcelParserService;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UploadReviewIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestCaseRepository testCaseRepository;
+
+    @Autowired
+    private UploadHistoryRepository uploadHistoryRepository;
+
+    @Autowired
+    private UploadReviewSessionRepository uploadReviewSessionRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        uploadReviewSessionRepository.deleteAll();
+        uploadHistoryRepository.deleteAll();
+        testCaseRepository.deleteAll();
+        userRepository.deleteAll();
+
+        userRepository.save(new AppUser(
+            "user@example.com",
+            passwordEncoder.encode("Password123"),
+            "TEAM1"
+        ));
+    }
+
+    @Test
+    void exactDuplicateFileIsBlockedByHash() throws Exception {
+        MockMultipartFile upload = new MockMultipartFile(
+            "file",
+            "duplicate-check.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            workbookBytes(
+                row("TC-100", "First upload", "Draft", "UI", "Open page", "", "Page visible")
+            )
+        );
+
+        MvcResult firstUpload = mockMvc.perform(multipart("/api/upload")
+                .file(upload)
+                .with(csrf())
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        EtlResultSummary firstResult = objectMapper.readValue(
+            firstUpload.getResponse().getContentAsByteArray(),
+            EtlResultSummary.class
+        );
+
+        assertThat(firstResult.isExactDuplicateFile()).isFalse();
+        assertThat(firstResult.isReviewRequired()).isFalse();
+        assertThat(firstResult.getImportedCount()).isEqualTo(1);
+        assertThat(uploadHistoryRepository.count()).isEqualTo(1);
+        assertThat(testCaseRepository.countByTeamKey("TEAM1")).isEqualTo(1);
+
+        MvcResult secondUpload = mockMvc.perform(multipart("/api/upload")
+                .file(upload)
+                .with(csrf())
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        EtlResultSummary secondResult = objectMapper.readValue(
+            secondUpload.getResponse().getContentAsByteArray(),
+            EtlResultSummary.class
+        );
+
+        assertThat(secondResult.isExactDuplicateFile()).isTrue();
+        assertThat(secondResult.getMessage()).contains("exact file was already uploaded");
+        assertThat(testCaseRepository.countByTeamKey("TEAM1")).isEqualTo(1);
+        assertThat(uploadHistoryRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void changedDuplicateCreatesReviewSessionAndApplyMergesIt() throws Exception {
+        TestCase existing = existingCase("TC-101", "Original summary", "Original description", "Original precondition");
+        testCaseRepository.save(existing);
+
+        MockMultipartFile upload = new MockMultipartFile(
+            "file",
+            "review-needed.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            workbookBytes(
+                rowWithDetails(
+                    "TC-101",
+                    "Updated summary",
+                    "Updated summary description",
+                    "Updated summary precondition",
+                    "Draft",
+                    "UI",
+                    "Open login page",
+                    "",
+                    "Login form shows"
+                ),
+                row("TC-102", "Brand new case", "Pass", "API", "Call endpoint", "payload", "Success response")
+            )
+        );
+
+        MvcResult uploadResult = mockMvc.perform(multipart("/api/upload")
+                .file(upload)
+                .with(csrf())
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        EtlResultSummary result = objectMapper.readValue(
+            uploadResult.getResponse().getContentAsByteArray(),
+            EtlResultSummary.class
+        );
+
+        assertThat(result.isReviewRequired()).isTrue();
+        assertThat(result.getReviewSessionId()).isNotBlank();
+        assertThat(result.getDuplicateChangedCount()).isEqualTo(1);
+        assertThat(result.getStagedNewCount()).isEqualTo(1);
+        assertThat(testCaseRepository.countByTeamKey("TEAM1")).isEqualTo(1);
+
+        mockMvc.perform(get("/workspace/import/review/{sessionId}", result.getReviewSessionId())
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("Resolve Duplicate Test Cases Before Saving")));
+
+        UploadReviewSession session = uploadReviewSessionRepository
+            .findById(result.getReviewSessionId())
+            .orElseThrow();
+
+        UploadReviewItem changedItem = session.getItems().stream()
+            .filter(item -> UploadReviewItem.TYPE_CHANGED_DUPLICATE.equals(item.getConflictType()))
+            .findFirst()
+            .orElseThrow();
+
+        mockMvc.perform(post("/workspace/import/review/{sessionId}/apply", result.getReviewSessionId())
+                .with(csrf())
+                .with(user("user@example.com").roles("USER"))
+                .param("action_" + changedItem.getId(), "MERGE")
+                .param("stepCount_" + changedItem.getId(), "1")
+                .param("stepNumber_" + changedItem.getId() + "_0", "1")
+                .param("stepSummary_" + changedItem.getId() + "_0", "Open login page")
+                .param("testData_" + changedItem.getId() + "_0", "")
+                .param("expectedResult_" + changedItem.getId() + "_0", "Login form shows"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrlPattern("/workspace?importSuccess=*"));
+
+        assertThat(testCaseRepository.countByTeamKey("TEAM1")).isEqualTo(2);
+        assertThat(testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101"))
+            .get()
+            .extracting(TestCase::getSummary)
+            .isEqualTo("Updated summary");
+        assertThat(testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-102")).isPresent();
+        assertThat(uploadHistoryRepository.count()).isEqualTo(1);
+        assertThat(uploadReviewSessionRepository.findById(result.getReviewSessionId()))
+            .get()
+            .extracting(UploadReviewSession::getStatus)
+            .isEqualTo(UploadReviewSession.STATUS_APPLIED);
+    }
+
+    @Test
+    void mergedDuplicateUploadAgainIsTreatedAsUnchanged() throws Exception {
+        MockMultipartFile firstUpload = new MockMultipartFile(
+            "file",
+            "original.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            workbookBytes(
+                rowWithDetails(
+                    "TC-200",
+                    "Original summary",
+                    "Original description",
+                    "Original precondition",
+                    "Draft",
+                    "UI",
+                    "Open login page",
+                    "",
+                    "Login form shows"
+                )
+            )
+        );
+
+        MockMultipartFile changedUpload = new MockMultipartFile(
+            "file",
+            "changed.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            workbookBytes(
+                rowWithDetails(
+                    "TC-200",
+                    "Updated summary",
+                    "Line 1\nLine 2",
+                    "Updated precondition",
+                    "Draft",
+                    "UI",
+                    "Open login page",
+                    "",
+                    "Login form shows"
+                )
+            )
+        );
+
+        MockMultipartFile sameLogicalUploadAgain = new MockMultipartFile(
+            "file",
+            "changed-again.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            workbookBytes(
+                List.of(
+                    rowWithDetails(
+                        "TC-200",
+                        "Updated summary",
+                        "Line 1\nLine 2",
+                        "Updated precondition",
+                        "Draft",
+                        "UI",
+                        "Open login page",
+                        "",
+                        "Login form shows"
+                    ),
+                    blankRow()
+                )
+            )
+        );
+
+        MvcResult firstResultRaw = mockMvc.perform(multipart("/api/upload")
+                .file(firstUpload)
+                .with(csrf())
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        EtlResultSummary firstResult = objectMapper.readValue(
+            firstResultRaw.getResponse().getContentAsByteArray(),
+            EtlResultSummary.class
+        );
+
+        assertThat(firstResult.isReviewRequired()).isFalse();
+        assertThat(firstResult.getImportedCount()).isEqualTo(1);
+
+        MvcResult secondResultRaw = mockMvc.perform(multipart("/api/upload")
+                .file(changedUpload)
+                .with(csrf())
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        EtlResultSummary secondResult = objectMapper.readValue(
+            secondResultRaw.getResponse().getContentAsByteArray(),
+            EtlResultSummary.class
+        );
+
+        assertThat(secondResult.isReviewRequired()).isTrue();
+        assertThat(secondResult.getReviewSessionId()).isNotBlank();
+
+        UploadReviewSession session = uploadReviewSessionRepository
+            .findById(secondResult.getReviewSessionId())
+            .orElseThrow();
+
+        UploadReviewItem changedItem = session.getItems().stream()
+            .filter(item -> UploadReviewItem.TYPE_CHANGED_DUPLICATE.equals(item.getConflictType()))
+            .findFirst()
+            .orElseThrow();
+
+        mockMvc.perform(post("/workspace/import/review/{sessionId}/apply", secondResult.getReviewSessionId())
+                .with(csrf())
+                .with(user("user@example.com").roles("USER"))
+                .param("action_" + changedItem.getId(), "MERGE")
+                .param("description_" + changedItem.getId(), "Line 1\r\nLine 2")
+                .param("stepCount_" + changedItem.getId(), "1")
+                .param("stepNumber_" + changedItem.getId() + "_0", "1")
+                .param("stepSummary_" + changedItem.getId() + "_0", "Open login page")
+                .param("testData_" + changedItem.getId() + "_0", "")
+                .param("expectedResult_" + changedItem.getId() + "_0", "Login form shows"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrlPattern("/workspace?importSuccess=*"));
+
+        MvcResult thirdResultRaw = mockMvc.perform(multipart("/api/upload")
+                .file(sameLogicalUploadAgain)
+                .with(csrf())
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        EtlResultSummary thirdResult = objectMapper.readValue(
+            thirdResultRaw.getResponse().getContentAsByteArray(),
+            EtlResultSummary.class
+        );
+
+        assertThat(thirdResult.isExactDuplicateFile()).isFalse();
+        assertThat(thirdResult.isReviewRequired()).isFalse();
+        assertThat(thirdResult.getDuplicateChangedCount()).isEqualTo(0);
+        assertThat(thirdResult.getDuplicateUnchangedCount()).isEqualTo(1);
+        assertThat(testCaseRepository.countByTeamKey("TEAM1")).isEqualTo(1);
+    }
+
+    private TestCase existingCase(String workKey, String summary, String description, String precondition) {
+        TestCase testCase = new TestCase(
+            "TEAM1",
+            workKey,
+            summary,
+            description,
+            precondition,
+            "Draft",
+            "High",
+            "Alice",
+            "Bob",
+            "5m",
+            "auth",
+            "UI",
+            "Sprint 1",
+            "1.0",
+            "V1",
+            "Auth/Login",
+            "Regression",
+            "creator@example.com",
+            "2026-03-01",
+            "editor@example.com",
+            "2026-03-02",
+            "ST-1",
+            "No",
+            "1"
+        );
+        testCase.addStep(new TestStep(1, "Open login page", "", "Login form shows"));
+        return testCase;
+    }
+
+    private byte[] workbookBytes(String[]... rows) throws Exception {
+        return workbookBytes(List.of(rows));
+    }
+
+    private byte[] workbookBytes(List<String[]> rows) throws Exception {
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+
+            var sheet = workbook.createSheet("Test Cases");
+            Row header = sheet.createRow(0);
+            List<String> headers = ExcelParserService.CANONICAL_HEADERS;
+
+            for (int index = 0; index < headers.size(); index++) {
+                header.createCell(index).setCellValue(headers.get(index));
+            }
+
+            for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+                Row row = sheet.createRow(rowIndex + 1);
+                String[] values = rows.get(rowIndex);
+
+                for (int columnIndex = 0; columnIndex < values.length; columnIndex++) {
+                    if (values[columnIndex] != null) {
+                        row.createCell(columnIndex).setCellValue(values[columnIndex]);
+                    }
+                }
+            }
+
+            workbook.write(outputStream);
+            return outputStream.toByteArray();
+        }
+    }
+
+    private String[] row(String workKey,
+                         String summary,
+                         String status,
+                         String components,
+                         String stepSummary,
+                         String testData,
+                         String expectedResult) {
+        String[] values = new String[ExcelParserService.CANONICAL_HEADERS.size()];
+        values[0] = workKey;
+        values[1] = summary;
+        values[2] = summary + " description";
+        values[3] = summary + " precondition";
+        values[4] = status;
+        values[5] = "High";
+        values[6] = "Alice";
+        values[7] = "Bob";
+        values[8] = "5m";
+        values[9] = "auth";
+        values[10] = components;
+        values[11] = "Sprint 1";
+        values[12] = "1.0";
+        values[13] = stepSummary;
+        values[14] = testData;
+        values[15] = expectedResult;
+        values[16] = "V1";
+        values[17] = "Folder/A";
+        values[18] = "Regression";
+        values[19] = "creator@example.com";
+        values[20] = "2026-03-01";
+        values[21] = "editor@example.com";
+        values[22] = "2026-03-02";
+        values[23] = "ST-1";
+        values[24] = "No";
+        values[25] = "1";
+        return values;
+    }
+
+    private String[] rowWithDetails(String workKey,
+                                    String summary,
+                                    String description,
+                                    String precondition,
+                                    String status,
+                                    String components,
+                                    String stepSummary,
+                                    String testData,
+                                    String expectedResult) {
+        String[] values = row(workKey, summary, status, components, stepSummary, testData, expectedResult);
+        values[2] = description;
+        values[3] = precondition;
+        return values;
+    }
+
+    private String[] blankRow() {
+        return new String[ExcelParserService.CANONICAL_HEADERS.size()];
+    }
+}


### PR DESCRIPTION
- added exact duplicate file detection using file hash
- added handling for changed vs unchanged duplicate testcases
- added review session and merge/skip flow for duplicates
- added upload review page and supporting backend logic
- added merge editor layout matching the workspace testcase editor more closely
- added detected-difference filtering/count behavior based on the editable review fields
- added workspace upload feedback for review-required imports
- added integration tests for exact duplicate blocking, merge flow, and unchanged re-upload behavior