### PR TITLE
IP-based throttles (login + team code) + team code join/create + copy UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
         DB_URL: jdbc:postgresql://localhost:5432/testdb
         DB_USERNAME: testuser
         DB_PASSWORD: testpassword
+        # test profile reads TEST_DB_* (keeps local tests from accidentally using DB_URL)
+        TEST_DB_URL: jdbc:postgresql://localhost:5432/testdb
+        TEST_DB_USERNAME: testuser
+        TEST_DB_PASSWORD: testpassword
+        TEST_DB_DRIVER: org.postgresql.Driver
       run: ./mvnw clean test -B --no-transfer-progress -Dspring.profiles.active=test
     - name: Upload Test Reports
       # This ensures the reports upload even if the previous test step fails

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ build/
 ### VS Code ###
 .vscode/
 .env
+
+### JVM crash logs ###
+hs_err_pid*.log
+replay_pid*.log

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-h2console</artifactId>
 		</dependency>

--- a/src/main/java/com/formswim/teststream/auth/config/FlashMessageSupport.java
+++ b/src/main/java/com/formswim/teststream/auth/config/FlashMessageSupport.java
@@ -1,12 +1,13 @@
 package com.formswim.teststream.auth.config;
 
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.FlashMap;
+import org.springframework.web.servlet.FlashMapManager;
+import org.springframework.web.servlet.support.RequestContextUtils;
+import org.springframework.web.servlet.support.SessionFlashMapManager;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.web.servlet.FlashMapManager;
-import org.springframework.web.servlet.support.SessionFlashMapManager;
-import org.springframework.web.servlet.FlashMap;
-import org.springframework.web.servlet.DispatcherServlet;
-import org.springframework.web.servlet.support.RequestContextUtils;
 
 final class FlashMessageSupport {
 

--- a/src/main/java/com/formswim/teststream/auth/config/FlashMessageSupport.java
+++ b/src/main/java/com/formswim/teststream/auth/config/FlashMessageSupport.java
@@ -1,0 +1,53 @@
+package com.formswim.teststream.auth.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.FlashMapManager;
+import org.springframework.web.servlet.support.SessionFlashMapManager;
+import org.springframework.web.servlet.FlashMap;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.support.RequestContextUtils;
+
+final class FlashMessageSupport {
+
+    private FlashMessageSupport() {
+    }
+
+    static void addFlashMessage(HttpServletRequest request,
+                                HttpServletResponse response,
+                                String attributeName,
+                                String attributeValue) {
+        String targetPath = request == null ? null : request.getRequestURI();
+        addFlashMessage(request, response, attributeName, attributeValue, targetPath);
+    }
+
+    static void addFlashMessage(HttpServletRequest request,
+                                HttpServletResponse response,
+                                String attributeName,
+                                String attributeValue,
+                                String targetPath) {
+        FlashMap flashMap = RequestContextUtils.getOutputFlashMap(request);
+        if (flashMap == null) {
+            flashMap = new FlashMap();
+            if (request != null) {
+                request.setAttribute(DispatcherServlet.OUTPUT_FLASH_MAP_ATTRIBUTE, flashMap);
+            }
+        }
+
+        if (targetPath != null && !targetPath.isBlank()) {
+            flashMap.setTargetRequestPath(targetPath);
+        }
+
+        flashMap.put(attributeName, attributeValue);
+
+        FlashMapManager flashMapManager = RequestContextUtils.getFlashMapManager(request);
+        if (flashMapManager == null) {
+            flashMapManager = new SessionFlashMapManager();
+            if (request != null) {
+                request.setAttribute(DispatcherServlet.FLASH_MAP_MANAGER_ATTRIBUTE, flashMapManager);
+            }
+        }
+
+        flashMapManager.saveOutputFlashMap(flashMap, request, response);
+    }
+}

--- a/src/main/java/com/formswim/teststream/auth/config/LoginRateLimitFilter.java
+++ b/src/main/java/com/formswim/teststream/auth/config/LoginRateLimitFilter.java
@@ -1,14 +1,16 @@
 package com.formswim.teststream.auth.config;
 
+import java.io.IOException;
+import java.time.Duration;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.formswim.teststream.auth.service.LoginThrottleService;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.time.Duration;
 
 final class LoginRateLimitFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/formswim/teststream/auth/config/LoginRateLimitFilter.java
+++ b/src/main/java/com/formswim/teststream/auth/config/LoginRateLimitFilter.java
@@ -1,0 +1,77 @@
+package com.formswim.teststream.auth.config;
+
+import com.formswim.teststream.auth.service.LoginThrottleService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+
+final class LoginRateLimitFilter extends OncePerRequestFilter {
+
+    private final LoginThrottleService loginThrottleService;
+
+    LoginRateLimitFilter(LoginThrottleService loginThrottleService) {
+        this.loginThrottleService = loginThrottleService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (!isLoginPost(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String clientIp = getClientIp(request);
+        loginThrottleService.recordAttempt(clientIp);
+
+        if (loginThrottleService.isBlocked(clientIp)) {
+            Duration remaining = loginThrottleService.getRemainingBlockDuration(clientIp);
+            long minutes = Math.max(1, (remaining.toSeconds() + 59) / 60);
+
+            FlashMessageSupport.addFlashMessage(
+                request,
+                response,
+                "errorMessage",
+                "Too many attempts. Please try again in " + minutes + " minutes.",
+                "/login"
+            );
+            response.sendRedirect(request.getContextPath() + "/login");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isLoginPost(HttpServletRequest request) {
+        if (request == null) {
+            return false;
+        }
+
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return false;
+        }
+
+        String contextPath = request.getContextPath();
+        String requestUri = request.getRequestURI();
+        if (requestUri == null) {
+            return false;
+        }
+
+        String expected = (contextPath == null ? "" : contextPath) + "/login";
+        return expected.equals(requestUri) || "/login".equals(request.getServletPath());
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        if (request == null) {
+            return "";
+        }
+        String remote = request.getRemoteAddr();
+        return remote == null ? "" : remote;
+    }
+}

--- a/src/main/java/com/formswim/teststream/auth/config/SecurityConfig.java
+++ b/src/main/java/com/formswim/teststream/auth/config/SecurityConfig.java
@@ -2,8 +2,6 @@ package com.formswim.teststream.auth.config;
 
 import com.formswim.teststream.auth.service.AppUserDetailsService;
 import com.formswim.teststream.auth.service.LoginThrottleService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,8 +11,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
-import org.springframework.web.servlet.FlashMap;
-import org.springframework.web.servlet.support.RequestContextUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 
 @Configuration
@@ -81,13 +79,20 @@ public class SecurityConfig {
                 .referrerPolicy(referrerPolicy -> referrerPolicy.policy(org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
             );
 
+        http.addFilterAfter(loginRateLimitFilter(), org.springframework.security.web.csrf.CsrfFilter.class);
+
         return http.build();
+    }
+
+    @Bean
+    LoginRateLimitFilter loginRateLimitFilter() {
+        return new LoginRateLimitFilter(loginThrottleService);
     }
 
     @Bean
     public AuthenticationSuccessHandler authenticationSuccessHandler() {
         return (request, response, authentication) -> {
-            loginThrottleService.resetFailures(authentication.getName());
+            loginThrottleService.resetFailures(getClientIp(request));
             response.sendRedirect(request.getContextPath() + "/workspace");
         };
     }
@@ -97,10 +102,10 @@ public class SecurityConfig {
         return (request, response, exception) -> {
             if (!(exception instanceof org.springframework.security.authentication.LockedException)
                 && !(exception instanceof org.springframework.security.authentication.DisabledException)) {
-                loginThrottleService.recordFailure(request.getParameter("email"));
+                loginThrottleService.recordFailure(getClientIp(request));
             }
 
-            addFlashMessage(request, response, "errorMessage", GENERIC_LOGIN_ERROR);
+            FlashMessageSupport.addFlashMessage(request, response, "errorMessage", GENERIC_LOGIN_ERROR, "/login");
             response.sendRedirect(request.getContextPath() + "/login");
         };
     }
@@ -108,24 +113,17 @@ public class SecurityConfig {
     @Bean
     public LogoutSuccessHandler logoutSuccessHandler() {
         return (request, response, authentication) -> {
-            addFlashMessage(request, response, "logoutMessage", "You have been logged out");
+            FlashMessageSupport.addFlashMessage(request, response, "logoutMessage", "You have been logged out", "/login");
             response.sendRedirect(request.getContextPath() + "/login");
         };
     }
 
-    private void addFlashMessage(HttpServletRequest request,
-                                 HttpServletResponse response,
-                                 String attributeName,
-                                 String attributeValue) {
-        FlashMap flashMap = RequestContextUtils.getOutputFlashMap(request);
-        var flashMapManager = RequestContextUtils.getFlashMapManager(request);
-
-        if (flashMap != null && flashMapManager != null) {
-            flashMap.put(attributeName, attributeValue);
-            flashMapManager.saveOutputFlashMap(flashMap, request, response);
-            return;
+    private String getClientIp(HttpServletRequest request) {
+        if (request == null) {
+            return "";
         }
-
-        request.getSession(true).setAttribute(attributeName, attributeValue);
+        // With server.forward-headers-strategy=framework, getRemoteAddr() reflects the real client when behind a proxy.
+        String remote = request.getRemoteAddr();
+        return remote == null ? "" : remote;
     }
 }

--- a/src/main/java/com/formswim/teststream/auth/config/SecurityConfig.java
+++ b/src/main/java/com/formswim/teststream/auth/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.formswim.teststream.auth.config;
 
-import com.formswim.teststream.auth.service.AppUserDetailsService;
-import com.formswim.teststream.auth.service.LoginThrottleService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,6 +9,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+import com.formswim.teststream.auth.service.AppUserDetailsService;
+import com.formswim.teststream.auth.service.LoginThrottleService;
 
 import jakarta.servlet.http.HttpServletRequest;
 

--- a/src/main/java/com/formswim/teststream/auth/config/SecurityConfig.java
+++ b/src/main/java/com/formswim/teststream/auth/config/SecurityConfig.java
@@ -101,10 +101,7 @@ public class SecurityConfig {
     @Bean
     public AuthenticationFailureHandler authenticationFailureHandler() {
         return (request, response, exception) -> {
-            if (!(exception instanceof org.springframework.security.authentication.LockedException)
-                && !(exception instanceof org.springframework.security.authentication.DisabledException)) {
-                loginThrottleService.recordFailure(getClientIp(request));
-            }
+            loginThrottleService.recordFailure(getClientIp(request));
 
             FlashMessageSupport.addFlashMessage(request, response, "errorMessage", GENERIC_LOGIN_ERROR, "/login");
             response.sendRedirect(request.getContextPath() + "/login");

--- a/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
+++ b/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
@@ -1,24 +1,33 @@
 package com.formswim.teststream.auth.controller;
 
-import com.formswim.teststream.auth.dto.RegistrationForm;
-import com.formswim.teststream.auth.model.AppUser;
-import com.formswim.teststream.auth.repository.UserRepository;
-import jakarta.servlet.http.HttpSession;
-import jakarta.validation.Valid;
-import org.springframework.stereotype.Controller;
-import org.springframework.validation.BindingResult;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-
+import java.security.SecureRandom;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.formswim.teststream.auth.dto.RegistrationForm;
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+
 @Controller
 public class AuthController {
+
+    private static final int GENERATED_TEAM_CODE_LENGTH = 16;
+    private static final String TEAM_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final SecureRandom TEAM_CODE_RANDOM = new SecureRandom();
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -78,6 +87,18 @@ public class AuthController {
             fieldErrors.putIfAbsent("email", "An account with that email already exists");
         }
 
+        String normalizedTeamCode = normalizeTeamCode(registrationForm.getTeamCode());
+        boolean generatedTeam = false;
+        if (normalizedTeamCode == null || normalizedTeamCode.isBlank()) {
+            normalizedTeamCode = generateUniqueTeamCode();
+            generatedTeam = true;
+        } else {
+            // A team "exists" if any user is already assigned that team key.
+            if (!userRepository.existsByTeamKeyIgnoreCase(normalizedTeamCode)) {
+                fieldErrors.putIfAbsent("teamCode", "Team code not found. Leave blank to create a new team.");
+            }
+        }
+
         if (!fieldErrors.isEmpty()) {
             redirectAttributes.addFlashAttribute("errorMessage", "Please correct the highlighted fields.");
             redirectAttributes.addFlashAttribute("fieldErrors", fieldErrors);
@@ -87,11 +108,47 @@ public class AuthController {
         }
 
         String hashedPassword = passwordEncoder.encode(registrationForm.getPassword());
-        AppUser user = new AppUser(normalizedEmail, hashedPassword, registrationForm.getTeamCode());
+        AppUser user = new AppUser(normalizedEmail, hashedPassword, normalizedTeamCode);
         userRepository.save(user);
 
-        redirectAttributes.addFlashAttribute("successMessage", "Account created successfully. Sign in to continue.");
+        if (generatedTeam) {
+            redirectAttributes.addFlashAttribute("generatedTeamCode", normalizedTeamCode);
+            redirectAttributes.addFlashAttribute("successMessage", "Account created successfully. Sign in to continue.");
+        } else {
+            redirectAttributes.addFlashAttribute("successMessage", "Account created successfully. Sign in to continue.");
+        }
         return "redirect:/login";
+    }
+
+    private String normalizeTeamCode(String rawTeamCode) {
+        if (rawTeamCode == null) {
+            return null;
+        }
+        String trimmed = rawTeamCode.trim();
+        if (trimmed.isBlank()) {
+            return "";
+        }
+        return trimmed.toUpperCase();
+    }
+
+    private String generateUniqueTeamCode() {
+        for (int attempt = 0; attempt < 100; attempt++) {
+            String candidate = generateTeamCode();
+            if (!userRepository.existsByTeamKeyIgnoreCase(candidate)) {
+                return candidate;
+            }
+        }
+        // Extremely unlikely unless the code space is exhausted.
+        throw new IllegalStateException("Unable to generate a unique team code");
+    }
+
+    private String generateTeamCode() {
+        StringBuilder builder = new StringBuilder(GENERATED_TEAM_CODE_LENGTH);
+        for (int i = 0; i < GENERATED_TEAM_CODE_LENGTH; i++) {
+            int index = TEAM_CODE_RANDOM.nextInt(TEAM_CODE_ALPHABET.length());
+            builder.append(TEAM_CODE_ALPHABET.charAt(index));
+        }
+        return builder.toString();
     }
     private boolean isAuthenticated(Authentication authentication) {
         return authentication != null

--- a/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
+++ b/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
@@ -93,6 +93,14 @@ public class AuthController {
             fieldErrors.putIfAbsent("email", "An account with that email already exists");
         }
 
+        if (!fieldErrors.isEmpty()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Please correct the highlighted fields.");
+            redirectAttributes.addFlashAttribute("fieldErrors", fieldErrors);
+            redirectAttributes.addFlashAttribute("email", registrationForm.getEmail());
+            redirectAttributes.addFlashAttribute("teamCode", registrationForm.getTeamCode());
+            return "redirect:/register";
+        }
+
         String normalizedTeamCode = normalizeTeamCode(registrationForm.getTeamCode());
         boolean generatedTeam = false;
         if (normalizedTeamCode == null || normalizedTeamCode.isBlank()) {
@@ -128,10 +136,9 @@ public class AuthController {
 
         if (generatedTeam) {
             redirectAttributes.addFlashAttribute("generatedTeamCode", normalizedTeamCode);
-            redirectAttributes.addFlashAttribute("successMessage", "Account created successfully. Sign in to continue.");
-        } else {
-            redirectAttributes.addFlashAttribute("successMessage", "Account created successfully. Sign in to continue.");
         }
+
+        redirectAttributes.addFlashAttribute("successMessage", "Account created successfully. Sign in to continue.");
         return "redirect:/login";
     }
 

--- a/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
+++ b/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.formswim.teststream.auth.controller;
 
 import java.security.SecureRandom;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -142,7 +143,7 @@ public class AuthController {
         if (trimmed.isBlank()) {
             return "";
         }
-        return trimmed.toUpperCase();
+        return trimmed.toUpperCase(Locale.ROOT);
     }
 
     private String getClientIp(HttpServletRequest request) {

--- a/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
+++ b/src/main/java/com/formswim/teststream/auth/controller/AuthController.java
@@ -18,7 +18,9 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import com.formswim.teststream.auth.dto.RegistrationForm;
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.auth.service.TeamCodeThrottleService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 
@@ -31,10 +33,12 @@ public class AuthController {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TeamCodeThrottleService teamCodeThrottleService;
 
-    public AuthController(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public AuthController(UserRepository userRepository, PasswordEncoder passwordEncoder, TeamCodeThrottleService teamCodeThrottleService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.teamCodeThrottleService = teamCodeThrottleService;
     }
 
     // Shows landing page
@@ -68,7 +72,8 @@ public class AuthController {
     @PostMapping("/register")
     public String register(@Valid @ModelAttribute RegistrationForm registrationForm,
                            BindingResult bindingResult,
-                           RedirectAttributes redirectAttributes) {
+                           RedirectAttributes redirectAttributes,
+                           HttpServletRequest request) {
         String normalizedEmail = AppUser.normalizeEmail(registrationForm.getEmail());
         Map<String, String> fieldErrors = new LinkedHashMap<>();
 
@@ -93,9 +98,18 @@ public class AuthController {
             normalizedTeamCode = generateUniqueTeamCode();
             generatedTeam = true;
         } else {
+            String clientIp = getClientIp(request);
+            if (teamCodeThrottleService.isBlocked(clientIp)) {
+                redirectAttributes.addFlashAttribute("errorMessage", "Too many attempts. Please try again later.");
+                redirectAttributes.addFlashAttribute("email", registrationForm.getEmail());
+                redirectAttributes.addFlashAttribute("teamCode", registrationForm.getTeamCode());
+                return "redirect:/register";
+            }
+
             // A team "exists" if any user is already assigned that team key.
             if (!userRepository.existsByTeamKeyIgnoreCase(normalizedTeamCode)) {
                 fieldErrors.putIfAbsent("teamCode", "Team code not found. Leave blank to create a new team.");
+                teamCodeThrottleService.recordFailure(clientIp);
             }
         }
 
@@ -129,6 +143,17 @@ public class AuthController {
             return "";
         }
         return trimmed.toUpperCase();
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        if (request == null) {
+            return "";
+        }
+
+        // With server.forward-headers-strategy=framework, Spring will translate proxy headers
+        // (Forwarded / X-Forwarded-For) so getRemoteAddr() reflects the real client when behind a proxy.
+        String remote = request.getRemoteAddr();
+        return remote == null ? "" : remote;
     }
 
     private String generateUniqueTeamCode() {

--- a/src/main/java/com/formswim/teststream/auth/repository/UserRepository.java
+++ b/src/main/java/com/formswim/teststream/auth/repository/UserRepository.java
@@ -1,14 +1,17 @@
 package com.formswim.teststream.auth.repository;
 
-import com.formswim.teststream.auth.model.AppUser;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.formswim.teststream.auth.model.AppUser;
 
 @Repository
 public interface UserRepository extends JpaRepository<AppUser, Long> {
     Optional<AppUser> findByEmail(String email);
 
     Optional<AppUser> findByEmailIgnoreCase(String email);
+
+    boolean existsByTeamKeyIgnoreCase(String teamKey);
 }

--- a/src/main/java/com/formswim/teststream/auth/service/AppUserDetailsService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/AppUserDetailsService.java
@@ -3,7 +3,6 @@ package com.formswim.teststream.auth.service;
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
 import org.springframework.security.authentication.DisabledException;
-import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,20 +16,14 @@ import java.util.List;
 public class AppUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
-    private final LoginThrottleService loginThrottleService;
 
-    public AppUserDetailsService(UserRepository userRepository, LoginThrottleService loginThrottleService) {
+    public AppUserDetailsService(UserRepository userRepository) {
         this.userRepository = userRepository;
-        this.loginThrottleService = loginThrottleService;
     }
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         String normalizedEmail = AppUser.normalizeEmail(username);
-
-        if (loginThrottleService.isBlocked(normalizedEmail)) {
-            throw new LockedException("Invalid email or password");
-        }
 
         AppUser user = userRepository.findByEmailIgnoreCase(normalizedEmail)
             .orElseThrow(() -> new UsernameNotFoundException("Invalid email or password"));

--- a/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
@@ -1,8 +1,5 @@
 package com.formswim.teststream.auth.service;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -10,6 +7,9 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import org.springframework.stereotype.Service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 @Service
 public class LoginThrottleService {

--- a/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
@@ -1,12 +1,13 @@
 package com.formswim.teststream.auth.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Service;
 
@@ -18,7 +19,10 @@ public class LoginThrottleService {
     static final Duration INITIAL_BLOCK_DURATION = Duration.ofMinutes(15);
     static final Duration MAX_BLOCK_DURATION = Duration.ofHours(24);
 
-    private final Map<String, AttemptRecord> attempts = new ConcurrentHashMap<>();
+    private final Cache<String, AttemptRecord> attempts = Caffeine.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterWrite(WINDOW_DURATION)
+        .build();
     private final Clock clock;
 
     public LoginThrottleService() {
@@ -39,24 +43,18 @@ public class LoginThrottleService {
             return;
         }
 
-        attempts.compute(key, (ip, existing) -> {
-            Instant now = Instant.now(clock);
-            AttemptRecord record = existing;
-
-            if (record == null) {
-                record = new AttemptRecord();
-            }
-
+        Instant now = Instant.now(clock);
+        AttemptRecord record = attempts.get(key, ip -> new AttemptRecord());
+        synchronized (record) {
             pruneOldFailures(record, now);
 
             if (!isCurrentlyBlocked(record, now) && record.failures.isEmpty() && shouldReset(record, now)) {
-                return null;
+                attempts.invalidate(key);
+                return;
             }
 
             record.lastAttemptAt = now;
-
-            return record;
-        });
+        }
     }
 
     /** Records a failed login attempt for the given IP. */
@@ -66,20 +64,15 @@ public class LoginThrottleService {
             return;
         }
 
-        attempts.compute(key, (ip, existing) -> {
-            Instant now = Instant.now(clock);
-            AttemptRecord record = existing;
-
-            if (record == null) {
-                record = new AttemptRecord();
-            }
-
+        Instant now = Instant.now(clock);
+        AttemptRecord record = attempts.get(key, ip -> new AttemptRecord());
+        synchronized (record) {
             record.lastAttemptAt = now;
             pruneOldFailures(record, now);
 
             // If already blocked, don't extend the block on each request.
             if (isCurrentlyBlocked(record, now)) {
-                return record;
+                return;
             }
 
             record.failures.addLast(now);
@@ -96,9 +89,7 @@ public class LoginThrottleService {
                 record.currentBlockDuration = next;
                 record.blockExpiresAt = now.plus(next);
             }
-
-            return record;
-        });
+        }
     }
 
     /** Resets all throttling state for the IP, typically after a successful login. */
@@ -108,7 +99,7 @@ public class LoginThrottleService {
             return;
         }
 
-        attempts.remove(key);
+        attempts.invalidate(key);
     }
 
     public boolean isBlocked(String clientIp) {
@@ -117,24 +108,25 @@ public class LoginThrottleService {
             return false;
         }
 
-        AttemptRecord record = attempts.get(key);
+        AttemptRecord record = attempts.getIfPresent(key);
         if (record == null) {
             return false;
         }
 
         Instant now = Instant.now(clock);
+        synchronized (record) {
+            if (record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
+                record.blockExpiresAt = null;
+            }
 
-        if (record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
-            record.blockExpiresAt = null;
+            pruneOldFailures(record, now);
+            if (!isCurrentlyBlocked(record, now) && record.failures.isEmpty() && shouldReset(record, now)) {
+                attempts.invalidate(key);
+                return false;
+            }
+
+            return isCurrentlyBlocked(record, now);
         }
-
-        pruneOldFailures(record, now);
-        if (!isCurrentlyBlocked(record, now) && record.failures.isEmpty() && shouldReset(record, now)) {
-            attempts.remove(key);
-            return false;
-        }
-
-        return isCurrentlyBlocked(record, now);
     }
 
     public Duration getRemainingBlockDuration(String clientIp) {
@@ -143,17 +135,18 @@ public class LoginThrottleService {
             return Duration.ZERO;
         }
 
-        AttemptRecord record = attempts.get(key);
+        AttemptRecord record = attempts.getIfPresent(key);
         if (record == null || record.blockExpiresAt == null) {
             return Duration.ZERO;
         }
 
         Instant now = Instant.now(clock);
-        if (now.isAfter(record.blockExpiresAt)) {
-            return Duration.ZERO;
+        synchronized (record) {
+            if (record.blockExpiresAt == null || now.isAfter(record.blockExpiresAt)) {
+                return Duration.ZERO;
+            }
+            return Duration.between(now, record.blockExpiresAt);
         }
-
-        return Duration.between(now, record.blockExpiresAt);
     }
 
     private boolean shouldReset(AttemptRecord record, Instant now) {

--- a/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
@@ -1,11 +1,12 @@
 package com.formswim.teststream.auth.service;
 
-import com.formswim.teststream.auth.model.AppUser;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -13,7 +14,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class LoginThrottleService {
 
     static final int MAX_FAILURES = 5;
-    static final Duration BLOCK_DURATION = Duration.ofMinutes(15);
+    static final Duration WINDOW_DURATION = Duration.ofMinutes(30);
+    static final Duration INITIAL_BLOCK_DURATION = Duration.ofMinutes(15);
+    static final Duration MAX_BLOCK_DURATION = Duration.ofHours(24);
 
     private final Map<String, AttemptRecord> attempts = new ConcurrentHashMap<>();
     private final Clock clock;
@@ -26,60 +29,178 @@ public class LoginThrottleService {
         this.clock = clock;
     }
 
-    public void recordFailure(String email) {
-        String normalizedEmail = AppUser.normalizeEmail(email);
-        if (normalizedEmail == null || normalizedEmail.isBlank()) {
+    /**
+     * Records a login attempt (successful or not). Used to keep the rolling window "alive" so state
+     * only resets after {@link #WINDOW_DURATION} with no login posts from the IP.
+     */
+    public void recordAttempt(String clientIp) {
+        String key = normalizeClientIp(clientIp);
+        if (key == null) {
             return;
         }
 
-        attempts.compute(normalizedEmail, (key, existing) -> {
+        attempts.compute(key, (ip, existing) -> {
             Instant now = Instant.now(clock);
             AttemptRecord record = existing;
 
-            if (record == null || record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
+            if (record == null) {
                 record = new AttemptRecord();
             }
 
-            record.failureCount++;
-            if (record.failureCount >= MAX_FAILURES) {
-                record.blockExpiresAt = now.plus(BLOCK_DURATION);
+            pruneOldFailures(record, now);
+
+            if (!isCurrentlyBlocked(record, now) && record.failures.isEmpty() && shouldReset(record, now)) {
+                return null;
+            }
+
+            record.lastAttemptAt = now;
+
+            return record;
+        });
+    }
+
+    /** Records a failed login attempt for the given IP. */
+    public void recordFailure(String clientIp) {
+        String key = normalizeClientIp(clientIp);
+        if (key == null) {
+            return;
+        }
+
+        attempts.compute(key, (ip, existing) -> {
+            Instant now = Instant.now(clock);
+            AttemptRecord record = existing;
+
+            if (record == null) {
+                record = new AttemptRecord();
+            }
+
+            record.lastAttemptAt = now;
+            pruneOldFailures(record, now);
+
+            // If already blocked, don't extend the block on each request.
+            if (isCurrentlyBlocked(record, now)) {
+                return record;
+            }
+
+            record.failures.addLast(now);
+            pruneOldFailures(record, now);
+
+            if (record.failures.size() >= MAX_FAILURES) {
+                Duration next = record.currentBlockDuration == null
+                    ? INITIAL_BLOCK_DURATION
+                    : record.currentBlockDuration.multipliedBy(2);
+                if (next.compareTo(MAX_BLOCK_DURATION) > 0) {
+                    next = MAX_BLOCK_DURATION;
+                }
+
+                record.currentBlockDuration = next;
+                record.blockExpiresAt = now.plus(next);
             }
 
             return record;
         });
     }
 
-    public void resetFailures(String email) {
-        String normalizedEmail = AppUser.normalizeEmail(email);
-        if (normalizedEmail == null || normalizedEmail.isBlank()) {
+    /** Resets all throttling state for the IP, typically after a successful login. */
+    public void resetFailures(String clientIp) {
+        String key = normalizeClientIp(clientIp);
+        if (key == null) {
             return;
         }
 
-        attempts.remove(normalizedEmail);
+        attempts.remove(key);
     }
 
-    public boolean isBlocked(String email) {
-        String normalizedEmail = AppUser.normalizeEmail(email);
-        if (normalizedEmail == null || normalizedEmail.isBlank()) {
+    public boolean isBlocked(String clientIp) {
+        String key = normalizeClientIp(clientIp);
+        if (key == null) {
             return false;
         }
 
-        AttemptRecord record = attempts.get(normalizedEmail);
+        AttemptRecord record = attempts.get(key);
         if (record == null) {
             return false;
         }
 
         Instant now = Instant.now(clock);
+
         if (record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
-            attempts.remove(normalizedEmail);
+            record.blockExpiresAt = null;
+        }
+
+        pruneOldFailures(record, now);
+        if (!isCurrentlyBlocked(record, now) && record.failures.isEmpty() && shouldReset(record, now)) {
+            attempts.remove(key);
             return false;
         }
 
+        return isCurrentlyBlocked(record, now);
+    }
+
+    public Duration getRemainingBlockDuration(String clientIp) {
+        String key = normalizeClientIp(clientIp);
+        if (key == null) {
+            return Duration.ZERO;
+        }
+
+        AttemptRecord record = attempts.get(key);
+        if (record == null || record.blockExpiresAt == null) {
+            return Duration.ZERO;
+        }
+
+        Instant now = Instant.now(clock);
+        if (now.isAfter(record.blockExpiresAt)) {
+            return Duration.ZERO;
+        }
+
+        return Duration.between(now, record.blockExpiresAt);
+    }
+
+    private boolean shouldReset(AttemptRecord record, Instant now) {
+        if (record.lastAttemptAt == null) {
+            return true;
+        }
+        return Duration.between(record.lastAttemptAt, now).compareTo(WINDOW_DURATION) > 0;
+    }
+
+    private boolean isCurrentlyBlocked(AttemptRecord record, Instant now) {
         return record.blockExpiresAt != null && !now.isAfter(record.blockExpiresAt);
     }
 
+    private void pruneOldFailures(AttemptRecord record, Instant now) {
+        Instant cutoff = now.minus(WINDOW_DURATION);
+        while (!record.failures.isEmpty()) {
+            Instant head = record.failures.peekFirst();
+            if (head != null && head.isBefore(cutoff)) {
+                record.failures.removeFirst();
+                continue;
+            }
+            break;
+        }
+
+        if (record.failures.isEmpty() && record.blockExpiresAt == null && record.lastAttemptAt != null
+            && Duration.between(record.lastAttemptAt, now).compareTo(WINDOW_DURATION) > 0) {
+            record.currentBlockDuration = null;
+        }
+    }
+
+    private String normalizeClientIp(String clientIp) {
+        if (clientIp == null) {
+            return null;
+        }
+
+        String trimmed = clientIp.trim();
+        if (trimmed.isBlank()) {
+            return null;
+        }
+
+        return trimmed;
+    }
+
     private static final class AttemptRecord {
-        private int failureCount;
+        private final Deque<Instant> failures = new ArrayDeque<>();
         private Instant blockExpiresAt;
+        private Duration currentBlockDuration;
+        private Instant lastAttemptAt;
     }
 }

--- a/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
@@ -1,7 +1,5 @@
 package com.formswim.teststream.auth.service;
 
-import org.springframework.stereotype.Service;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -9,6 +7,8 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
 
 @Service
 public class LoginThrottleService {

--- a/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/LoginThrottleService.java
@@ -21,7 +21,7 @@ public class LoginThrottleService {
 
     private final Cache<String, AttemptRecord> attempts = Caffeine.newBuilder()
         .maximumSize(10_000)
-        .expireAfterWrite(WINDOW_DURATION)
+        .expireAfterAccess(MAX_BLOCK_DURATION)
         .build();
     private final Clock clock;
 

--- a/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
@@ -13,6 +13,7 @@ public class TeamCodeThrottleService {
 
     static final int MAX_FAILURES = 5;
     static final Duration BLOCK_DURATION = Duration.ofMinutes(15);
+    static final Duration INACTIVITY_RESET_AFTER = Duration.ofHours(1);
 
     private final Map<String, AttemptRecord> attempts = new ConcurrentHashMap<>();
     private final Clock clock;
@@ -35,11 +36,18 @@ public class TeamCodeThrottleService {
             Instant now = Instant.now(clock);
             AttemptRecord record = existing;
 
-            if (record == null || record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
+            boolean blockExpired = record != null && record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt);
+            boolean inactiveTooLong = record != null
+                && record.lastFailureAt != null
+                && record.blockExpiresAt == null
+                && Duration.between(record.lastFailureAt, now).compareTo(INACTIVITY_RESET_AFTER) > 0;
+
+            if (record == null || blockExpired || inactiveTooLong) {
                 record = new AttemptRecord();
             }
 
             record.failureCount++;
+            record.lastFailureAt = now;
             if (record.failureCount >= MAX_FAILURES) {
                 record.blockExpiresAt = now.plus(BLOCK_DURATION);
             }
@@ -69,12 +77,21 @@ public class TeamCodeThrottleService {
         }
 
         Instant now = Instant.now(clock);
-        if (record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
-            attempts.remove(key);
-            return false;
+
+        if (record.blockExpiresAt != null) {
+            if (now.isAfter(record.blockExpiresAt)) {
+                attempts.remove(key);
+                return false;
+            }
+            return true;
         }
 
-        return record.blockExpiresAt != null && !now.isAfter(record.blockExpiresAt);
+        if (record.lastFailureAt != null
+            && Duration.between(record.lastFailureAt, now).compareTo(INACTIVITY_RESET_AFTER) > 0) {
+            attempts.remove(key);
+        }
+
+        return false;
     }
 
     private String normalizeClientIp(String clientIp) {
@@ -93,5 +110,6 @@ public class TeamCodeThrottleService {
     private static final class AttemptRecord {
         private int failureCount;
         private Instant blockExpiresAt;
+        private Instant lastFailureAt;
     }
 }

--- a/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
@@ -1,13 +1,13 @@
 package com.formswim.teststream.auth.service;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 
 import org.springframework.stereotype.Service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 @Service
 public class TeamCodeThrottleService {

--- a/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
@@ -1,0 +1,97 @@
+package com.formswim.teststream.auth.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TeamCodeThrottleService {
+
+    static final int MAX_FAILURES = 5;
+    static final Duration BLOCK_DURATION = Duration.ofMinutes(15);
+
+    private final Map<String, AttemptRecord> attempts = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    public TeamCodeThrottleService() {
+        this(Clock.systemUTC());
+    }
+
+    TeamCodeThrottleService(Clock clock) {
+        this.clock = clock;
+    }
+
+    public void recordFailure(String clientIp) {
+        String key = normalizeClientIp(clientIp);
+        if (key == null) {
+            return;
+        }
+
+        attempts.compute(key, (ip, existing) -> {
+            Instant now = Instant.now(clock);
+            AttemptRecord record = existing;
+
+            if (record == null || record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
+                record = new AttemptRecord();
+            }
+
+            record.failureCount++;
+            if (record.failureCount >= MAX_FAILURES) {
+                record.blockExpiresAt = now.plus(BLOCK_DURATION);
+            }
+
+            return record;
+        });
+    }
+
+    public void resetFailures(String clientIp) {
+        String key = normalizeClientIp(clientIp);
+        if (key == null) {
+            return;
+        }
+
+        attempts.remove(key);
+    }
+
+    public boolean isBlocked(String clientIp) {
+        String key = normalizeClientIp(clientIp);
+        if (key == null) {
+            return false;
+        }
+
+        AttemptRecord record = attempts.get(key);
+        if (record == null) {
+            return false;
+        }
+
+        Instant now = Instant.now(clock);
+        if (record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt)) {
+            attempts.remove(key);
+            return false;
+        }
+
+        return record.blockExpiresAt != null && !now.isAfter(record.blockExpiresAt);
+    }
+
+    private String normalizeClientIp(String clientIp) {
+        if (clientIp == null) {
+            return null;
+        }
+
+        String trimmed = clientIp.trim();
+        if (trimmed.isBlank()) {
+            return null;
+        }
+
+        return trimmed;
+    }
+
+    private static final class AttemptRecord {
+        private int failureCount;
+        private Instant blockExpiresAt;
+    }
+}

--- a/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
@@ -39,12 +39,21 @@ public class TeamCodeThrottleService {
         Instant now = Instant.now(clock);
         AttemptRecord record = attempts.get(key, ip -> new AttemptRecord());
         synchronized (record) {
-            boolean blockExpired = record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt);
+            if (record.blockExpiresAt != null) {
+                if (now.isAfter(record.blockExpiresAt)) {
+                    record.failureCount = 0;
+                    record.blockExpiresAt = null;
+                    record.lastFailureAt = null;
+                } else {
+                    return;
+                }
+            }
+
             boolean inactiveTooLong = record.lastFailureAt != null
                 && record.blockExpiresAt == null
                 && Duration.between(record.lastFailureAt, now).compareTo(INACTIVITY_RESET_AFTER) > 0;
 
-            if (blockExpired || inactiveTooLong) {
+            if (inactiveTooLong) {
                 record.failureCount = 0;
                 record.blockExpiresAt = null;
                 record.lastFailureAt = null;

--- a/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
@@ -1,10 +1,11 @@
 package com.formswim.teststream.auth.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,10 @@ public class TeamCodeThrottleService {
     static final Duration BLOCK_DURATION = Duration.ofMinutes(15);
     static final Duration INACTIVITY_RESET_AFTER = Duration.ofHours(1);
 
-    private final Map<String, AttemptRecord> attempts = new ConcurrentHashMap<>();
+    private final Cache<String, AttemptRecord> attempts = Caffeine.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterWrite(Duration.ofMinutes(30))
+        .build();
     private final Clock clock;
 
     public TeamCodeThrottleService() {
@@ -32,18 +36,18 @@ public class TeamCodeThrottleService {
             return;
         }
 
-        attempts.compute(key, (ip, existing) -> {
-            Instant now = Instant.now(clock);
-            AttemptRecord record = existing;
-
-            boolean blockExpired = record != null && record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt);
-            boolean inactiveTooLong = record != null
-                && record.lastFailureAt != null
+        Instant now = Instant.now(clock);
+        AttemptRecord record = attempts.get(key, ip -> new AttemptRecord());
+        synchronized (record) {
+            boolean blockExpired = record.blockExpiresAt != null && now.isAfter(record.blockExpiresAt);
+            boolean inactiveTooLong = record.lastFailureAt != null
                 && record.blockExpiresAt == null
                 && Duration.between(record.lastFailureAt, now).compareTo(INACTIVITY_RESET_AFTER) > 0;
 
-            if (record == null || blockExpired || inactiveTooLong) {
-                record = new AttemptRecord();
+            if (blockExpired || inactiveTooLong) {
+                record.failureCount = 0;
+                record.blockExpiresAt = null;
+                record.lastFailureAt = null;
             }
 
             record.failureCount++;
@@ -51,9 +55,7 @@ public class TeamCodeThrottleService {
             if (record.failureCount >= MAX_FAILURES) {
                 record.blockExpiresAt = now.plus(BLOCK_DURATION);
             }
-
-            return record;
-        });
+        }
     }
 
     public void resetFailures(String clientIp) {
@@ -62,7 +64,7 @@ public class TeamCodeThrottleService {
             return;
         }
 
-        attempts.remove(key);
+        attempts.invalidate(key);
     }
 
     public boolean isBlocked(String clientIp) {
@@ -71,27 +73,28 @@ public class TeamCodeThrottleService {
             return false;
         }
 
-        AttemptRecord record = attempts.get(key);
+        AttemptRecord record = attempts.getIfPresent(key);
         if (record == null) {
             return false;
         }
 
         Instant now = Instant.now(clock);
-
-        if (record.blockExpiresAt != null) {
-            if (now.isAfter(record.blockExpiresAt)) {
-                attempts.remove(key);
-                return false;
+        synchronized (record) {
+            if (record.blockExpiresAt != null) {
+                if (now.isAfter(record.blockExpiresAt)) {
+                    attempts.invalidate(key);
+                    return false;
+                }
+                return true;
             }
-            return true;
-        }
 
-        if (record.lastFailureAt != null
-            && Duration.between(record.lastFailureAt, now).compareTo(INACTIVITY_RESET_AFTER) > 0) {
-            attempts.remove(key);
-        }
+            if (record.lastFailureAt != null
+                && Duration.between(record.lastFailureAt, now).compareTo(INACTIVITY_RESET_AFTER) > 0) {
+                attempts.invalidate(key);
+            }
 
-        return false;
+            return false;
+        }
     }
 
     private String normalizeClientIp(String clientIp) {

--- a/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
+++ b/src/main/java/com/formswim/teststream/auth/service/TeamCodeThrottleService.java
@@ -18,7 +18,7 @@ public class TeamCodeThrottleService {
 
     private final Cache<String, AttemptRecord> attempts = Caffeine.newBuilder()
         .maximumSize(10_000)
-        .expireAfterWrite(Duration.ofMinutes(30))
+        .expireAfterAccess(INACTIVITY_RESET_AFTER)
         .build();
     private final Clock clock;
 

--- a/src/main/java/com/formswim/teststream/etl/controller/TestCaseController.java
+++ b/src/main/java/com/formswim/teststream/etl/controller/TestCaseController.java
@@ -1,21 +1,13 @@
 package com.formswim.teststream.etl.controller;
 
-import com.formswim.teststream.auth.model.AppUser;
-import com.formswim.teststream.auth.repository.UserRepository;
-import com.formswim.teststream.etl.dto.BulkMoveRequest;
-import com.formswim.teststream.etl.dto.BulkMoveResult;
-import com.formswim.teststream.etl.dto.EtlResultSummary;
-import com.formswim.teststream.etl.dto.ReviewApplyResult;
-import com.formswim.teststream.etl.dto.UploadReviewSessionView;
-import com.formswim.teststream.etl.model.TestCase;
-import com.formswim.teststream.etl.repository.TestCaseRepository;
-import jakarta.validation.Valid;
-import com.formswim.teststream.etl.service.ExcelExportService;
-import com.formswim.teststream.etl.service.TestCaseBulkMoveService;
-import com.formswim.teststream.etl.service.TestIngestionService;
-import com.formswim.teststream.etl.service.UploadReviewService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,19 +18,29 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.etl.dto.BulkMoveRequest;
+import com.formswim.teststream.etl.dto.BulkMoveResult;
+import com.formswim.teststream.etl.dto.EtlResultSummary;
+import com.formswim.teststream.etl.dto.ReviewApplyResult;
+import com.formswim.teststream.etl.dto.UploadReviewSessionView;
+import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.etl.service.ExcelExportService;
+import com.formswim.teststream.etl.service.TestCaseBulkMoveService;
+import com.formswim.teststream.etl.service.TestIngestionService;
+import com.formswim.teststream.etl.service.UploadReviewService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 
 @Controller
 @RequestMapping
@@ -107,6 +109,7 @@ public class TestCaseController {
         }
 
         model.addAttribute("userEmail", user.getEmail());
+        model.addAttribute("teamKey", teamKey);
         model.addAttribute("testCases", cases);
         model.addAttribute("testCaseCount", testCaseRepository.countByTeamKey(teamKey));
         model.addAttribute("search", search != null ? search : "");

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -24,6 +24,23 @@
                 <div th:if="${successMessage}" class="p-3 bg-emerald-500/10 border border-emerald-500 text-emerald-400 text-sm rounded text-center" th:text="${successMessage}"></div>
                 <div th:if="${logoutMessage}" class="p-3 bg-white/10 border border-white/20 text-white text-sm rounded text-center" th:text="${logoutMessage}"></div>
 
+                <div th:if="${generatedTeamCode}" class="p-4 bg-white/5 border border-white/20 text-white rounded">
+                    <div class="text-sm text-white/70">Your new team code</div>
+                    <div class="mt-2 flex items-center justify-between gap-3">
+                        <div class="font-mono text-lg tracking-widest" id="teamCodeValue" th:text="${generatedTeamCode}"></div>
+                        <button
+                            type="button"
+                            class="shrink-0 py-2 px-3 text-black font-bold transition-all hover:opacity-80"
+                            style="background-color: #E7FF02;"
+                            onclick="copyTeamCode()"
+                            id="copyTeamCodeButton"
+                        >
+                            Copy
+                        </button>
+                    </div>
+                    <div class="mt-2 text-xs text-white/60" id="copyTeamCodeStatus" aria-live="polite"></div>
+                </div>
+
                 <div>
                     <label for="email" class="block text-white mb-2 font-semibold">
                         Email
@@ -73,5 +90,40 @@
             </form>
         </div>
     </div>
+
+    <script>
+        async function copyTeamCode() {
+            const valueEl = document.getElementById('teamCodeValue');
+            const statusEl = document.getElementById('copyTeamCodeStatus');
+            const buttonEl = document.getElementById('copyTeamCodeButton');
+            const teamCode = valueEl ? valueEl.textContent.trim() : '';
+
+            if (!teamCode) {
+                if (statusEl) statusEl.textContent = 'No team code found.';
+                return;
+            }
+
+            try {
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(teamCode);
+                } else {
+                    const input = document.createElement('input');
+                    input.value = teamCode;
+                    document.body.appendChild(input);
+                    input.select();
+                    document.execCommand('copy');
+                    document.body.removeChild(input);
+                }
+
+                if (statusEl) statusEl.textContent = 'Copied to clipboard.';
+                if (buttonEl) buttonEl.textContent = 'Copied';
+                setTimeout(() => {
+                    if (buttonEl) buttonEl.textContent = 'Copy';
+                }, 1200);
+            } catch (e) {
+                if (statusEl) statusEl.textContent = 'Copy failed. Please select and copy manually.';
+            }
+        }
+    </script>
 </body>
 </html>

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -87,7 +87,7 @@
 									aria-controls="workspaceAccountDropdown"
 									id="workspaceAccountToggle"
 								>
-									Account
+									Account <span aria-hidden="true" class="text-white/45">▾</span>
 								</button>
 								<div
 									id="workspaceAccountDropdown"
@@ -120,17 +120,31 @@
 									aria-label="Team code"
 								>
 									<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Team code</p>
-									<div
-										id="workspaceTeamCodeValue"
-										class="mt-2 font-mono text-sm text-white/80 tracking-widest cursor-pointer select-text"
-										th:text="${teamKey}"
-										title="Copy to clipboard"
-										role="button"
-										tabindex="0"
-										onclick="copyWorkspaceTeamCode()"
-										onkeydown="onWorkspaceTeamCodeKeydown(event)"
-									>
-										TEAMCODE
+									<div class="mt-2 flex items-center justify-between gap-2">
+										<div
+											id="workspaceTeamCodeValue"
+											class="font-mono text-sm text-white/80 tracking-widest cursor-pointer select-text transition-colors hover:text-white"
+											th:text="${teamKey}"
+											title="Copy to clipboard"
+											role="button"
+											tabindex="0"
+											onclick="copyWorkspaceTeamCode()"
+											onkeydown="onWorkspaceTeamCodeKeydown(event)"
+										>
+											TEAMCODE
+										</div>
+										<button
+											type="button"
+											class="shrink-0 p-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors"
+											aria-label="Copy team code"
+											title="Copy to clipboard"
+											onclick="copyWorkspaceTeamCode()"
+										>
+											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4">
+												<rect x="9" y="9" width="10" height="10" rx="1"></rect>
+												<rect x="5" y="5" width="10" height="10" rx="1"></rect>
+											</svg>
+										</button>
 									</div>
 									<div class="text-xs text-white/45 mt-2" id="workspaceCopyTeamCodeStatus" aria-live="polite"></div>
 								</div>

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -9,6 +9,9 @@
 	<link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;700;900&display=swap" rel="stylesheet">
 	<meta name="workspace-api-base" content="/api/testcases">
 	<meta name="workspace-export-base" content="/workspace/export">
+	<style>
+		summary::-webkit-details-marker { display: none; }
+	</style>
 </head>
 
 <body class="bg-black text-white">
@@ -78,6 +81,27 @@
 						<div class="hidden sm:block text-right min-w-0">
 							<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Account</p>
 							<p class="text-sm text-white/70 truncate" th:text="${userEmail != null ? userEmail : 'Signed in'}">Signed in</p>
+						</div>
+						<div class="hidden sm:block text-right min-w-0" th:if="${teamKey != null}">
+							<div class="flex items-center justify-end gap-2">
+								<details>
+									<summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
+										Team code <span aria-hidden="true" class="text-white/45">▾</span>
+									</summary>
+									<div class="mt-2 border border-white/20 bg-white/5 px-3 py-2 text-left">
+										<div id="workspaceTeamCodeValue" class="font-mono text-sm text-white/80 tracking-widest" th:text="${teamKey}">TEAMCODE</div>
+									</div>
+								</details>
+								<button
+									type="button"
+									class="px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs"
+									onclick="copyWorkspaceTeamCode()"
+									id="workspaceCopyTeamCodeButton"
+								>
+									Copy
+								</button>
+							</div>
+							<div class="text-xs text-white/45" id="workspaceCopyTeamCodeStatus" aria-live="polite"></div>
 						</div>
 						<form th:action="@{/logout}" method="post">
 							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
@@ -303,6 +327,39 @@
 			const visibleItems = container.querySelectorAll('[data-flash-item]:not(.hidden)');
 			if (visibleItems.length === 0) {
 				container.classList.add('hidden');
+			}
+		}
+
+		async function copyWorkspaceTeamCode() {
+			const valueEl = document.getElementById('workspaceTeamCodeValue');
+			const statusEl = document.getElementById('workspaceCopyTeamCodeStatus');
+			const buttonEl = document.getElementById('workspaceCopyTeamCodeButton');
+			const teamCode = valueEl ? valueEl.textContent.trim() : '';
+
+			if (!teamCode) {
+				if (statusEl) statusEl.textContent = 'No team code found.';
+				return;
+			}
+
+			try {
+				if (navigator.clipboard && navigator.clipboard.writeText) {
+					await navigator.clipboard.writeText(teamCode);
+				} else {
+					const input = document.createElement('input');
+					input.value = teamCode;
+					document.body.appendChild(input);
+					input.select();
+					document.execCommand('copy');
+					document.body.removeChild(input);
+				}
+
+				if (statusEl) statusEl.textContent = 'Copied team code.';
+				if (buttonEl) buttonEl.textContent = 'Copied';
+				setTimeout(() => {
+					if (buttonEl) buttonEl.textContent = 'Copy';
+				}, 1200);
+			} catch (e) {
+				if (statusEl) statusEl.textContent = 'Copy failed. Please copy manually.';
 			}
 		}
 	</script>

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -9,9 +9,6 @@
 	<link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;700;900&display=swap" rel="stylesheet">
 	<meta name="workspace-api-base" content="/api/testcases">
 	<meta name="workspace-export-base" content="/workspace/export">
-	<style>
-		summary::-webkit-details-marker { display: none; }
-	</style>
 </head>
 
 <body class="bg-black text-white">
@@ -78,30 +75,66 @@
 					</div>
 
 					<div class="flex items-center gap-3">
-						<div class="hidden sm:block text-right min-w-0">
-							<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Account</p>
-							<p class="text-sm text-white/70 truncate" th:text="${userEmail != null ? userEmail : 'Signed in'}">Signed in</p>
-						</div>
-						<div class="hidden sm:block text-right min-w-0" th:if="${teamKey != null}">
-							<div class="flex items-center justify-end gap-2">
-								<details>
-									<summary class="cursor-pointer select-none text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
-										Team code <span aria-hidden="true" class="text-white/45">▾</span>
-									</summary>
-									<div class="mt-2 border border-white/20 bg-white/5 px-3 py-2 text-left">
-										<div id="workspaceTeamCodeValue" class="font-mono text-sm text-white/80 tracking-widest" th:text="${teamKey}">TEAMCODE</div>
-									</div>
-								</details>
+						<div class="hidden sm:flex items-start gap-4">
+							<!-- Account dropdown toggle -->
+							<div class="relative text-right min-w-0">
 								<button
 									type="button"
-									class="px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs"
-									onclick="copyWorkspaceTeamCode()"
-									id="workspaceCopyTeamCodeButton"
+									class="text-xs uppercase tracking-wider text-white/45 hover:text-[#E7FF02] transition-colors select-none"
+									style="font-family: 'Work Sans', sans-serif; font-weight: 700;"
+									onclick="toggleWorkspaceHeaderDropdown('account')"
+									aria-haspopup="true"
+									aria-controls="workspaceAccountDropdown"
+									id="workspaceAccountToggle"
 								>
-									Copy
+									Account
 								</button>
+								<div
+									id="workspaceAccountDropdown"
+									class="hidden absolute right-0 mt-2 z-50 w-64 border border-white/20 bg-black px-4 py-3 text-left"
+									role="dialog"
+									aria-label="Account details"
+								>
+									<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Signed in as</p>
+									<p class="mt-1 text-sm text-white/80 break-words" th:text="${userEmail != null ? userEmail : 'Signed in'}">Signed in</p>
+								</div>
 							</div>
-							<div class="text-xs text-white/45" id="workspaceCopyTeamCodeStatus" aria-live="polite"></div>
+
+							<!-- Team code dropdown toggle -->
+							<div class="relative text-right min-w-0" th:if="${teamKey != null}">
+								<button
+									type="button"
+									class="text-xs uppercase tracking-wider text-white/45 hover:text-[#E7FF02] transition-colors select-none"
+									style="font-family: 'Work Sans', sans-serif; font-weight: 700;"
+									onclick="toggleWorkspaceHeaderDropdown('team')"
+									aria-haspopup="true"
+									aria-controls="workspaceTeamCodeDropdown"
+									id="workspaceTeamCodeToggle"
+								>
+									Team code <span aria-hidden="true" class="text-white/45">▾</span>
+								</button>
+								<div
+									id="workspaceTeamCodeDropdown"
+									class="hidden absolute right-0 mt-2 z-50 w-64 border border-white/20 bg-black px-4 py-3 text-left"
+									role="dialog"
+									aria-label="Team code"
+								>
+									<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Team code</p>
+									<div
+										id="workspaceTeamCodeValue"
+										class="mt-2 font-mono text-sm text-white/80 tracking-widest cursor-pointer select-text"
+										th:text="${teamKey}"
+										title="Copy to clipboard"
+										role="button"
+										tabindex="0"
+										onclick="copyWorkspaceTeamCode()"
+										onkeydown="onWorkspaceTeamCodeKeydown(event)"
+									>
+										TEAMCODE
+									</div>
+									<div class="text-xs text-white/45 mt-2" id="workspaceCopyTeamCodeStatus" aria-live="polite"></div>
+								</div>
+							</div>
 						</div>
 						<form th:action="@{/logout}" method="post">
 							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
@@ -313,6 +346,28 @@
 	</div>
 
 	<script>
+		function toggleWorkspaceHeaderDropdown(which) {
+			const account = document.getElementById('workspaceAccountDropdown');
+			const team = document.getElementById('workspaceTeamCodeDropdown');
+
+			const isAccountOpen = account && !account.classList.contains('hidden');
+			const isTeamOpen = team && !team.classList.contains('hidden');
+
+			const nextAccountOpen = which === 'account' ? !isAccountOpen : false;
+			const nextTeamOpen = which === 'team' ? !isTeamOpen : false;
+
+			if (account) account.classList.toggle('hidden', !nextAccountOpen);
+			if (team) team.classList.toggle('hidden', !nextTeamOpen);
+		}
+
+		function onWorkspaceTeamCodeKeydown(event) {
+			if (!event) return;
+			if (event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault();
+				copyWorkspaceTeamCode();
+			}
+		}
+
 		function dismissWorkspaceFlash(button) {
 			const item = button.closest('[data-flash-item]');
 			if (item) {
@@ -333,7 +388,6 @@
 		async function copyWorkspaceTeamCode() {
 			const valueEl = document.getElementById('workspaceTeamCodeValue');
 			const statusEl = document.getElementById('workspaceCopyTeamCodeStatus');
-			const buttonEl = document.getElementById('workspaceCopyTeamCodeButton');
 			const teamCode = valueEl ? valueEl.textContent.trim() : '';
 
 			if (!teamCode) {
@@ -354,9 +408,8 @@
 				}
 
 				if (statusEl) statusEl.textContent = 'Copied team code.';
-				if (buttonEl) buttonEl.textContent = 'Copied';
 				setTimeout(() => {
-					if (buttonEl) buttonEl.textContent = 'Copy';
+					if (statusEl) statusEl.textContent = '';
 				}, 1200);
 			} catch (e) {
 				if (statusEl) statusEl.textContent = 'Copy failed. Please copy manually.';

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -85,6 +85,7 @@
 									onclick="toggleWorkspaceHeaderDropdown('account')"
 									aria-haspopup="true"
 									aria-controls="workspaceAccountDropdown"
+									aria-expanded="false"
 									id="workspaceAccountToggle"
 								>
 									Account <span aria-hidden="true" class="text-white/45">▾</span>
@@ -109,6 +110,7 @@
 									onclick="toggleWorkspaceHeaderDropdown('team')"
 									aria-haspopup="true"
 									aria-controls="workspaceTeamCodeDropdown"
+									aria-expanded="false"
 									id="workspaceTeamCodeToggle"
 								>
 									Team code <span aria-hidden="true" class="text-white/45">▾</span>
@@ -363,6 +365,8 @@
 		function toggleWorkspaceHeaderDropdown(which) {
 			const account = document.getElementById('workspaceAccountDropdown');
 			const team = document.getElementById('workspaceTeamCodeDropdown');
+			const accountToggle = document.getElementById('workspaceAccountToggle');
+			const teamToggle = document.getElementById('workspaceTeamCodeToggle');
 
 			const isAccountOpen = account && !account.classList.contains('hidden');
 			const isTeamOpen = team && !team.classList.contains('hidden');
@@ -372,6 +376,8 @@
 
 			if (account) account.classList.toggle('hidden', !nextAccountOpen);
 			if (team) team.classList.toggle('hidden', !nextTeamOpen);
+			if (accountToggle) accountToggle.setAttribute('aria-expanded', nextAccountOpen ? 'true' : 'false');
+			if (teamToggle) teamToggle.setAttribute('aria-expanded', nextTeamOpen ? 'true' : 'false');
 		}
 
 		function onWorkspaceTeamCodeKeydown(event) {

--- a/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
@@ -1,8 +1,8 @@
 package com.formswim.teststream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
@@ -1,32 +1,35 @@
 package com.formswim.teststream;
 
-import com.formswim.teststream.auth.model.AppUser;
-import com.formswim.teststream.auth.repository.UserRepository;
-import com.formswim.teststream.auth.service.LoginThrottleService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.auth.service.LoginThrottleService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class AuthSecurityIntegrationTests {
 
     @Autowired
@@ -169,5 +172,55 @@ class AuthSecurityIntegrationTests {
             .andExpect(status().isOk())
             .andExpect(view().name("register"))
             .andExpect(content().string(org.hamcrest.Matchers.containsString("Create your account")));
+    }
+
+    @Test
+    void registerBlankTeamCodeGeneratesNewTeamKey() throws Exception {
+        mockMvc.perform(post("/register")
+                .with(csrf())
+                .param("email", "newuser@example.com")
+                .param("password", "Password123")
+                .param("confirmPassword", "Password123")
+                .param("teamCode", ""))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/login"))
+            .andExpect(flash().attributeExists("successMessage"))
+            .andExpect(flash().attributeExists("generatedTeamCode"));
+
+        AppUser created = userRepository.findByEmailIgnoreCase("newuser@example.com").orElseThrow();
+        assertThat(created.getTeamKey()).isNotBlank();
+        assertThat(created.getTeamKey()).hasSizeGreaterThanOrEqualTo(16);
+
+        mockMvc.perform(get("/workspace").with(user("newuser@example.com").roles("USER")))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void registerUnknownTeamCodeShowsFieldError() throws Exception {
+        mockMvc.perform(post("/register")
+                .with(csrf())
+                .param("email", "unknownteam@example.com")
+                .param("password", "Password123")
+                .param("confirmPassword", "Password123")
+                .param("teamCode", "NOT_A_REAL_TEAM"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/register"))
+            .andExpect(flash().attribute("errorMessage", "Please correct the highlighted fields."))
+            .andExpect(flash().attribute("fieldErrors", hasEntry("teamCode", "Team code not found. Leave blank to create a new team.")));
+    }
+
+    @Test
+    void registerWithExistingTeamCodeJoinsThatTeam() throws Exception {
+        mockMvc.perform(post("/register")
+                .with(csrf())
+                .param("email", "joiner@example.com")
+                .param("password", "Password123")
+                .param("confirmPassword", "Password123")
+                .param("teamCode", "team1"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/login"));
+
+        AppUser created = userRepository.findByEmailIgnoreCase("joiner@example.com").orElseThrow();
+        assertThat(created.getTeamKey()).isEqualTo("TEAM1");
     }
 }

--- a/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
 import com.formswim.teststream.auth.service.LoginThrottleService;
+import com.formswim.teststream.auth.service.TeamCodeThrottleService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -44,12 +45,17 @@ class AuthSecurityIntegrationTests {
     @Autowired
     private LoginThrottleService loginThrottleService;
 
+    @Autowired
+    private TeamCodeThrottleService teamCodeThrottleService;
+
     @BeforeEach
     void setUp() {
         userRepository.deleteAll();
         loginThrottleService.resetFailures("user@example.com");
         loginThrottleService.resetFailures("disabled@example.com");
         loginThrottleService.resetFailures("missing@example.com");
+        teamCodeThrottleService.resetFailures("127.0.0.1");
+        teamCodeThrottleService.resetFailures("203.0.113.10");
 
         userRepository.save(new AppUser("user@example.com", passwordEncoder.encode("Password123"), "TEAM1"));
 
@@ -223,5 +229,38 @@ class AuthSecurityIntegrationTests {
 
         AppUser created = userRepository.findByEmailIgnoreCase("joiner@example.com").orElseThrow();
         assertThat(created.getTeamKey()).isEqualTo("TEAM1");
+    }
+
+    @Test
+    void repeatedUnknownTeamCodeAttemptsBlockRegistrationFromSameIp() throws Exception {
+        for (int attempt = 0; attempt < 5; attempt++) {
+            mockMvc.perform(post("/register")
+                    .with(csrf())
+                    .with(request -> {
+                        request.setRemoteAddr("203.0.113.10");
+                        return request;
+                    })
+                    .param("email", "ipblock" + attempt + "@example.com")
+                    .param("password", "Password123")
+                    .param("confirmPassword", "Password123")
+                    .param("teamCode", "NOT_A_REAL_TEAM"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/register"))
+                .andExpect(flash().attribute("errorMessage", "Please correct the highlighted fields."));
+        }
+
+        mockMvc.perform(post("/register")
+                .with(csrf())
+                .with(request -> {
+                    request.setRemoteAddr("203.0.113.10");
+                    return request;
+                })
+                .param("email", "blocked@example.com")
+                .param("password", "Password123")
+                .param("confirmPassword", "Password123")
+                .param("teamCode", "NOT_A_REAL_TEAM"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/register"))
+            .andExpect(flash().attribute("errorMessage", "Too many attempts. Please try again later."));
     }
 }

--- a/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
@@ -85,7 +85,8 @@ class AuthSecurityIntegrationTests {
 
         mockMvc.perform(get("/workspace").with(user("user@example.com").roles("USER")))
             .andExpect(status().isOk())
-            .andExpect(model().attribute("userEmail", "user@example.com"));
+            .andExpect(model().attribute("userEmail", "user@example.com"))
+            .andExpect(model().attribute("teamKey", "TEAM1"));
     }
 
     @Test

--- a/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/AuthSecurityIntegrationTests.java
@@ -2,6 +2,7 @@ package com.formswim.teststream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.containsString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,9 +52,8 @@ class AuthSecurityIntegrationTests {
     @BeforeEach
     void setUp() {
         userRepository.deleteAll();
-        loginThrottleService.resetFailures("user@example.com");
-        loginThrottleService.resetFailures("disabled@example.com");
-        loginThrottleService.resetFailures("missing@example.com");
+        loginThrottleService.resetFailures("127.0.0.1");
+        loginThrottleService.resetFailures("203.0.113.10");
         teamCodeThrottleService.resetFailures("127.0.0.1");
         teamCodeThrottleService.resetFailures("203.0.113.10");
 
@@ -143,22 +143,32 @@ class AuthSecurityIntegrationTests {
     }
     @Test
     void repeatedFailuresTemporarilyBlockSubsequentLogins() throws Exception {
+        String attackerIp = "203.0.113.10";
         for (int attempt = 0; attempt < 5; attempt++) {
             mockMvc.perform(post("/login")
                     .with(csrf())
+                    .with(request -> {
+                        request.setRemoteAddr(attackerIp);
+                        return request;
+                    })
                     .param("email", "user@example.com")
                     .param("password", "WrongPassword"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/login"));
         }
 
-        assertThat(loginThrottleService.isBlocked("user@example.com")).isTrue();
+        assertThat(loginThrottleService.isBlocked(attackerIp)).isTrue();
         mockMvc.perform(post("/login")
                 .with(csrf())
+                .with(request -> {
+                    request.setRemoteAddr(attackerIp);
+                    return request;
+                })
                 .param("email", "user@example.com")
                 .param("password", "Password123"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl("/login"));
+            .andExpect(redirectedUrl("/login"))
+            .andExpect(flash().attribute("errorMessage", containsString("Too many attempts")));
     }
 
 

--- a/src/test/java/com/formswim/teststream/BulkMoveIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/BulkMoveIntegrationTests.java
@@ -1,32 +1,34 @@
 package com.formswim.teststream;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.formswim.teststream.auth.model.AppUser;
-import com.formswim.teststream.auth.repository.UserRepository;
-import com.formswim.teststream.etl.model.TestCase;
-import com.formswim.teststream.etl.repository.TestCaseRepository;
-import com.formswim.teststream.support.TestCaseFixtures;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.support.TestCaseFixtures;
+
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class BulkMoveIntegrationTests {
 
     @Autowired

--- a/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
+++ b/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
@@ -1,27 +1,29 @@
 package com.formswim.teststream;
 
-import com.formswim.teststream.auth.model.AppUser;
-import com.formswim.teststream.auth.repository.UserRepository;
-import com.formswim.teststream.etl.repository.TestCaseRepository;
-import com.formswim.teststream.support.TestCaseFixtures;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.web.servlet.MockMvc;
-
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.etl.repository.TestCaseRepository;
+import com.formswim.teststream.support.TestCaseFixtures;
+
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class TeststreamApplicationTests {
 
 	@Autowired

--- a/src/test/java/com/formswim/teststream/UploadReviewIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/UploadReviewIntegrationTests.java
@@ -1,5 +1,31 @@
 package com.formswim.teststream;
 
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
@@ -13,34 +39,10 @@ import com.formswim.teststream.etl.repository.UploadHistoryRepository;
 import com.formswim.teststream.etl.repository.UploadReviewSessionRepository;
 import com.formswim.teststream.etl.service.ExcelParserService;
 import com.formswim.teststream.support.TestCaseFixtures;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-
-import java.io.ByteArrayOutputStream;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class UploadReviewIntegrationTests {
 
     @Autowired

--- a/src/test/java/com/formswim/teststream/WorkspaceExportIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/WorkspaceExportIntegrationTests.java
@@ -1,30 +1,32 @@
 package com.formswim.teststream;
 
-import com.formswim.teststream.auth.model.AppUser;
-import com.formswim.teststream.auth.repository.UserRepository;
-import com.formswim.teststream.etl.model.TestCase;
-import com.formswim.teststream.etl.model.TestStep;
-import com.formswim.teststream.etl.repository.TestCaseRepository;
+import java.io.ByteArrayInputStream;
+
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import java.io.ByteArrayInputStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.etl.model.TestCase;
+import com.formswim.teststream.etl.model.TestStep;
+import com.formswim.teststream.etl.repository.TestCaseRepository;
+
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class WorkspaceExportIntegrationTests {
 
     @Autowired

--- a/src/test/java/com/formswim/teststream/auth/service/LoginThrottleServiceTests.java
+++ b/src/test/java/com/formswim/teststream/auth/service/LoginThrottleServiceTests.java
@@ -1,0 +1,105 @@
+package com.formswim.teststream.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.Test;
+
+class LoginThrottleServiceTests {
+
+    @Test
+    void blocksAfterFiveFailuresWithinWindow() {
+        Instant start = Instant.parse("2026-03-19T00:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        LoginThrottleService throttle = new LoginThrottleService(clock);
+
+        String ip = "203.0.113.10";
+
+        for (int i = 0; i < LoginThrottleService.MAX_FAILURES; i++) {
+            throttle.recordFailure(ip);
+        }
+
+        assertThat(throttle.isBlocked(ip)).isTrue();
+        assertThat(throttle.getRemainingBlockDuration(ip)).isGreaterThan(Duration.ZERO);
+    }
+
+    @Test
+    void blockDurationDoublesOnRepeatedBlocks() {
+        Instant start = Instant.parse("2026-03-19T00:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        LoginThrottleService throttle = new LoginThrottleService(clock);
+
+        String ip = "127.0.0.1";
+
+        for (int i = 0; i < LoginThrottleService.MAX_FAILURES; i++) {
+            throttle.recordFailure(ip);
+        }
+        Duration first = throttle.getRemainingBlockDuration(ip);
+        assertThat(first).isGreaterThan(Duration.ZERO);
+
+        // Let the first block expire but keep failures within the 30-minute window.
+        clock.setInstant(start.plus(LoginThrottleService.INITIAL_BLOCK_DURATION).plusSeconds(1));
+        assertThat(throttle.isBlocked(ip)).isFalse();
+
+        // One more failure inside the same rolling window should trigger the next block (double duration).
+        throttle.recordFailure(ip);
+        assertThat(throttle.isBlocked(ip)).isTrue();
+
+        Duration second = throttle.getRemainingBlockDuration(ip);
+        assertThat(second).isGreaterThanOrEqualTo(LoginThrottleService.INITIAL_BLOCK_DURATION.multipliedBy(2).minusSeconds(5));
+    }
+
+    @Test
+    void stateResetsAfterWindowExpiresWithoutFurtherAttempts() {
+        Instant start = Instant.parse("2026-03-19T00:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        LoginThrottleService throttle = new LoginThrottleService(clock);
+
+        String ip = "198.51.100.5";
+
+        throttle.recordFailure(ip);
+        throttle.recordFailure(ip);
+
+        // No attempts for > 30 minutes; state should reset on the next attempt.
+        clock.setInstant(start.plus(LoginThrottleService.WINDOW_DURATION).plusSeconds(1));
+        throttle.recordAttempt(ip);
+
+        // Now only 3 more failures should NOT trigger a block (because earlier failures were out of window).
+        throttle.recordFailure(ip);
+        throttle.recordFailure(ip);
+        throttle.recordFailure(ip);
+
+        assertThat(throttle.isBlocked(ip)).isFalse();
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void setInstant(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/com/formswim/teststream/auth/service/TeamCodeThrottleServiceTests.java
+++ b/src/test/java/com/formswim/teststream/auth/service/TeamCodeThrottleServiceTests.java
@@ -1,0 +1,85 @@
+package com.formswim.teststream.auth.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+class TeamCodeThrottleServiceTests {
+
+    @Test
+    void failuresResetAfterInactivityWindow() {
+        Instant start = Instant.parse("2026-03-19T00:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        TeamCodeThrottleService throttle = new TeamCodeThrottleService(clock);
+
+        String ip = "203.0.113.10";
+
+        throttle.recordFailure(ip);
+        throttle.recordFailure(ip);
+        assertThat(throttle.isBlocked(ip)).isFalse();
+
+        // After > 1 hour of no failures, counts should reset.
+        clock.setInstant(start.plus(TeamCodeThrottleService.INACTIVITY_RESET_AFTER).plusSeconds(1));
+
+        throttle.recordFailure(ip);
+        throttle.recordFailure(ip);
+        throttle.recordFailure(ip);
+        throttle.recordFailure(ip);
+
+        // If earlier failures had not reset, this would have hit the 5-failure threshold and blocked.
+        assertThat(throttle.isBlocked(ip)).isFalse();
+
+        throttle.recordFailure(ip);
+        assertThat(throttle.isBlocked(ip)).isTrue();
+    }
+
+    @Test
+    void blockStillAppliesWithinBlockDuration() {
+        Instant start = Instant.parse("2026-03-19T00:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        TeamCodeThrottleService throttle = new TeamCodeThrottleService(clock);
+
+        String ip = "127.0.0.1";
+        for (int i = 0; i < TeamCodeThrottleService.MAX_FAILURES; i++) {
+            throttle.recordFailure(ip);
+        }
+
+        assertThat(throttle.isBlocked(ip)).isTrue();
+
+        clock.setInstant(start.plus(TeamCodeThrottleService.BLOCK_DURATION).minusSeconds(1));
+        assertThat(throttle.isBlocked(ip)).isTrue();
+
+        clock.setInstant(start.plus(TeamCodeThrottleService.BLOCK_DURATION).plusSeconds(1));
+        assertThat(throttle.isBlocked(ip)).isFalse();
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void setInstant(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/com/formswim/teststream/auth/service/TeamCodeThrottleServiceTests.java
+++ b/src/test/java/com/formswim/teststream/auth/service/TeamCodeThrottleServiceTests.java
@@ -56,6 +56,27 @@ class TeamCodeThrottleServiceTests {
         assertThat(throttle.isBlocked(ip)).isFalse();
     }
 
+    @Test
+    void blockedRequestsDoNotExtendBlockDuration() {
+        Instant start = Instant.parse("2026-03-19T00:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        TeamCodeThrottleService throttle = new TeamCodeThrottleService(clock);
+
+        String ip = "203.0.113.99";
+        for (int i = 0; i < TeamCodeThrottleService.MAX_FAILURES; i++) {
+            throttle.recordFailure(ip);
+        }
+
+        assertThat(throttle.isBlocked(ip)).isTrue();
+
+        Instant expiry = start.plus(TeamCodeThrottleService.BLOCK_DURATION);
+        clock.setInstant(expiry.minusSeconds(1));
+        throttle.recordFailure(ip);
+
+        clock.setInstant(expiry.plusSeconds(1));
+        assertThat(throttle.isBlocked(ip)).isFalse();
+    }
+
     private static final class MutableClock extends Clock {
         private Instant instant;
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,14 +1,12 @@
-# 1. Map the environment variables injected by GitHub Actions
-spring.datasource.url=${DB_URL}
-spring.datasource.username=${DB_USERNAME}
-spring.datasource.password=${DB_PASSWORD}
+# Use an isolated in-memory DB for tests by default.
+# You can override these with TEST_DB_* env vars when needed (e.g., in CI).
+spring.datasource.url=${TEST_DB_URL:jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+spring.datasource.username=${TEST_DB_USERNAME:sa}
+spring.datasource.password=${TEST_DB_PASSWORD:}
+spring.datasource.driver-class-name=${TEST_DB_DRIVER:org.h2.Driver}
 
-# 2. Explicitly define the driver as a failsafe
-spring.datasource.driver-class-name=org.postgresql.Driver
-
-# 3. Force the application to build its own database tables 
-# from scratch so the tests have a schema to run against.
+# Force the application to build its own database tables from scratch so the tests have a schema to run against.
 spring.jpa.hibernate.ddl-auto=create-drop
 
-# Tell Spring Session to create its JDBC tables automatically
+# Tell Spring Session to create its JDBC tables automatically.
 spring.session.jdbc.initialize-schema=always


### PR DESCRIPTION

closes #25 

## Description
 - Registration now supports join-or-create teams: blank team code generates a unique 16-char SecureRandom code; provided team code must already exist.
 - Shows the generated team code after registration and adds persistent team code display/copy controls in the workspace header.
 
Adds IP-based throttling:
 - Team code guessing: blocks repeated “team code not found” attempts.
 - Login: rolling-window limiter (5 failures / 30 minutes) with exponential backoff blocks (15m → 30m → 60m … up to 24h).

Stabilizes integration [test](vscode-file://vscode-app/c:/Users/jjtru/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html)s with an H2 test profile and adds coverage for the critical flows.

## Testing:

[./mvnw test](vscode-file://vscode-app/c:/Users/jjtru/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (or on PowerShell: [.\mvnw test](vscode-file://vscode-app/c:/Users/jjtru/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html))