### PR TITLE
Feat/14 api endpoint for bulk testcase move

### DIFF
--- a/src/main/java/com/formswim/teststream/etl/controller/TestCaseController.java
+++ b/src/main/java/com/formswim/teststream/etl/controller/TestCaseController.java
@@ -11,6 +11,7 @@ import com.formswim.teststream.etl.model.TestCase;
 import com.formswim.teststream.etl.repository.TestCaseRepository;
 import jakarta.validation.Valid;
 import com.formswim.teststream.etl.service.ExcelExportService;
+import com.formswim.teststream.etl.service.TestCaseBulkMoveService;
 import com.formswim.teststream.etl.service.TestIngestionService;
 import com.formswim.teststream.etl.service.UploadReviewService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -45,17 +46,20 @@ public class TestCaseController {
 
     private final TestCaseRepository testCaseRepository;
     private final ExcelExportService excelExportService;
+    private final TestCaseBulkMoveService testCaseBulkMoveService;
     private final TestIngestionService testIngestionService;
     private final UploadReviewService uploadReviewService;
     private final UserRepository userRepository;
 
     public TestCaseController(TestCaseRepository testCaseRepository,
                               ExcelExportService excelExportService,
+                              TestCaseBulkMoveService testCaseBulkMoveService,
                               TestIngestionService testIngestionService,
                               UploadReviewService uploadReviewService,
                               UserRepository userRepository) {
         this.testCaseRepository = testCaseRepository;
         this.excelExportService = excelExportService;
+        this.testCaseBulkMoveService = testCaseBulkMoveService;
         this.testIngestionService = testIngestionService;
         this.uploadReviewService = uploadReviewService;
         this.userRepository = userRepository;
@@ -300,10 +304,8 @@ public class TestCaseController {
             return ResponseEntity.badRequest().build();
         }
 
-        // Currently not implemented
-        int requestedCount = request.getWorkKeys() == null ? 0 : request.getWorkKeys().size();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-            .body(BulkMoveResult.phaseOneNotImplemented(requestedCount));
+        BulkMoveResult result = testCaseBulkMoveService.bulkMoveByWorkKeys(user.getTeamKey(), request);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/com/formswim/teststream/etl/controller/TestCaseController.java
+++ b/src/main/java/com/formswim/teststream/etl/controller/TestCaseController.java
@@ -2,11 +2,14 @@ package com.formswim.teststream.etl.controller;
 
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.etl.dto.BulkMoveRequest;
+import com.formswim.teststream.etl.dto.BulkMoveResult;
 import com.formswim.teststream.etl.dto.EtlResultSummary;
 import com.formswim.teststream.etl.dto.ReviewApplyResult;
 import com.formswim.teststream.etl.dto.UploadReviewSessionView;
 import com.formswim.teststream.etl.model.TestCase;
 import com.formswim.teststream.etl.repository.TestCaseRepository;
+import jakarta.validation.Valid;
 import com.formswim.teststream.etl.service.ExcelExportService;
 import com.formswim.teststream.etl.service.TestIngestionService;
 import com.formswim.teststream.etl.service.UploadReviewService;
@@ -19,9 +22,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
@@ -265,6 +270,40 @@ public class TestCaseController {
         }
         EtlResultSummary result = testIngestionService.ingestFile(file, user.getTeamKey());
         return ResponseEntity.ok(result);
+    }
+    /**
+     * PATCH /api/testcases/bulk-move
+     * Endpoint accepts a list of test case work keys and a target folder
+     * and moves the specified test cases to the target folder, returning a summary of the results.
+     * @param request
+     * @param session
+     * @param authentication
+     * @return a summary of the bulk move results, including counts of moved, forbidden, not found, and any failures with reasons.
+     */
+    @PatchMapping("/api/testcases/bulk-move")
+    @ResponseBody
+    public ResponseEntity<BulkMoveResult> apiBulkMoveTestCases(@Valid @RequestBody BulkMoveRequest request,
+                                                               HttpSession session,
+                                                               Authentication authentication) {
+        Optional<AppUser> currentUser = resolveCurrentUser(session, authentication);
+        if (currentUser.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        AppUser user = currentUser.get();
+        if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        String targetFolder = request.getTargetFolder() == null ? "" : request.getTargetFolder().trim();
+        if (targetFolder.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        // Currently not implemented
+        int requestedCount = request.getWorkKeys() == null ? 0 : request.getWorkKeys().size();
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
+            .body(BulkMoveResult.phaseOneNotImplemented(requestedCount));
     }
 
     /**

--- a/src/main/java/com/formswim/teststream/etl/dto/BulkMoveRequest.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/BulkMoveRequest.java
@@ -1,0 +1,35 @@
+package com.formswim.teststream.etl.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BulkMoveRequest {
+
+    @NotNull(message = "workKeys is required")
+    private List<String> workKeys = new ArrayList<>();
+
+    @NotBlank(message = "targetFolder is required")
+    private String targetFolder;
+
+    public List<String> getWorkKeys() {
+        if (workKeys == null) {
+            workKeys = new ArrayList<>();
+        }
+        return workKeys;
+    }
+
+    public void setWorkKeys(List<String> workKeys) {
+        this.workKeys = workKeys == null ? new ArrayList<>() : new ArrayList<>(workKeys);
+    }
+
+    public String getTargetFolder() {
+        return targetFolder;
+    }
+
+    public void setTargetFolder(String targetFolder) {
+        this.targetFolder = targetFolder;
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/dto/BulkMoveResult.java
+++ b/src/main/java/com/formswim/teststream/etl/dto/BulkMoveResult.java
@@ -1,0 +1,101 @@
+package com.formswim.teststream.etl.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BulkMoveResult {
+
+    private int requestedCount;
+    private int movedCount;
+    private int invalidCount;
+    private int forbiddenCount;
+    private int notFoundCount;
+    private List<BulkMoveFailure> failures = new ArrayList<>();
+
+    public int getRequestedCount() {
+        return requestedCount;
+    }
+
+    public void setRequestedCount(int requestedCount) {
+        this.requestedCount = requestedCount;
+    }
+
+    public int getMovedCount() {
+        return movedCount;
+    }
+
+    public void setMovedCount(int movedCount) {
+        this.movedCount = movedCount;
+    }
+
+    public int getInvalidCount() {
+        return invalidCount;
+    }
+
+    public void setInvalidCount(int invalidCount) {
+        this.invalidCount = invalidCount;
+    }
+
+    public int getForbiddenCount() {
+        return forbiddenCount;
+    }
+
+    public void setForbiddenCount(int forbiddenCount) {
+        this.forbiddenCount = forbiddenCount;
+    }
+
+    public int getNotFoundCount() {
+        return notFoundCount;
+    }
+
+    public void setNotFoundCount(int notFoundCount) {
+        this.notFoundCount = notFoundCount;
+    }
+
+    public List<BulkMoveFailure> getFailures() {
+        if (failures == null) {
+            failures = new ArrayList<>();
+        }
+        return failures;
+    }
+
+    public void setFailures(List<BulkMoveFailure> failures) {
+        this.failures = failures == null ? new ArrayList<>() : new ArrayList<>(failures);
+    }
+
+    public static BulkMoveResult phaseOneNotImplemented(int requestedCount) {
+        BulkMoveResult result = new BulkMoveResult();
+        result.setRequestedCount(requestedCount);
+        return result;
+    }
+
+    public static class BulkMoveFailure {
+
+        private String workKey;
+        private String reason;
+
+        public BulkMoveFailure() {
+        }
+
+        public BulkMoveFailure(String workKey, String reason) {
+            this.workKey = workKey;
+            this.reason = reason;
+        }
+
+        public String getWorkKey() {
+            return workKey;
+        }
+
+        public void setWorkKey(String workKey) {
+            this.workKey = workKey;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+
+        public void setReason(String reason) {
+            this.reason = reason;
+        }
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/repository/TestCaseRepository.java
+++ b/src/main/java/com/formswim/teststream/etl/repository/TestCaseRepository.java
@@ -1,8 +1,10 @@
 package com.formswim.teststream.etl.repository;
 
 import com.formswim.teststream.etl.model.TestCase;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
@@ -14,6 +16,32 @@ public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
 
     @Query("select distinct testCase from TestCase testCase left join fetch testCase.steps where testCase.teamKey = :teamKey")
     List<TestCase> findAllWithStepsByTeamKey(String teamKey);
+
+    @Query("""
+            select testCase.workKey
+            from TestCase testCase
+            where testCase.teamKey = :teamKey
+              and testCase.workKey in :workKeys
+            """)
+    List<String> findOwnedWorkKeysIn(@Param("teamKey") String teamKey, @Param("workKeys") Collection<String> workKeys);
+
+    @Query("""
+            select distinct testCase.workKey
+            from TestCase testCase
+            where testCase.workKey in :workKeys
+            """)
+    List<String> findExistingWorkKeysIn(@Param("workKeys") Collection<String> workKeys);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update TestCase testCase
+            set testCase.folder = :targetFolder
+            where testCase.teamKey = :teamKey
+              and testCase.workKey in :workKeys
+            """)
+    int bulkMoveToFolderByTeamKeyAndWorkKeys(@Param("teamKey") String teamKey,
+                                             @Param("workKeys") Collection<String> workKeys,
+                                             @Param("targetFolder") String targetFolder);
 
     @Query("""
             select distinct testCase

--- a/src/main/java/com/formswim/teststream/etl/service/TestCaseBulkMoveService.java
+++ b/src/main/java/com/formswim/teststream/etl/service/TestCaseBulkMoveService.java
@@ -1,0 +1,90 @@
+package com.formswim.teststream.etl.service;
+
+import com.formswim.teststream.etl.dto.BulkMoveRequest;
+import com.formswim.teststream.etl.dto.BulkMoveResult;
+import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.repository.TestCaseRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+@Service
+public class TestCaseBulkMoveService {
+
+    private static final String FAILURE_INVALID = "INVALID_WORK_KEY";
+    private static final String FAILURE_FORBIDDEN = "FORBIDDEN";
+    private static final String FAILURE_NOT_FOUND = "NOT_FOUND";
+
+    private final TestCaseRepository testCaseRepository;
+
+    public TestCaseBulkMoveService(TestCaseRepository testCaseRepository) {
+        this.testCaseRepository = testCaseRepository;
+    }
+
+    @Transactional
+    public BulkMoveResult bulkMoveByWorkKeys(String teamKey, BulkMoveRequest request) {
+        BulkMoveResult result = new BulkMoveResult();
+        List<String> requestedWorkKeys = request.getWorkKeys();
+        result.setRequestedCount(requestedWorkKeys.size());
+
+        // Normalize incoming keys while preserving first-seen order for predictable response payloads.
+        LinkedHashSet<String> normalizedUniqueWorkKeys = new LinkedHashSet<>();
+        for (String rawWorkKey : requestedWorkKeys) {
+            if (rawWorkKey == null) {
+                addFailure(result, null, FAILURE_INVALID);
+                result.setInvalidCount(result.getInvalidCount() + 1);
+                continue;
+            }
+
+            String normalized = rawWorkKey.trim();
+            if (normalized.isBlank()) {
+                addFailure(result, rawWorkKey, FAILURE_INVALID);
+                result.setInvalidCount(result.getInvalidCount() + 1);
+                continue;
+            }
+            normalizedUniqueWorkKeys.add(normalized);
+        }
+
+        if (normalizedUniqueWorkKeys.isEmpty()) {
+            return result;
+        }
+
+        List<String> allowedWorkKeys = new ArrayList<>();
+        for (String workKey : normalizedUniqueWorkKeys) {
+            if (testCaseRepository.existsByTeamKeyAndWorkKey(teamKey, workKey)) {
+                allowedWorkKeys.add(workKey);
+                continue;
+            }
+
+            // Distinguish between cross-team keys and truly missing keys for frontend feedback.
+            boolean existsInAnotherTeam = testCaseRepository.countByWorkKeyIn(List.of(workKey)) > 0;
+            if (existsInAnotherTeam) {
+                addFailure(result, workKey, FAILURE_FORBIDDEN);
+                result.setForbiddenCount(result.getForbiddenCount() + 1);
+            } else {
+                addFailure(result, workKey, FAILURE_NOT_FOUND);
+                result.setNotFoundCount(result.getNotFoundCount() + 1);
+            }
+        }
+
+        if (allowedWorkKeys.isEmpty()) {
+            return result;
+        }
+
+        String trimmedTargetFolder = request.getTargetFolder().trim();
+        List<TestCase> testCasesToMove = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn(teamKey, allowedWorkKeys);
+        for (TestCase testCase : testCasesToMove) {
+            testCase.setFolder(trimmedTargetFolder);
+        }
+        testCaseRepository.saveAll(testCasesToMove);
+        result.setMovedCount(testCasesToMove.size());
+        return result;
+    }
+
+    private void addFailure(BulkMoveResult result, String workKey, String reason) {
+        result.getFailures().add(new BulkMoveResult.BulkMoveFailure(workKey, reason));
+    }
+}

--- a/src/main/java/com/formswim/teststream/etl/service/TestCaseBulkMoveService.java
+++ b/src/main/java/com/formswim/teststream/etl/service/TestCaseBulkMoveService.java
@@ -2,14 +2,15 @@ package com.formswim.teststream.etl.service;
 
 import com.formswim.teststream.etl.dto.BulkMoveRequest;
 import com.formswim.teststream.etl.dto.BulkMoveResult;
-import com.formswim.teststream.etl.model.TestCase;
 import com.formswim.teststream.etl.repository.TestCaseRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class TestCaseBulkMoveService {
@@ -52,16 +53,19 @@ public class TestCaseBulkMoveService {
             return result;
         }
 
+        List<String> normalizedWorkKeys = new ArrayList<>(normalizedUniqueWorkKeys);
+        Set<String> ownedWorkKeys = new HashSet<>(testCaseRepository.findOwnedWorkKeysIn(teamKey, normalizedWorkKeys));
+        Set<String> existingWorkKeys = new HashSet<>(testCaseRepository.findExistingWorkKeysIn(normalizedWorkKeys));
+
         List<String> allowedWorkKeys = new ArrayList<>();
-        for (String workKey : normalizedUniqueWorkKeys) {
-            if (testCaseRepository.existsByTeamKeyAndWorkKey(teamKey, workKey)) {
+        for (String workKey : normalizedWorkKeys) {
+            if (ownedWorkKeys.contains(workKey)) {
                 allowedWorkKeys.add(workKey);
                 continue;
             }
 
-            // Distinguish between cross-team keys and truly missing keys for frontend feedback.
-            boolean existsInAnotherTeam = testCaseRepository.countByWorkKeyIn(List.of(workKey)) > 0;
-            if (existsInAnotherTeam) {
+            // Classify each non-owned key for frontend feedback without per-key database calls.
+            if (existingWorkKeys.contains(workKey)) {
                 addFailure(result, workKey, FAILURE_FORBIDDEN);
                 result.setForbiddenCount(result.getForbiddenCount() + 1);
             } else {
@@ -75,12 +79,9 @@ public class TestCaseBulkMoveService {
         }
 
         String trimmedTargetFolder = request.getTargetFolder().trim();
-        List<TestCase> testCasesToMove = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn(teamKey, allowedWorkKeys);
-        for (TestCase testCase : testCasesToMove) {
-            testCase.setFolder(trimmedTargetFolder);
-        }
-        testCaseRepository.saveAll(testCasesToMove);
-        result.setMovedCount(testCasesToMove.size());
+        // Apply one scoped update statement for all eligible keys in this request.
+        int movedCount = testCaseRepository.bulkMoveToFolderByTeamKeyAndWorkKeys(teamKey, allowedWorkKeys, trimmedTargetFolder);
+        result.setMovedCount(movedCount);
         return result;
     }
 

--- a/src/test/java/com/formswim/teststream/BulkMoveIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/BulkMoveIntegrationTests.java
@@ -1,0 +1,151 @@
+package com.formswim.teststream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.support.TestCaseFixtures;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BulkMoveIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestCaseRepository testCaseRepository;
+
+    @BeforeEach
+    void setUp() {
+        testCaseRepository.deleteAll();
+        userRepository.deleteAll();
+
+        userRepository.save(new AppUser("team1.user@example.com", "test-hash", "TEAM1"));
+        userRepository.save(new AppUser("team2.user@example.com", "test-hash", "TEAM2"));
+        userRepository.save(new AppUser("noteam.user@example.com", "test-hash", "   "));
+
+        testCaseRepository.saveAll(List.of(
+            TestCaseFixtures.basicCase("TEAM1", "TC-101", "Payments/Core"),
+            TestCaseFixtures.basicCase("TEAM1", "TC-102", "Payments/Core"),
+            TestCaseFixtures.basicCase("TEAM2", "TC-201", "Auth/Login")
+        ));
+    }
+
+    @Test
+    void bulkMoveReturnsPartialSuccessAndMovesOnlyOwnedKeys() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101", "TC-201", "TC-999", "   ", "TC-101"));
+        payload.put("targetFolder", "QA/NewFolder");
+
+        mockMvc.perform(patch("/api/testcases/bulk-move")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.requestedCount").value(5))
+            .andExpect(jsonPath("$.movedCount").value(1))
+            .andExpect(jsonPath("$.invalidCount").value(1))
+            .andExpect(jsonPath("$.forbiddenCount").value(1))
+            .andExpect(jsonPath("$.notFoundCount").value(1))
+            .andExpect(jsonPath("$.failures.length()").value(3));
+
+        TestCase moved = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101").orElseThrow();
+        TestCase untouchedSameTeam = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-102").orElseThrow();
+        TestCase untouchedOtherTeam = testCaseRepository.findByTeamKeyAndWorkKey("TEAM2", "TC-201").orElseThrow();
+
+        assertThat(moved.getFolder()).isEqualTo("QA/NewFolder");
+        assertThat(untouchedSameTeam.getFolder()).isEqualTo("Payments/Core");
+        assertThat(untouchedOtherTeam.getFolder()).isEqualTo("Auth/Login");
+    }
+
+    @Test
+    void bulkEndpointSupportsSingleWorkKeyMove() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-102"));
+        payload.put("targetFolder", "QA/Single");
+
+        mockMvc.perform(patch("/api/testcases/bulk-move")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.requestedCount").value(1))
+            .andExpect(jsonPath("$.movedCount").value(1))
+            .andExpect(jsonPath("$.invalidCount").value(0))
+            .andExpect(jsonPath("$.forbiddenCount").value(0))
+            .andExpect(jsonPath("$.notFoundCount").value(0));
+
+        TestCase moved = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-102").orElseThrow();
+        assertThat(moved.getFolder()).isEqualTo("QA/Single");
+    }
+
+    @Test
+    void bulkMoveReturnsUnauthorizedWhenPrincipalHasNoUserRecord() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("targetFolder", "QA/NoUser");
+
+        mockMvc.perform(patch("/api/testcases/bulk-move")
+                .with(csrf())
+                .with(user("ghost.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void bulkMoveReturnsForbiddenWhenUserHasNoTeamKey() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("targetFolder", "QA/Forbidden");
+
+        mockMvc.perform(patch("/api/testcases/bulk-move")
+                .with(csrf())
+                .with(user("noteam.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void bulkMoveReturnsBadRequestWhenTargetFolderIsBlankAfterTrim() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("targetFolder", "   ");
+
+        mockMvc.perform(patch("/api/testcases/bulk-move")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
+++ b/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
@@ -2,8 +2,8 @@ package com.formswim.teststream;
 
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
-import com.formswim.teststream.etl.model.TestCase;
 import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.support.TestCaseFixtures;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -42,11 +42,11 @@ class TeststreamApplicationTests {
 		userRepository.save(new AppUser("team2.user@example.com", "test-hash", "TEAM2"));
 
 		testCaseRepository.saveAll(List.of(
-				testCase("TEAM1", "TC-101", "Payments/Core"),
-				testCase("TEAM1", "TC-102", "Payments/Core"),
-				testCase("TEAM1", "TC-103", "Billing/Refunds"),
-				testCase("TEAM2", "TC-201", "Auth/Login"),
-				testCase("TEAM2", "TC-202", "Auth/Signup")
+				TestCaseFixtures.basicCase("TEAM1", "TC-101", "Payments/Core"),
+				TestCaseFixtures.basicCase("TEAM1", "TC-102", "Payments/Core"),
+				TestCaseFixtures.basicCase("TEAM1", "TC-103", "Billing/Refunds"),
+				TestCaseFixtures.basicCase("TEAM2", "TC-201", "Auth/Login"),
+				TestCaseFixtures.basicCase("TEAM2", "TC-202", "Auth/Signup")
 		));
 	}
 
@@ -72,13 +72,13 @@ class TeststreamApplicationTests {
 	void getFoldersReturnsCleanSortedCaseSensitiveWhitespaceNormalizedArray() throws Exception {
 		testCaseRepository.deleteAll();
 		testCaseRepository.saveAll(List.of(
-				testCase("TEAM1", "TC-301", " UI "),
-				testCase("TEAM1", "TC-302", "UI"),
-				testCase("TEAM1", "TC-303", "ui"),
-				testCase("TEAM1", "TC-304", "Billing"),
-				testCase("TEAM1", "TC-305", ""),
-				testCase("TEAM1", "TC-306", "   "),
-				testCase("TEAM1", "TC-307", null)
+				TestCaseFixtures.basicCase("TEAM1", "TC-301", " UI "),
+				TestCaseFixtures.basicCase("TEAM1", "TC-302", "UI"),
+				TestCaseFixtures.basicCase("TEAM1", "TC-303", "ui"),
+				TestCaseFixtures.basicCase("TEAM1", "TC-304", "Billing"),
+				TestCaseFixtures.basicCase("TEAM1", "TC-305", ""),
+				TestCaseFixtures.basicCase("TEAM1", "TC-306", "   "),
+				TestCaseFixtures.basicCase("TEAM1", "TC-307", null)
 		));
 
 		mockMvc.perform(get("/api/folders")
@@ -88,35 +88,6 @@ class TeststreamApplicationTests {
 				.andExpect(jsonPath("$[0]").value("Billing"))
 				.andExpect(jsonPath("$[1]").value("UI"))
 				.andExpect(jsonPath("$[2]").value("ui"));
-	}
-
-	private TestCase testCase(String teamKey, String workKey, String folder) {
-		return new TestCase(
-				teamKey,
-				workKey,
-				"Summary " + workKey,
-				"Description",
-				"Precondition",
-				"Draft",
-				"Medium",
-				"Assignee",
-				"Reporter",
-				"5m",
-				"label",
-				"component",
-				"Sprint 1",
-				"1.0",
-				"V1",
-				folder,
-				"Regression",
-				"creator@example.com",
-				"2026-03-18",
-				"editor@example.com",
-				"2026-03-18",
-				"ST-1",
-				"No",
-				"0"
-		);
 	}
 
 }

--- a/src/test/java/com/formswim/teststream/UploadReviewIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/UploadReviewIntegrationTests.java
@@ -12,6 +12,7 @@ import com.formswim.teststream.etl.repository.TestCaseRepository;
 import com.formswim.teststream.etl.repository.UploadHistoryRepository;
 import com.formswim.teststream.etl.repository.UploadReviewSessionRepository;
 import com.formswim.teststream.etl.service.ExcelParserService;
+import com.formswim.teststream.support.TestCaseFixtures;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.BeforeEach;
@@ -126,7 +127,15 @@ class UploadReviewIntegrationTests {
 
     @Test
     void changedDuplicateCreatesReviewSessionAndApplyMergesIt() throws Exception {
-        TestCase existing = existingCase("TC-101", "Original summary", "Original description", "Original precondition");
+        TestCase existing = TestCaseFixtures.detailedCase(
+            "TEAM1",
+            "TC-101",
+            "Original summary",
+            "Original description",
+            "Original precondition",
+            "Auth/Login"
+        );
+        existing.addStep(new TestStep(1, "Open login page", "", "Login form shows"));
         testCaseRepository.save(existing);
 
         MockMultipartFile upload = new MockMultipartFile(
@@ -337,37 +346,6 @@ class UploadReviewIntegrationTests {
         assertThat(thirdResult.getDuplicateChangedCount()).isEqualTo(0);
         assertThat(thirdResult.getDuplicateUnchangedCount()).isEqualTo(1);
         assertThat(testCaseRepository.countByTeamKey("TEAM1")).isEqualTo(1);
-    }
-
-    private TestCase existingCase(String workKey, String summary, String description, String precondition) {
-        TestCase testCase = new TestCase(
-            "TEAM1",
-            workKey,
-            summary,
-            description,
-            precondition,
-            "Draft",
-            "High",
-            "Alice",
-            "Bob",
-            "5m",
-            "auth",
-            "UI",
-            "Sprint 1",
-            "1.0",
-            "V1",
-            "Auth/Login",
-            "Regression",
-            "creator@example.com",
-            "2026-03-01",
-            "editor@example.com",
-            "2026-03-02",
-            "ST-1",
-            "No",
-            "1"
-        );
-        testCase.addStep(new TestStep(1, "Open login page", "", "Login form shows"));
-        return testCase;
     }
 
     private byte[] workbookBytes(String[]... rows) throws Exception {

--- a/src/test/java/com/formswim/teststream/support/TestCaseFixtures.java
+++ b/src/test/java/com/formswim/teststream/support/TestCaseFixtures.java
@@ -1,0 +1,72 @@
+package com.formswim.teststream.support;
+
+import com.formswim.teststream.etl.model.TestCase;
+
+public final class TestCaseFixtures {
+
+    private TestCaseFixtures() {
+    }
+
+    public static TestCase basicCase(String teamKey, String workKey, String folder) {
+        return new TestCase(
+            teamKey,
+            workKey,
+            "Summary " + workKey,
+            "Description",
+            "Precondition",
+            "Draft",
+            "Medium",
+            "Assignee",
+            "Reporter",
+            "5m",
+            "label",
+            "component",
+            "Sprint 1",
+            "1.0",
+            "V1",
+            folder,
+            "Regression",
+            "creator@example.com",
+            "2026-03-18",
+            "editor@example.com",
+            "2026-03-18",
+            "ST-1",
+            "No",
+            "0"
+        );
+    }
+
+    public static TestCase detailedCase(String teamKey,
+                                        String workKey,
+                                        String summary,
+                                        String description,
+                                        String precondition,
+                                        String folder) {
+        return new TestCase(
+            teamKey,
+            workKey,
+            summary,
+            description,
+            precondition,
+            "Draft",
+            "High",
+            "Alice",
+            "Bob",
+            "5m",
+            "auth",
+            "UI",
+            "Sprint 1",
+            "1.0",
+            "V1",
+            folder,
+            "Regression",
+            "creator@example.com",
+            "2026-03-01",
+            "editor@example.com",
+            "2026-03-02",
+            "ST-1",
+            "No",
+            "1"
+        );
+    }
+}


### PR DESCRIPTION
Finished #14, created the dto for the bulk edits, ensuring that all testcases exists and the requesting user has the correct team key. Partial success ensures that regardless testcases are moved. Test is in place with repository have new `@Modifiying` query to the database. 

Currently this can be used to move single testcase by testkey as well.