### PR TITLE
Dropdown preview page vs right aligned window + title preview on hover

### DIFF
--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -68,6 +68,10 @@ Current frontend shape:
 
 - the workspace page now uses feature-scoped JS modules under `src/main/resources/static/js/workspace`
 - the workspace template now composes fragments from `src/main/resources/templates/workspace`
+- workspace row preview now uses inline expandable rows in the grid (multi-expand), rather than opening from row actions into the right-side drawer
+- workspace preview UX now includes in-card collapse controls, a global `Collapse all previews` control, and selected-row/preview linked highlighting
+- workspace grid now includes truncation-aware title tooltips (hover/focus only when truncated)
+- shared tooltip behavior was extracted into `src/main/resources/static/js/workspace/components/workspace-tooltip.js` and consumed by grid rendering
 - other pages still use the older flat-template and inline-script patterns
 
 Known frontend hotspots:

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -114,10 +114,10 @@ export function createWorkspaceFolderTree(options) {
         folderTree.innerHTML = '';
 
         const selectedFolder = uiState.getSelectedFolder();
-        const selectedRowClasses = 'bg-[#E7FF02]/10 border-[#E7FF02] text-white';
-        const unselectedRowClasses = 'border-transparent text-white/80 hover:bg-white/5 hover:border-white/10';
+        const selectedRowClasses = 'bg-[#E7FF02]/30 text-white';
+        const unselectedRowClasses = 'text-white/80 hover:bg-white/5';
         const rowWrapClasses = 'select-none';
-        const rowInnerBaseClasses = 'flex items-center gap-2 py-2 pl-2 pr-2 text-sm rounded-md border transition-colors w-full';
+        const rowInnerBaseClasses = 'flex items-center gap-2 py-2 pl-2 pr-2 text-sm rounded-md transition-colors w-full';
         const rowSelectButtonClasses = 'min-w-0 flex-1 flex items-center gap-2 text-left';
 
         const showAllWrap = document.createElement('div');
@@ -167,10 +167,22 @@ export function createWorkspaceFolderTree(options) {
             const rowWrap = document.createElement('div');
             rowWrap.className = rowWrapClasses;
             rowWrap.style.paddingLeft = String(12 + depth * 16) + 'px';
+            rowWrap.style.position = 'relative';
+
+            if (depth > 0) {
+                for (let guideLevel = 1; guideLevel <= depth; guideLevel++) {
+                    const guide = document.createElement('span');
+                    guide.className = 'pointer-events-none absolute top-0 bottom-0 w-px bg-white/20';
+                    guide.style.left = String(12 + (guideLevel - 1) * 16 + 8) + 'px';
+                    rowWrap.appendChild(guide);
+                }
+            }
 
             const rowInner = document.createElement('div');
             const isSelected = uiState.getSelectedFolder() === node.path;
             rowInner.className = rowInnerBaseClasses + ' ' + (isSelected ? selectedRowClasses : unselectedRowClasses);
+            rowInner.style.position = 'relative';
+            rowInner.style.zIndex = '1';
             rowInner.dataset.dropTarget = 'folder';
             rowInner.dataset.folderPath = node.path;
 

--- a/src/main/resources/static/js/workspace/components/workspace-inline-preview-row.js
+++ b/src/main/resources/static/js/workspace/components/workspace-inline-preview-row.js
@@ -1,0 +1,168 @@
+function escapeHtml(value) {
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function textOrDash(value) {
+    const raw = String(value == null ? '' : value).trim();
+    return raw ? escapeHtml(raw) : '-';
+}
+
+function parseDelimited(value) {
+    if (!value) {
+        return [];
+    }
+
+    return String(value)
+        .split(/[,;|]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+}
+
+function buildPreviewId(workKey) {
+    const raw = String(workKey || '').trim() || 'unknown';
+    return 'ws-preview-' + raw.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+function renderMetaItem(label, value) {
+    return '' +
+        '<div class="border border-white/10 bg-black/30 px-3 py-2">' +
+            '<p class="text-[11px] uppercase tracking-wider text-white/45">' + escapeHtml(label) + '</p>' +
+            '<p class="mt-1 text-xs text-white/80 break-words">' + textOrDash(value) + '</p>' +
+        '</div>';
+}
+
+function renderTagBadges(testCase) {
+    const values = [];
+    values.push(...parseDelimited(testCase?.components));
+    values.push(...parseDelimited(testCase?.testCaseType));
+    values.push(...parseDelimited(testCase?.labels));
+
+    const seen = new Set();
+    const tags = [];
+    for (const value of values) {
+        const key = value.toLowerCase();
+        if (!seen.has(key)) {
+            seen.add(key);
+            tags.push(value);
+        }
+    }
+
+    if (tags.length === 0) {
+        return '<span class="text-xs text-white/50">No tags</span>';
+    }
+
+    return tags
+        .map((tag) => '<span class="inline-flex items-center px-2 py-1 border border-white/15 text-[11px] text-white/70">' + escapeHtml(tag) + '</span>')
+        .join('');
+}
+
+function renderSteps(steps) {
+    const safeSteps = Array.isArray(steps) ? steps : [];
+    if (safeSteps.length === 0) {
+        return {
+            html: '<p class="text-xs text-white/50">No steps available.</p>',
+            hiddenCount: 0
+        };
+    }
+
+    const initiallyVisibleCount = 3;
+    let html = '<ol class="space-y-3">';
+    for (let index = 0; index < safeSteps.length; index++) {
+        const step = safeSteps[index] || {};
+        const isExtra = index >= initiallyVisibleCount;
+        html += '' +
+            '<li class="border border-white/10 bg-black/25 p-3' + (isExtra ? ' hidden ws-preview-step-extra' : '') + '">' +
+                '<div class="flex items-center justify-between gap-3">' +
+                    '<p class="text-[11px] uppercase tracking-wider text-white/45">Step ' + escapeHtml(step.stepNumber || String(index + 1)) + '</p>' +
+                '</div>' +
+                '<div class="mt-2 space-y-2 text-xs">' +
+                    '<div>' +
+                        '<p class="text-white/50">Action</p>' +
+                        '<p class="text-white/85 break-words">' + textOrDash(step.stepSummary) + '</p>' +
+                    '</div>' +
+                    '<div>' +
+                        '<p class="text-white/50">Data</p>' +
+                        '<p class="text-white/85 break-words">' + textOrDash(step.testData) + '</p>' +
+                    '</div>' +
+                    '<div>' +
+                        '<p class="text-white/50">Expected</p>' +
+                        '<p class="text-white/85 break-words">' + textOrDash(step.expectedResult) + '</p>' +
+                    '</div>' +
+                '</div>' +
+            '</li>';
+    }
+    html += '</ol>';
+
+    return {
+        html,
+        hiddenCount: Math.max(safeSteps.length - initiallyVisibleCount, 0)
+    };
+}
+
+export function renderInlinePreviewRow(testCase, options) {
+    const viewOptions = options || {};
+    const workKey = String(testCase?.workKey || '').trim();
+    const previewId = buildPreviewId(workKey);
+    const isSelected = Boolean(viewOptions.isSelected);
+    const stepsView = renderSteps(testCase?.steps);
+    const hasExpandableSteps = stepsView.hiddenCount > 0;
+
+    const stepToggleButton = hasExpandableSteps
+        ? '<button type="button" class="ws-interactive mt-3 px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs text-white/70" data-action="toggle-preview-steps" data-expanded="false" data-hidden-count="' + escapeHtml(String(stepsView.hiddenCount)) + '">Show all ' + escapeHtml(String(stepsView.hiddenCount)) + ' more steps</button>'
+        : '';
+
+    return '' +
+        '<tr class="ws-preview-row border-b border-white/10' + (isSelected ? ' ws-preview-selected' : ' ws-preview-open') + '">' +
+            '<td colspan="7" class="px-0 py-0">' +
+                '<section id="' + escapeHtml(previewId) + '" class="ws-preview-card bg-white/[0.02]" data-preview-card-for="' + escapeHtml(workKey) + '">' +
+                    '<div class="px-4 sm:px-6 py-4 space-y-4">' +
+                        '<div>' +
+                            '<div class="flex flex-wrap items-start justify-between gap-3">' +
+                                '<div class="min-w-0">' +
+                                    '<p class="text-[11px] uppercase tracking-wider text-white/45">Title</p>' +
+                                    '<p class="mt-1 text-sm text-white/92 break-words whitespace-pre-wrap">' + textOrDash(testCase?.summary) + '</p>' +
+                                    '<p class="mt-1 text-xs text-white/60 break-all">' + textOrDash(testCase?.workKey) + '</p>' +
+                                '</div>' +
+                                '<button type="button" class="ws-row-action ws-interactive px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs text-white/75" data-action="preview" data-work-key="' + escapeHtml(workKey) + '" aria-expanded="true" aria-controls="' + escapeHtml(previewId) + '">Collapse</button>' +
+                            '</div>' +
+                        '</div>' +
+                        '<div class="grid grid-cols-1 xl:grid-cols-2 gap-3">' +
+                            renderMetaItem('Status', testCase?.status) +
+                            renderMetaItem('Priority', testCase?.priority) +
+                            renderMetaItem('Folder', testCase?.folder) +
+                            renderMetaItem('Updated', testCase?.updatedOn) +
+                            renderMetaItem('Assignee', testCase?.assignee) +
+                            renderMetaItem('Reporter', testCase?.reporter) +
+                        '</div>' +
+                        '<div>' +
+                            '<p class="text-[11px] uppercase tracking-wider text-white/45">Description</p>' +
+                            '<p class="mt-1 text-xs text-white/85 leading-6 break-words">' + textOrDash(testCase?.description) + '</p>' +
+                        '</div>' +
+                        '<div>' +
+                            '<p class="text-[11px] uppercase tracking-wider text-white/45">Precondition</p>' +
+                            '<p class="mt-1 text-xs text-white/85 leading-6 break-words">' + textOrDash(testCase?.precondition) + '</p>' +
+                        '</div>' +
+                        '<div>' +
+                            '<p class="text-[11px] uppercase tracking-wider text-white/45">Tags</p>' +
+                            '<div class="mt-2 flex flex-wrap gap-2">' + renderTagBadges(testCase) + '</div>' +
+                        '</div>' +
+                        '<div>' +
+                            '<div class="flex items-center justify-between gap-3">' +
+                                '<p class="text-[11px] uppercase tracking-wider text-white/45">Steps</p>' +
+                                '<span class="text-[11px] text-white/50">' + escapeHtml(String(Array.isArray(testCase?.steps) ? testCase.steps.length : 0)) + ' total</span>' +
+                            '</div>' +
+                            '<div class="mt-2">' + stepsView.html + stepToggleButton + '</div>' +
+                        '</div>' +
+                        '<div class="pt-1 border-t border-white/10 flex items-center justify-end">' +
+                            '<button type="button" class="ws-row-action ws-interactive mt-3 px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs text-white/75" data-action="preview" data-work-key="' + escapeHtml(workKey) + '" aria-expanded="true" aria-controls="' + escapeHtml(previewId) + '">Collapse</button>' +
+                        '</div>' +
+                    '</div>' +
+                '</section>' +
+            '</td>' +
+        '</tr>';
+}

--- a/src/main/resources/static/js/workspace/components/workspace-tooltip.js
+++ b/src/main/resources/static/js/workspace/components/workspace-tooltip.js
@@ -1,0 +1,87 @@
+function positionTooltip(anchorRect, tooltipRect) {
+    const padding = 8;
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+
+    let left = anchorRect.left;
+    let top = anchorRect.bottom + padding;
+
+    if (left + tooltipRect.width + padding > viewportWidth) {
+        left = Math.max(padding, viewportWidth - tooltipRect.width - padding);
+    }
+
+    if (top + tooltipRect.height + padding > viewportHeight) {
+        const above = anchorRect.top - padding - tooltipRect.height;
+        if (above >= padding) {
+            top = above;
+        } else {
+            top = Math.max(padding, viewportHeight - tooltipRect.height - padding);
+        }
+    }
+
+    return { left, top };
+}
+
+export function createWorkspaceTooltip(options) {
+    const tooltipOptions = options || {};
+    const className = tooltipOptions.className || 'fixed z-50 border border-white/20 bg-black px-3 py-2 text-xs text-white/80';
+    const maxWidth = tooltipOptions.maxWidth || '22rem';
+    const whiteSpace = tooltipOptions.whiteSpace || '';
+    const wordBreak = tooltipOptions.wordBreak || '';
+
+    let tooltipEl = null;
+
+    function ensureElement() {
+        if (tooltipEl) {
+            return tooltipEl;
+        }
+
+        const el = document.createElement('div');
+        el.className = className;
+        el.style.display = 'none';
+        el.style.pointerEvents = 'none';
+        el.style.maxWidth = maxWidth;
+        if (whiteSpace) {
+            el.style.whiteSpace = whiteSpace;
+        }
+        if (wordBreak) {
+            el.style.wordBreak = wordBreak;
+        }
+
+        document.body.appendChild(el);
+        window.addEventListener('scroll', hide, true);
+        window.addEventListener('resize', hide);
+        tooltipEl = el;
+        return el;
+    }
+
+    function hide() {
+        if (!tooltipEl) {
+            return;
+        }
+
+        tooltipEl.style.display = 'none';
+        tooltipEl.innerHTML = '';
+    }
+
+    function show(anchorEl, html) {
+        if (!anchorEl) {
+            return;
+        }
+
+        const tooltip = ensureElement();
+        tooltip.innerHTML = String(html || '');
+        tooltip.style.display = 'block';
+
+        const anchorRect = anchorEl.getBoundingClientRect();
+        const tooltipRect = tooltip.getBoundingClientRect();
+        const pos = positionTooltip(anchorRect, tooltipRect);
+        tooltip.style.left = String(Math.round(pos.left)) + 'px';
+        tooltip.style.top = String(Math.round(pos.top)) + 'px';
+    }
+
+    return {
+        hide,
+        show
+    };
+}

--- a/src/main/resources/static/js/workspace/features/workspace-data-controller.js
+++ b/src/main/resources/static/js/workspace/features/workspace-data-controller.js
@@ -50,6 +50,7 @@ export function createWorkspaceDataController(options) {
     const filterStatus = options.filterStatus;
     const filterTag = options.filterTag;
     const syncRowSelectionUi = options.syncRowSelectionUi;
+    const onAfterRender = typeof options.onAfterRender === 'function' ? options.onAfterRender : null;
 
     let currentPageCases = [];
     let activePageRequestId = 0;
@@ -101,8 +102,12 @@ export function createWorkspaceDataController(options) {
         }
 
         const visibleIds = currentPageCases.map((testCase) => testCase.workKey).filter(Boolean);
+        uiState.retainExpandedPreviewKeys(visibleIds);
         selection.retainSelectedIds(visibleIds);
-        grid.renderRows(currentPageCases, new Set(selection.getSelectedIds()));
+        const expandedPreviewKeys = uiState.getExpandedPreviewKeys();
+        grid.renderRows(currentPageCases, new Set(selection.getSelectedIds()), {
+            expandedPreviewKeys
+        });
         selection.setVisibleIds(visibleIds);
         selection.bindRowCheckboxes(tbody);
         if (typeof syncRowSelectionUi === 'function') {
@@ -110,6 +115,13 @@ export function createWorkspaceDataController(options) {
         }
         updatePageControls();
         uiState.syncWorkspaceUrl(getFilterElements());
+        if (onAfterRender) {
+            onAfterRender({
+                currentPageCases: currentPageCases.slice(),
+                expandedPreviewKeys,
+                visibleIds
+            });
+        }
     }
 
     function loadCurrentPage(options) {
@@ -190,11 +202,16 @@ export function createWorkspaceDataController(options) {
         return currentPageCases.slice();
     }
 
+    function rerenderCurrentPage() {
+        renderCurrentPage();
+    }
+
     return {
         applyFilters,
         getCurrentPageCases,
         loadCurrentPage,
         loadFilterOptions,
+        rerenderCurrentPage,
         updatePageControls
     };
 }

--- a/src/main/resources/static/js/workspace/features/workspace-preview-controls.js
+++ b/src/main/resources/static/js/workspace/features/workspace-preview-controls.js
@@ -1,0 +1,33 @@
+export function bindWorkspacePreviewControls(options) {
+    const uiState = options.uiState;
+    const collapseAllButton = options.collapseAllButton;
+    const rerenderCurrentPage = typeof options.rerenderCurrentPage === 'function'
+        ? options.rerenderCurrentPage
+        : () => {};
+
+    function refresh() {
+        if (!collapseAllButton) {
+            return;
+        }
+
+        const expandedCount = uiState.getExpandedPreviewKeys().size;
+        collapseAllButton.classList.toggle('hidden', expandedCount === 0);
+        collapseAllButton.disabled = expandedCount === 0;
+        collapseAllButton.textContent = expandedCount > 0
+            ? 'Collapse all previews (' + expandedCount + ')'
+            : 'Collapse all previews';
+    }
+
+    if (collapseAllButton) {
+        collapseAllButton.addEventListener('click', () => {
+            uiState.clearExpandedPreviews();
+            rerenderCurrentPage();
+        });
+    }
+
+    refresh();
+
+    return {
+        refresh
+    };
+}

--- a/src/main/resources/static/js/workspace/features/workspace-row-actions.js
+++ b/src/main/resources/static/js/workspace/features/workspace-row-actions.js
@@ -5,8 +5,11 @@ function isInteractiveTarget(target) {
 export function bindWorkspaceRowActions(options) {
     const tbody = options.tbody;
     const selection = options.selection;
-    const drawer = options.drawer;
     const editBasePath = options.editBasePath || '/workspace/test-cases/';
+    const uiState = options.uiState;
+    const rerenderCurrentPage = typeof options.rerenderCurrentPage === 'function'
+        ? options.rerenderCurrentPage
+        : () => {};
 
     function syncRowSelectionUi() {
         if (!tbody) {
@@ -18,6 +21,19 @@ export function bindWorkspaceRowActions(options) {
             const workKey = row.dataset.workKey || '';
             const isSelected = selection.isSelected(workKey);
             row.classList.toggle('ws-row-selected', isSelected);
+        });
+
+        const previewCards = tbody.querySelectorAll('[data-preview-card-for]');
+        previewCards.forEach((previewCard) => {
+            const workKey = previewCard.getAttribute('data-preview-card-for') || '';
+            const isSelected = selection.isSelected(workKey);
+            const previewRow = previewCard.closest('tr.ws-preview-row');
+            if (!previewRow) {
+                return;
+            }
+
+            previewRow.classList.toggle('ws-preview-selected', isSelected);
+            previewRow.classList.toggle('ws-preview-open', !isSelected);
         });
     }
 
@@ -42,9 +58,37 @@ export function bindWorkspaceRowActions(options) {
 
                 const action = actionButton.dataset.action;
                 if (action === 'preview') {
-                    drawer.openByWorkKey(workKey, { readOnly: true });
+                    if (!uiState || typeof uiState.togglePreviewExpanded !== 'function') {
+                        return;
+                    }
+                    uiState.togglePreviewExpanded(workKey);
+                    rerenderCurrentPage();
                 } else if (action === 'edit' && actionButton.tagName !== 'A') {
                     window.location.href = editBasePath + encodeURIComponent(workKey);
+                }
+                return;
+            }
+
+            const genericAction = event.target?.closest?.('[data-action]');
+            if (genericAction && !genericAction.classList.contains('ws-row-action')) {
+                const action = genericAction.dataset.action;
+                if (action === 'toggle-preview-steps') {
+                    const previewCard = genericAction.closest('[data-preview-card-for]');
+                    if (!previewCard) {
+                        return;
+                    }
+
+                    const isExpanded = String(genericAction.dataset.expanded || '').toLowerCase() === 'true';
+                    const hiddenStepRows = previewCard.querySelectorAll('.ws-preview-step-extra');
+                    hiddenStepRows.forEach((row) => {
+                        row.classList.toggle('hidden', isExpanded);
+                    });
+
+                    const hiddenCount = Number.parseInt(genericAction.dataset.hiddenCount || '0', 10) || 0;
+                    genericAction.dataset.expanded = isExpanded ? 'false' : 'true';
+                    genericAction.textContent = isExpanded
+                        ? 'Show all ' + hiddenCount + ' more steps'
+                        : 'Show fewer steps';
                 }
                 return;
             }

--- a/src/main/resources/static/js/workspace/grid.js
+++ b/src/main/resources/static/js/workspace/grid.js
@@ -201,7 +201,14 @@ export function createGrid(tbody) {
             row.innerHTML =
                 '<td class="px-2 sm:px-4 py-2.5 text-white/45">' +
                     '<button type="button" class="ws-row-grab ws-interactive h-7 w-7 inline-flex items-center justify-center border border-transparent hover:border-white/20 rounded-sm" aria-label="Drag to move" draggable="true" data-work-key="' + escHtml(workKey) + '">' +
-                        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-3.5 h-3.5"><circle cx="4" cy="3" r="1.1" /><circle cx="4" cy="8" r="1.1" /><circle cx="4" cy="13" r="1.1" /><circle cx="12" cy="3" r="1.1" /><circle cx="12" cy="8" r="1.1" /><circle cx="12" cy="13" r="1.1" /></svg>' +
+                        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5" aria-hidden="true">' +
+                            '<rect x="5" y="3.5" width="2" height="2" rx="0.4"></rect>' +
+                            '<rect x="5" y="9" width="2" height="2" rx="0.4"></rect>' +
+                            '<rect x="5" y="14.5" width="2" height="2" rx="0.4"></rect>' +
+                            '<rect x="13" y="3.5" width="2" height="2" rx="0.4"></rect>' +
+                            '<rect x="13" y="9" width="2" height="2" rx="0.4"></rect>' +
+                            '<rect x="13" y="14.5" width="2" height="2" rx="0.4"></rect>' +
+                        '</svg>' +
                     '</button>' +
                 '</td>' +
                 '<td class="px-2 sm:px-3 py-2.5">' +

--- a/src/main/resources/static/js/workspace/grid.js
+++ b/src/main/resources/static/js/workspace/grid.js
@@ -1,4 +1,5 @@
 import { renderInlinePreviewRow } from './components/workspace-inline-preview-row.js';
+import { createWorkspaceTooltip } from './components/workspace-tooltip.js';
 
 export function escHtml(value) {
     return String(value)
@@ -69,70 +70,29 @@ function buildPreviewElementId(workKey) {
     return 'ws-preview-' + String(workKey || '').replace(/[^a-zA-Z0-9_-]/g, '-');
 }
 
-let tagTooltipEl = null;
-let tagTooltipAnchor = null;
+const tagTooltip = createWorkspaceTooltip({
+    className: 'fixed z-50 border border-white/20 bg-black px-3 py-2 text-xs text-white/80',
+    maxWidth: '22rem'
+});
+const titleTooltip = createWorkspaceTooltip({
+    className: 'fixed z-50 border border-white/20 bg-black px-3.5 py-2.5 text-sm text-white/90',
+    maxWidth: '42rem',
+    whiteSpace: 'normal',
+    wordBreak: 'break-word'
+});
 
-function ensureTagTooltip() {
-    if (tagTooltipEl) {
-        return tagTooltipEl;
+function isHorizontallyTruncated(element) {
+    if (!element) {
+        return false;
     }
 
-    const el = document.createElement('div');
-    el.className = 'fixed z-50 border border-white/20 bg-black px-3 py-2 text-xs text-white/80';
-    el.style.display = 'none';
-    el.style.pointerEvents = 'none';
-    el.style.maxWidth = '22rem';
-    document.body.appendChild(el);
-
-    const hide = () => hideTagTooltip();
-    window.addEventListener('scroll', hide, true);
-    window.addEventListener('resize', hide);
-
-    tagTooltipEl = el;
-    return el;
-}
-
-function hideTagTooltip() {
-    if (!tagTooltipEl) {
-        return;
-    }
-    tagTooltipEl.style.display = 'none';
-    tagTooltipEl.innerHTML = '';
-    tagTooltipAnchor = null;
-}
-
-function positionTooltip(anchorRect, tooltipRect) {
-    const padding = 8;
-    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
-    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
-
-    let left = anchorRect.left;
-    let top = anchorRect.bottom + padding;
-
-    if (left + tooltipRect.width + padding > viewportWidth) {
-        left = Math.max(padding, viewportWidth - tooltipRect.width - padding);
-    }
-
-    if (top + tooltipRect.height + padding > viewportHeight) {
-        // If there's no room below, try above.
-        const above = anchorRect.top - padding - tooltipRect.height;
-        if (above >= padding) {
-            top = above;
-        } else {
-            top = Math.max(padding, viewportHeight - tooltipRect.height - padding);
-        }
-    }
-
-    return { left, top };
+    return element.scrollWidth > element.clientWidth + 1;
 }
 
 function showTagTooltip(anchorEl, tags) {
     if (!anchorEl || !tags || tags.length === 0) {
         return;
     }
-
-    const tooltip = ensureTagTooltip();
-    tagTooltipAnchor = anchorEl;
 
     // Render each tag as a badge so future per-tag colors are visible here.
     let html = '<div class="flex flex-wrap gap-2">';
@@ -141,14 +101,20 @@ function showTagTooltip(anchorEl, tags) {
     }
     html += '</div>';
 
-    tooltip.innerHTML = html;
-    tooltip.style.display = 'block';
+    tagTooltip.show(anchorEl, html);
+}
 
-    const anchorRect = anchorEl.getBoundingClientRect();
-    const tooltipRect = tooltip.getBoundingClientRect();
-    const pos = positionTooltip(anchorRect, tooltipRect);
-    tooltip.style.left = String(Math.round(pos.left)) + 'px';
-    tooltip.style.top = String(Math.round(pos.top)) + 'px';
+function showTitleTooltip(anchorEl, fullTitle) {
+    if (!anchorEl || !isHorizontallyTruncated(anchorEl)) {
+        return;
+    }
+
+    const normalizedTitle = String(fullTitle || '').trim();
+    if (!normalizedTitle) {
+        return;
+    }
+
+    titleTooltip.show(anchorEl, escHtml(normalizedTitle));
 }
 
 function decodeTagsFromDataset(value) {
@@ -177,8 +143,9 @@ export function createGrid(tbody) {
             ? viewOptions.expandedPreviewKeys
             : new Set();
 
-        // If the grid rerenders while hovering/focused, ensure any tag tooltip is dismissed.
-        hideTagTooltip();
+        // If the grid rerenders while hovering/focused, ensure active tooltips are dismissed.
+        tagTooltip.hide();
+        titleTooltip.hide();
 
         tbody.innerHTML = '';
         testCaseMap = {};
@@ -221,7 +188,7 @@ export function createGrid(tbody) {
 
             const titleCell =
                 '<div class="min-w-0">' +
-                    '<div class="font-semibold text-white/85 truncate">' + escHtml(title) + '</div>' +
+                    '<div class="font-semibold text-white/85 truncate ws-title-text" data-ws-title tabindex="0">' + escHtml(title) + '</div>' +
                     (folder ? '<div class="text-white/45 text-xs mt-0.5 truncate">' + escHtml(folder) + '</div>' : '') +
                 '</div>';
 
@@ -258,17 +225,25 @@ export function createGrid(tbody) {
                 if (tags.length > 0) {
                     tagsEl.addEventListener('mouseenter', () => showTagTooltip(tagsEl, tags));
                     tagsEl.addEventListener('mouseleave', () => {
-                        if (tagTooltipAnchor === tagsEl) {
-                            hideTagTooltip();
-                        }
+                        tagTooltip.hide();
                     });
                     tagsEl.addEventListener('focusin', () => showTagTooltip(tagsEl, tags));
                     tagsEl.addEventListener('focusout', () => {
-                        if (tagTooltipAnchor === tagsEl) {
-                            hideTagTooltip();
-                        }
+                        tagTooltip.hide();
                     });
                 }
+            }
+
+            const titleEl = row.querySelector('[data-ws-title]');
+            if (titleEl) {
+                titleEl.addEventListener('mouseenter', () => showTitleTooltip(titleEl, title));
+                titleEl.addEventListener('mouseleave', () => {
+                    titleTooltip.hide();
+                });
+                titleEl.addEventListener('focusin', () => showTitleTooltip(titleEl, title));
+                titleEl.addEventListener('focusout', () => {
+                    titleTooltip.hide();
+                });
             }
 
             tbody.appendChild(row);

--- a/src/main/resources/static/js/workspace/grid.js
+++ b/src/main/resources/static/js/workspace/grid.js
@@ -1,3 +1,5 @@
+import { renderInlinePreviewRow } from './components/workspace-inline-preview-row.js';
+
 export function escHtml(value) {
     return String(value)
         .replace(/&/g, '&amp;')
@@ -31,7 +33,7 @@ function parseTagList(value) {
 
 function buildTagBadges(testCase, maxVisible = 3) {
     // Today, tags live in `components` (often a string). `testCaseType` is shown as an additional badge.
-    // This helper keeps the future “real tags” implementation isolated.
+    // This helper keeps the future "real tags" implementation isolated.
     const list = [];
     list.push(...parseTagList(testCase?.components));
     list.push(...parseTagList(testCase?.testCaseType));
@@ -61,6 +63,10 @@ function buildTagBadges(testCase, maxVisible = 3) {
         tags,
         html
     };
+}
+
+function buildPreviewElementId(workKey) {
+    return 'ws-preview-' + String(workKey || '').replace(/[^a-zA-Z0-9_-]/g, '-');
 }
 
 let tagTooltipEl = null;
@@ -161,10 +167,15 @@ function decodeTagsFromDataset(value) {
 export function createGrid(tbody) {
     let testCaseMap = {};
 
-    function renderRows(testCases, selectedIds) {
+    function renderRows(testCases, selectedIds, options) {
         if (!tbody) {
             return;
         }
+
+        const viewOptions = options || {};
+        const expandedPreviewKeys = viewOptions.expandedPreviewKeys instanceof Set
+            ? viewOptions.expandedPreviewKeys
+            : new Set();
 
         // If the grid rerenders while hovering/focused, ensure any tag tooltip is dismissed.
         hideTagTooltip();
@@ -185,20 +196,23 @@ export function createGrid(tbody) {
         }
 
         for (const testCase of testCases) {
-            const workKey = testCase.workKey || '—';
-            const title = testCase.summary || '—';
+            const workKey = testCase.workKey || '-';
+            const title = testCase.summary || '-';
             const folder = testCase.folder || '';
-            const status = testCase.status || '—';
+            const status = testCase.status || '-';
             const tagModel = buildTagBadges(testCase, 3);
-            const updated = testCase.updatedOn || '—';
-            const idFontSize = workKey.length > 14 ? '10px' : (workKey.length > 10 ? '11px' : '12px');
+            const updated = testCase.updatedOn || '-';
             const previewUrl = '/workspace/test-cases/' + encodeURIComponent(workKey);
+            const isSelected = selectedIds.has(workKey);
+            const isExpanded = expandedPreviewKeys.has(workKey);
+            const previewElementId = buildPreviewElementId(workKey);
 
             testCaseMap[workKey] = testCase;
 
             const row = document.createElement('tr');
-            const isSelected = selectedIds.has(workKey);
-            row.className = 'ws-row border-b border-white/10 hover:bg-white/5 transition-colors cursor-pointer' + (isSelected ? ' ws-row-selected' : '');
+            row.className = 'ws-row border-b border-white/10 hover:bg-white/5 transition-colors cursor-pointer'
+                + (isSelected ? ' ws-row-selected' : '')
+                + (isExpanded ? ' ws-row-expanded' : '');
             row.dataset.id = workKey;
             row.dataset.workKey = workKey;
             row.dataset.title = title;
@@ -211,7 +225,7 @@ export function createGrid(tbody) {
                     (folder ? '<div class="text-white/45 text-xs mt-0.5 truncate">' + escHtml(folder) + '</div>' : '') +
                 '</div>';
 
-            const tagsCell = tagModel.html || '<span class="text-white/45">—</span>';
+            const tagsCell = tagModel.html || '<span class="text-white/45">-</span>';
             const encodedTags = tagModel.tags && tagModel.tags.length > 0
                 ? encodeURIComponent(JSON.stringify(tagModel.tags))
                 : '';
@@ -225,7 +239,7 @@ export function createGrid(tbody) {
                 '</td>' +
                 '<td class="px-2 sm:px-3 py-2.5">' +
                     '<input type="checkbox" class="ws-row-check ws-interactive h-4 w-4 accent-[#E7FF02]" aria-label="Select row" data-work-key="' + escHtml(workKey) + '"' +
-                    (selectedIds.has(workKey) ? ' checked' : '') + ' />' +
+                    (isSelected ? ' checked' : '') + ' />' +
                 '</td>' +
                 '<td class="px-3 sm:px-6 py-2.5"><div class="min-w-0 truncate">' + titleCell + '</div></td>' +
                 '<td class="px-3 sm:px-6 py-2.5"><span class="inline-flex items-center px-2 py-1 border border-white/15 text-xs text-white/70">' + escHtml(status) + '</span></td>' +
@@ -233,7 +247,7 @@ export function createGrid(tbody) {
                 '<td class="pl-3 pr-6 sm:pl-6 sm:pr-4 py-2.5 text-white/55"><div class="min-w-0 whitespace-nowrap">' + escHtml(updated) + '</div></td>' +
                 '<td class="px-2 sm:px-4 py-2.5 text-right">' +
                     '<div class="inline-flex items-center gap-2" data-work-key="' + escHtml(workKey) + '">' +
-                        '<button type="button" class="ws-row-action ws-row-preview ws-interactive px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="preview" data-work-key="' + escHtml(workKey) + '">Preview</button>' +
+                        '<button type="button" class="ws-row-action ws-row-preview ws-interactive px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="preview" data-work-key="' + escHtml(workKey) + '" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="' + escHtml(previewElementId) + '">' + (isExpanded ? 'Hide preview' : 'Preview') + '</button>' +
                         '<a class="ws-row-action ws-row-edit ws-interactive px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="edit" data-work-key="' + escHtml(workKey) + '" href="' + escHtml(previewUrl) + '">Edit</a>' +
                     '</div>' +
                 '</td>';
@@ -258,6 +272,10 @@ export function createGrid(tbody) {
             }
 
             tbody.appendChild(row);
+
+            if (isExpanded) {
+                tbody.insertAdjacentHTML('beforeend', renderInlinePreviewRow(testCase, { isSelected }));
+            }
         }
     }
 

--- a/src/main/resources/static/js/workspace/page.js
+++ b/src/main/resources/static/js/workspace/page.js
@@ -9,6 +9,7 @@ import { bindWorkspaceHeaderControls } from './features/workspace-header-control
 import { createWorkspaceImportController } from './features/workspace-import-controller.js';
 import { createWorkspaceMoveController } from './features/workspace-move-controller.js';
 import { createWorkspaceOrganizeModal } from './features/workspace-organize-modal.js';
+import { bindWorkspacePreviewControls } from './features/workspace-preview-controls.js';
 import { bindWorkspaceRowActions } from './features/workspace-row-actions.js';
 import { createGrid } from './grid.js';
 import { createSelection } from './selection.js';
@@ -32,6 +33,7 @@ const bulkOrganize = document.getElementById('bulkOrganize');
 const pageInfo = document.getElementById('wsPageInfo');
 const prevPageButton = document.getElementById('wsPrevPage');
 const nextPageButton = document.getElementById('wsNextPage');
+const collapseAllPreviews = document.getElementById('wsCollapsePreviews');
 const importNoticeContainer = document.getElementById('importNoticeContainer');
 const importNotice = document.getElementById('importNotice');
 const importNoticeBadge = document.getElementById('importNoticeBadge');
@@ -112,6 +114,9 @@ let importController = {
     clearNotice() {},
     showNotice() {}
 };
+let previewControls = {
+    refresh() {}
+};
 
 const dataController = createWorkspaceDataController({
     api,
@@ -127,7 +132,10 @@ const dataController = createWorkspaceDataController({
     filterComponent,
     filterStatus,
     filterTag,
-    syncRowSelectionUi: () => syncRowSelectionUi()
+    syncRowSelectionUi: () => syncRowSelectionUi(),
+    onAfterRender: () => {
+        previewControls.refresh();
+    }
 });
 
 const folderTreeController = createWorkspaceFolderTree({
@@ -152,10 +160,17 @@ const folderTreeController = createWorkspaceFolderTree({
 const rowActions = bindWorkspaceRowActions({
     tbody,
     selection,
-    drawer,
+    uiState,
+    rerenderCurrentPage: () => dataController.rerenderCurrentPage(),
     editBasePath: '/workspace/test-cases/'
 });
 syncRowSelectionUi = rowActions.syncRowSelectionUi;
+
+previewControls = bindWorkspacePreviewControls({
+    uiState,
+    collapseAllButton: collapseAllPreviews,
+    rerenderCurrentPage: () => dataController.rerenderCurrentPage()
+});
 
 importController = createWorkspaceImportController({
     api,

--- a/src/main/resources/static/js/workspace/state/workspace-ui-state.js
+++ b/src/main/resources/static/js/workspace/state/workspace-ui-state.js
@@ -12,6 +12,7 @@ export function createWorkspaceUiState(options) {
         isLoading: false
     };
     let sidebarExpanded = true;
+    const expandedPreviewKeys = new Set();
 
     function normalizeFolder(value) {
         const raw = String(value || '').trim();
@@ -176,6 +177,48 @@ export function createWorkspaceUiState(options) {
         return sidebarExpanded;
     }
 
+    function togglePreviewExpanded(workKey) {
+        const key = String(workKey || '').trim();
+        if (!key) {
+            return false;
+        }
+
+        if (expandedPreviewKeys.has(key)) {
+            expandedPreviewKeys.delete(key);
+            return false;
+        }
+
+        expandedPreviewKeys.add(key);
+        return true;
+    }
+
+    function isPreviewExpanded(workKey) {
+        const key = String(workKey || '').trim();
+        return key ? expandedPreviewKeys.has(key) : false;
+    }
+
+    function getExpandedPreviewKeys() {
+        return new Set(expandedPreviewKeys);
+    }
+
+    function clearExpandedPreviews() {
+        expandedPreviewKeys.clear();
+    }
+
+    function retainExpandedPreviewKeys(visibleWorkKeys) {
+        const keep = new Set((visibleWorkKeys || []).map((value) => String(value || '').trim()).filter(Boolean));
+        const removed = [];
+
+        for (const key of expandedPreviewKeys) {
+            if (!keep.has(key)) {
+                expandedPreviewKeys.delete(key);
+                removed.push(key);
+            }
+        }
+
+        return removed;
+    }
+
     return {
         applyPageLoadOptions,
         buildPageRequestParams,
@@ -190,6 +233,11 @@ export function createWorkspaceUiState(options) {
         setSelectedFolder,
         setSidebarExpanded,
         syncWorkspaceUrl,
-        updatePageData
+        updatePageData,
+        clearExpandedPreviews,
+        getExpandedPreviewKeys,
+        isPreviewExpanded,
+        retainExpandedPreviewKeys,
+        togglePreviewExpanded
     };
 }

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -28,6 +28,11 @@
 			transform: translateX(1px);
 		}
 
+		#wsTbody .ws-row,
+		#wsTbody .ws-preview-row {
+			border-bottom-color: rgba(255, 255, 255, 0.38) !important;
+		}
+
 		.ws-preview-open td {
 			background: rgba(255, 255, 255, 0.02);
 		}

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -27,6 +27,30 @@
 			color: rgba(255, 255, 255, 0.98) !important;
 			transform: translateX(1px);
 		}
+
+		.ws-preview-open td {
+			background: rgba(255, 255, 255, 0.02);
+		}
+
+		.ws-preview-selected td {
+			background: rgba(231, 255, 2, 0.08);
+		}
+
+		.ws-row-expanded {
+			border-bottom-color: rgba(255, 255, 255, 0.06) !important;
+		}
+
+		.ws-preview-row {
+			border-top: 0;
+		}
+
+		.ws-preview-row td {
+			padding-top: 0 !important;
+		}
+
+		.ws-preview-card {
+			border-top: 1px solid rgba(255, 255, 255, 0.08);
+		}
 	</style>
 </head>
 

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -28,6 +28,20 @@
 			transform: translateX(1px);
 		}
 
+		/* Stronger grid-only borders for the test-case table. */
+		#wsGridTopBar {
+			border-bottom-color: rgba(255, 255, 255, 0.38) !important;
+		}
+
+		#wsGridFrame {
+			border-left: 1px solid rgba(255, 255, 255, 0.38);
+			border-right: 1px solid rgba(255, 255, 255, 0.38);
+		}
+
+		#wsGridTable .border-b {
+			border-bottom-color: rgba(255, 255, 255, 0.38) !important;
+		}
+
 		#wsTbody .ws-row,
 		#wsTbody .ws-preview-row {
 			border-bottom-color: rgba(255, 255, 255, 0.38) !important;
@@ -42,7 +56,7 @@
 		}
 
 		.ws-row-expanded {
-			border-bottom-color: rgba(255, 255, 255, 0.06) !important;
+			border-bottom-color: rgba(255, 255, 255, 0.38) !important;
 		}
 
 		.ws-preview-row {

--- a/src/main/resources/templates/workspace/_bulk-bar.html
+++ b/src/main/resources/templates/workspace/_bulk-bar.html
@@ -26,9 +26,6 @@
 						<button id="bulkOrganize" type="button" class="px-4 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-sm">
 							Move to folder
 						</button>
-						<p class="text-xs text-white/45">
-							<!-- Export, bulk edit, or move the current-page selection. -->
-						</p>
 					</div>
 				</div>
 			</div>

--- a/src/main/resources/templates/workspace/_bulk-bar.html
+++ b/src/main/resources/templates/workspace/_bulk-bar.html
@@ -24,10 +24,10 @@
 							Bulk edit
 						</button>
 						<button id="bulkOrganize" type="button" class="px-4 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-sm">
-							Organize
+							Move to folder
 						</button>
 						<p class="text-xs text-white/45">
-							Export, bulk edit, or move the current-page selection.
+							<!-- Export, bulk edit, or move the current-page selection. -->
 						</p>
 					</div>
 				</div>

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -9,12 +9,15 @@
 						<div id="wsSidebarToggleCollapsedHost" class="hidden shrink-0"></div>
 						<div class="min-w-0">
 							<h1 class="text-base uppercase tracking-wider text-white/70" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Test cases</h1>
-							<p class="text-xs text-white/45 mt-1">Click row body to select. Use Preview/Edit actions for drawer details.</p>
+							<p class="text-xs text-white/45 mt-1">Click row body to select. Preview expands inline under each test case.</p>
 						</div>
 					</div>
 					<div class="text-right">
 						<p class="text-xs text-white/45">Total</p>
 						<p id="wsTotalCount" class="text-sm text-white/70" th:text="${testCaseCount != null ? testCaseCount : '-'}">-</p>
+						<button id="wsCollapsePreviews" type="button" class="hidden mt-2 px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-[11px] uppercase tracking-wider text-white/70">
+							Collapse all previews
+						</button>
 					</div>
 				</div>
 			</div>

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -3,7 +3,7 @@
 <body>
 	<th:block th:fragment="mainContent">
 		<main class="w-full px-0 sm:px-0">
-			<div class="px-6 sm:px-8 py-6 border-b border-white/10">
+			<div id="wsGridTopBar" class="px-6 sm:px-8 py-6 border-b border-white/10">
 				<div class="flex items-center justify-between gap-6">
 					<div class="flex items-start gap-3 min-w-0">
 						<div id="wsSidebarToggleCollapsedHost" class="hidden shrink-0"></div>
@@ -51,8 +51,8 @@
 				</aside>
 
 				<section class="flex-1 min-w-0">
-					<div class="overflow-x-hidden">
-						<table class="w-full table-fixed text-sm">
+					<div id="wsGridFrame" class="overflow-x-hidden">
+						<table id="wsGridTable" class="w-full table-fixed text-sm">
 							<thead class="text-white/50">
 								<tr class="border-b border-white/10">
 									<th class="px-2 sm:px-4 py-3 w-10"></th>


### PR DESCRIPTION
Closes #50 

# Summary
_Dropdown preview page vs right aligned window + title preview on hover_

# Changes
- Stayed modular by creating component files that are called from main files, files like grid.js only decide when to do things like display the title tooltip.
- But for the dropdown preview there is still a decent amount of logic in grid.js
- Multiple test casese can be expanded, open ones stored in an array (id)


**Sneakily added some heavier row separation** 