### PR TITLE
Bulk Edit Update, fixed status updates, case sensitive replace, preview and UI polish

### DIFF
--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated: 2026-04-01
+Last updated: 2026-04-02
 
 ## Summary
 
@@ -27,7 +27,7 @@ TestStream is a working Spring Boot and Thymeleaf application with core authenti
 - dedicated test case details page
 - duplicate upload conflict review flow with apply/cancel
 - bulk move endpoint and workspace flow
-- bulk edit backend and modal-driven workspace support
+- bulk edit backend and modal-driven workspace support with fixed status assignment, case-sensitive replacement, and Last updated refresh
 - stronger test coverage across auth, workspace, ingestion, export, and bulk features
 - GitHub Actions CI running tests against PostgreSQL
 
@@ -68,6 +68,7 @@ Current frontend shape:
 
 - the workspace page now uses feature-scoped JS modules under `src/main/resources/static/js/workspace`
 - the workspace template now composes fragments from `src/main/resources/templates/workspace`
+- workspace bulk edit now supports explicit field selection, fixed status changes, case-sensitive matching, and drawer preview access from the modal
 - workspace row preview now uses inline expandable rows in the grid (multi-expand), rather than opening from row actions into the right-side drawer
 - workspace preview UX now includes in-card collapse controls, a global `Collapse all previews` control, and selected-row/preview linked highlighting
 - workspace grid now includes truncation-aware title tooltips (hover/focus only when truncated)
@@ -106,7 +107,6 @@ This is a strength of the current project and should remain part of the definiti
 - oversized feature hotspots such as bulk edit logic and upload review orchestration
 - direct use of shared domain entities across multiple feature boundaries
 - `spring.jpa.hibernate.ddl-auto=update` plus startup schema adjustment is fast for iteration, but risky as production deployment matures
-- bulk edit rollout state is mid-refactor; the workspace page currently forces `bulkEditEnabled` in controller code
 
 ## Deployment State
 

--- a/src/main/java/com/formswim/teststream/bulk/controllers/BulkMutationController.java
+++ b/src/main/java/com/formswim/teststream/bulk/controllers/BulkMutationController.java
@@ -101,12 +101,16 @@ public class BulkMutationController {
             return ResponseEntity.badRequest().build();
         }
 
-        String findText = request.getFindText() == null ? "" : request.getFindText().trim();
-        if (findText.isBlank()) {
+        String normalizedFindText = normalizeTrimmed(request.getFindText());
+        String normalizedStatusValue = normalizeTrimmed(request.getStatusValue());
+        request.setFindText(normalizedFindText);
+        request.setStatusValue(normalizedStatusValue);
+
+        boolean hasTextOperation = !normalizedFindText.isBlank();
+        boolean hasStatusOperation = !normalizedStatusValue.isBlank();
+        if (!hasTextOperation && !hasStatusOperation) {
             return ResponseEntity.badRequest().build();
         }
-        // Use the normalized token for mutation so validation and execution are consistent.
-        request.setFindText(findText);
 
         try {
             BulkEditResult result = testCaseBulkEditService.bulkEditByWorkKeys(user.getTeamKey(), request);
@@ -114,6 +118,10 @@ public class BulkMutationController {
         } catch (IllegalArgumentException exception) {
             return ResponseEntity.badRequest().build();
         }
+    }
+
+    private String normalizeTrimmed(String value) {
+        return value == null ? "" : value.trim();
     }
 
 }

--- a/src/main/java/com/formswim/teststream/bulk/dto/BulkEditRequest.java
+++ b/src/main/java/com/formswim/teststream/bulk/dto/BulkEditRequest.java
@@ -1,6 +1,5 @@
 package com.formswim.teststream.bulk.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.ArrayList;
@@ -9,22 +8,24 @@ import java.util.List;
 /**
  * Request payload for PATCH /api/testcases/bulk-edit.
  *
- * <p>Callers provide a set of target test case work keys, literal text to find,
- * replacement text, and optional field selectors. If {@code fields} is omitted,
- * the service applies replacements to all supported editable text fields.</p>
+ * <p>Callers provide a set of target test case work keys, optional literal text to find,
+ * optional replacement text, optional field selectors, an optional case-sensitivity flag,
+ * and an optional status assignment value.</p>
  */
 public class BulkEditRequest {
 
     @NotNull(message = "workKeys is required")
     private List<String> workKeys = new ArrayList<>();
 
-    @NotBlank(message = "findText is required")
     private String findText;
 
-    @NotNull(message = "replaceText is required")
     private String replaceText;
 
     private List<String> fields = new ArrayList<>();
+
+    private Boolean caseSensitive;
+
+    private String statusValue;
 
     /**
      * Returns requested work keys as a non-null list.
@@ -80,5 +81,27 @@ public class BulkEditRequest {
      */
     public void setFields(List<String> fields) {
         this.fields = fields == null ? new ArrayList<>() : new ArrayList<>(fields);
+    }
+
+    /**
+     * Whether literal text replacement should match exact case.
+     */
+    public Boolean getCaseSensitive() {
+        return caseSensitive;
+    }
+
+    public void setCaseSensitive(Boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+    }
+
+    /**
+     * Optional status to apply directly to each selected test case.
+     */
+    public String getStatusValue() {
+        return statusValue;
+    }
+
+    public void setStatusValue(String statusValue) {
+        this.statusValue = statusValue;
     }
 }

--- a/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
+++ b/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -19,7 +20,7 @@ import java.util.Set;
 
 @Service
 /**
- * Service for large-scale exact text replacement across test cases and child steps.
+ * Service for bulk text replacement and fixed-status assignment across test cases and child steps.
  *
  * <p>The public mutation method is transactional so partial writes are rolled back
  * if any persistence error occurs during processing.</p>
@@ -29,12 +30,12 @@ public class TestCaseBulkEditService {
     private static final String FAILURE_INVALID = "INVALID_WORK_KEY";
     private static final String FAILURE_FORBIDDEN = "FORBIDDEN";
     private static final String FAILURE_NOT_FOUND = "NOT_FOUND";
+    private static final Set<String> ALLOWED_STATUS_VALUES = Set.of("Done", "Draft", "Pass", "Fail");
 
     private static final Set<String> SUPPORTED_FIELDS = Set.of(
         "summary",
         "description",
         "precondition",
-        "status",
         "priority",
         "assignee",
         "reporter",
@@ -49,7 +50,6 @@ public class TestCaseBulkEditService {
         "createdBy",
         "createdOn",
         "updatedBy",
-        "updatedOn",
         "storyLinkages",
         "isSharableStep",
         "flakyScore",
@@ -62,7 +62,6 @@ public class TestCaseBulkEditService {
         Map.entry("summary", "summary"),
         Map.entry("description", "description"),
         Map.entry("precondition", "precondition"),
-        Map.entry("status", "status"),
         Map.entry("priority", "priority"),
         Map.entry("assignee", "assignee"),
         Map.entry("reporter", "reporter"),
@@ -77,7 +76,6 @@ public class TestCaseBulkEditService {
         Map.entry("createdby", "createdBy"),
         Map.entry("createdon", "createdOn"),
         Map.entry("updatedby", "updatedBy"),
-        Map.entry("updatedon", "updatedOn"),
         Map.entry("storylinkages", "storyLinkages"),
         Map.entry("issharablestep", "isSharableStep"),
         Map.entry("flakyscore", "flakyScore"),
@@ -96,14 +94,14 @@ public class TestCaseBulkEditService {
     }
 
     /**
-     * Applies literal text replacement for a team-scoped set of work keys.
+     * Applies team-scoped text replacement and optional fixed-status assignment for work keys.
      *
      * <p>Processing flow:</p>
      * <ol>
      *     <li>Validate request size and normalize work keys.</li>
      *     <li>Classify non-owned/missing keys as failures.</li>
-     *     <li>Resolve and validate requested fields (including aliases).</li>
-     *     <li>Apply exact replacements to parent and child fields.</li>
+     *     <li>Resolve and validate requested text fields (including aliases).</li>
+     *     <li>Apply requested text replacements and status updates.</li>
      *     <li>Persist once; transaction rolls back if persistence fails.</li>
      * </ol>
      *
@@ -142,9 +140,12 @@ public class TestCaseBulkEditService {
             return result;
         }
 
-        Set<String> requestedFields = resolveRequestedFields(request.getFields());
         String findText = request.getFindText();
         String replaceText = request.getReplaceText();
+        boolean caseSensitive = request.getCaseSensitive() == null || request.getCaseSensitive();
+        String requestedStatusValue = normalizeStatusValue(request.getStatusValue());
+        boolean hasTextOperation = findText != null && !findText.isEmpty();
+        Set<String> requestedFields = hasTextOperation ? resolveRequestedFields(request.getFields()) : Set.of();
 
         List<String> normalizedWorkKeys = new ArrayList<>(normalizedUniqueWorkKeys);
         Set<String> ownedWorkKeys = new HashSet<>(testCaseRepository.findOwnedWorkKeysIn(teamKey, normalizedWorkKeys));
@@ -176,145 +177,147 @@ public class TestCaseBulkEditService {
         int updatedCaseCount = 0;
         int updatedStepCount = 0;
         int totalReplacements = 0;
+        String updatedOnValue = LocalDate.now().toString();
 
         for (TestCase testCase : cases) {
             boolean caseChanged = false;
+            boolean stepChanged = false;
 
-            ReplaceOutcome summaryOutcome = updateIfRequested(requestedFields.contains("summary"), testCase.getSummary(), findText, replaceText);
+            ReplaceOutcome summaryOutcome = updateIfRequested(requestedFields.contains("summary"), testCase.getSummary(), findText, replaceText, caseSensitive);
             testCase.setSummary(summaryOutcome.updatedValue());
             caseChanged = caseChanged || summaryOutcome.changed();
             totalReplacements += summaryOutcome.replacementCount();
 
-            ReplaceOutcome descriptionOutcome = updateIfRequested(requestedFields.contains("description"), testCase.getDescription(), findText, replaceText);
+            ReplaceOutcome descriptionOutcome = updateIfRequested(requestedFields.contains("description"), testCase.getDescription(), findText, replaceText, caseSensitive);
             testCase.setDescription(descriptionOutcome.updatedValue());
             caseChanged = caseChanged || descriptionOutcome.changed();
             totalReplacements += descriptionOutcome.replacementCount();
 
-            ReplaceOutcome preconditionOutcome = updateIfRequested(requestedFields.contains("precondition"), testCase.getPrecondition(), findText, replaceText);
+            ReplaceOutcome preconditionOutcome = updateIfRequested(requestedFields.contains("precondition"), testCase.getPrecondition(), findText, replaceText, caseSensitive);
             testCase.setPrecondition(preconditionOutcome.updatedValue());
             caseChanged = caseChanged || preconditionOutcome.changed();
             totalReplacements += preconditionOutcome.replacementCount();
 
-            ReplaceOutcome statusOutcome = updateIfRequested(requestedFields.contains("status"), testCase.getStatus(), findText, replaceText);
-            testCase.setStatus(statusOutcome.updatedValue());
-            caseChanged = caseChanged || statusOutcome.changed();
-            totalReplacements += statusOutcome.replacementCount();
-
-            ReplaceOutcome priorityOutcome = updateIfRequested(requestedFields.contains("priority"), testCase.getPriority(), findText, replaceText);
+            ReplaceOutcome priorityOutcome = updateIfRequested(requestedFields.contains("priority"), testCase.getPriority(), findText, replaceText, caseSensitive);
             testCase.setPriority(priorityOutcome.updatedValue());
             caseChanged = caseChanged || priorityOutcome.changed();
             totalReplacements += priorityOutcome.replacementCount();
 
-            ReplaceOutcome assigneeOutcome = updateIfRequested(requestedFields.contains("assignee"), testCase.getAssignee(), findText, replaceText);
+            ReplaceOutcome assigneeOutcome = updateIfRequested(requestedFields.contains("assignee"), testCase.getAssignee(), findText, replaceText, caseSensitive);
             testCase.setAssignee(assigneeOutcome.updatedValue());
             caseChanged = caseChanged || assigneeOutcome.changed();
             totalReplacements += assigneeOutcome.replacementCount();
 
-            ReplaceOutcome reporterOutcome = updateIfRequested(requestedFields.contains("reporter"), testCase.getReporter(), findText, replaceText);
+            ReplaceOutcome reporterOutcome = updateIfRequested(requestedFields.contains("reporter"), testCase.getReporter(), findText, replaceText, caseSensitive);
             testCase.setReporter(reporterOutcome.updatedValue());
             caseChanged = caseChanged || reporterOutcome.changed();
             totalReplacements += reporterOutcome.replacementCount();
 
-            ReplaceOutcome estimatedTimeOutcome = updateIfRequested(requestedFields.contains("estimatedTime"), testCase.getEstimatedTime(), findText, replaceText);
+            ReplaceOutcome estimatedTimeOutcome = updateIfRequested(requestedFields.contains("estimatedTime"), testCase.getEstimatedTime(), findText, replaceText, caseSensitive);
             testCase.setEstimatedTime(estimatedTimeOutcome.updatedValue());
             caseChanged = caseChanged || estimatedTimeOutcome.changed();
             totalReplacements += estimatedTimeOutcome.replacementCount();
 
-            ReplaceOutcome labelsOutcome = updateIfRequested(requestedFields.contains("labels"), testCase.getLabels(), findText, replaceText);
+            ReplaceOutcome labelsOutcome = updateIfRequested(requestedFields.contains("labels"), testCase.getLabels(), findText, replaceText, caseSensitive);
             testCase.setLabels(labelsOutcome.updatedValue());
             caseChanged = caseChanged || labelsOutcome.changed();
             totalReplacements += labelsOutcome.replacementCount();
 
-            ReplaceOutcome componentsOutcome = updateIfRequested(requestedFields.contains("components"), testCase.getComponents(), findText, replaceText);
+            ReplaceOutcome componentsOutcome = updateIfRequested(requestedFields.contains("components"), testCase.getComponents(), findText, replaceText, caseSensitive);
             testCase.setComponents(componentsOutcome.updatedValue());
             caseChanged = caseChanged || componentsOutcome.changed();
             totalReplacements += componentsOutcome.replacementCount();
 
-            ReplaceOutcome sprintOutcome = updateIfRequested(requestedFields.contains("sprint"), testCase.getSprint(), findText, replaceText);
+            ReplaceOutcome sprintOutcome = updateIfRequested(requestedFields.contains("sprint"), testCase.getSprint(), findText, replaceText, caseSensitive);
             testCase.setSprint(sprintOutcome.updatedValue());
             caseChanged = caseChanged || sprintOutcome.changed();
             totalReplacements += sprintOutcome.replacementCount();
 
-            ReplaceOutcome fixVersionsOutcome = updateIfRequested(requestedFields.contains("fixVersions"), testCase.getFixVersions(), findText, replaceText);
+            ReplaceOutcome fixVersionsOutcome = updateIfRequested(requestedFields.contains("fixVersions"), testCase.getFixVersions(), findText, replaceText, caseSensitive);
             testCase.setFixVersions(fixVersionsOutcome.updatedValue());
             caseChanged = caseChanged || fixVersionsOutcome.changed();
             totalReplacements += fixVersionsOutcome.replacementCount();
 
-            ReplaceOutcome versionOutcome = updateIfRequested(requestedFields.contains("version"), testCase.getVersion(), findText, replaceText);
+            ReplaceOutcome versionOutcome = updateIfRequested(requestedFields.contains("version"), testCase.getVersion(), findText, replaceText, caseSensitive);
             testCase.setVersion(versionOutcome.updatedValue());
             caseChanged = caseChanged || versionOutcome.changed();
             totalReplacements += versionOutcome.replacementCount();
 
-            ReplaceOutcome folderOutcome = updateIfRequested(requestedFields.contains("folder"), testCase.getFolder(), findText, replaceText);
+            ReplaceOutcome folderOutcome = updateIfRequested(requestedFields.contains("folder"), testCase.getFolder(), findText, replaceText, caseSensitive);
             testCase.setFolder(folderOutcome.updatedValue());
             caseChanged = caseChanged || folderOutcome.changed();
             totalReplacements += folderOutcome.replacementCount();
 
-            ReplaceOutcome testCaseTypeOutcome = updateIfRequested(requestedFields.contains("testCaseType"), testCase.getTestCaseType(), findText, replaceText);
+            ReplaceOutcome testCaseTypeOutcome = updateIfRequested(requestedFields.contains("testCaseType"), testCase.getTestCaseType(), findText, replaceText, caseSensitive);
             testCase.setTestCaseType(testCaseTypeOutcome.updatedValue());
             caseChanged = caseChanged || testCaseTypeOutcome.changed();
             totalReplacements += testCaseTypeOutcome.replacementCount();
 
-            ReplaceOutcome createdByOutcome = updateIfRequested(requestedFields.contains("createdBy"), testCase.getCreatedBy(), findText, replaceText);
+            ReplaceOutcome createdByOutcome = updateIfRequested(requestedFields.contains("createdBy"), testCase.getCreatedBy(), findText, replaceText, caseSensitive);
             testCase.setCreatedBy(createdByOutcome.updatedValue());
             caseChanged = caseChanged || createdByOutcome.changed();
             totalReplacements += createdByOutcome.replacementCount();
 
-            ReplaceOutcome createdOnOutcome = updateIfRequested(requestedFields.contains("createdOn"), testCase.getCreatedOn(), findText, replaceText);
+            ReplaceOutcome createdOnOutcome = updateIfRequested(requestedFields.contains("createdOn"), testCase.getCreatedOn(), findText, replaceText, caseSensitive);
             testCase.setCreatedOn(createdOnOutcome.updatedValue());
             caseChanged = caseChanged || createdOnOutcome.changed();
             totalReplacements += createdOnOutcome.replacementCount();
 
-            ReplaceOutcome updatedByOutcome = updateIfRequested(requestedFields.contains("updatedBy"), testCase.getUpdatedBy(), findText, replaceText);
+            ReplaceOutcome updatedByOutcome = updateIfRequested(requestedFields.contains("updatedBy"), testCase.getUpdatedBy(), findText, replaceText, caseSensitive);
             testCase.setUpdatedBy(updatedByOutcome.updatedValue());
             caseChanged = caseChanged || updatedByOutcome.changed();
             totalReplacements += updatedByOutcome.replacementCount();
 
-            ReplaceOutcome updatedOnOutcome = updateIfRequested(requestedFields.contains("updatedOn"), testCase.getUpdatedOn(), findText, replaceText);
-            testCase.setUpdatedOn(updatedOnOutcome.updatedValue());
-            caseChanged = caseChanged || updatedOnOutcome.changed();
-            totalReplacements += updatedOnOutcome.replacementCount();
-
-            ReplaceOutcome storyLinkagesOutcome = updateIfRequested(requestedFields.contains("storyLinkages"), testCase.getStoryLinkages(), findText, replaceText);
+            ReplaceOutcome storyLinkagesOutcome = updateIfRequested(requestedFields.contains("storyLinkages"), testCase.getStoryLinkages(), findText, replaceText, caseSensitive);
             testCase.setStoryLinkages(storyLinkagesOutcome.updatedValue());
             caseChanged = caseChanged || storyLinkagesOutcome.changed();
             totalReplacements += storyLinkagesOutcome.replacementCount();
 
-            ReplaceOutcome isSharableStepOutcome = updateIfRequested(requestedFields.contains("isSharableStep"), testCase.getIsSharableStep(), findText, replaceText);
+            ReplaceOutcome isSharableStepOutcome = updateIfRequested(requestedFields.contains("isSharableStep"), testCase.getIsSharableStep(), findText, replaceText, caseSensitive);
             testCase.setIsSharableStep(isSharableStepOutcome.updatedValue());
             caseChanged = caseChanged || isSharableStepOutcome.changed();
             totalReplacements += isSharableStepOutcome.replacementCount();
 
-            ReplaceOutcome flakyScoreOutcome = updateIfRequested(requestedFields.contains("flakyScore"), testCase.getFlakyScore(), findText, replaceText);
+            ReplaceOutcome flakyScoreOutcome = updateIfRequested(requestedFields.contains("flakyScore"), testCase.getFlakyScore(), findText, replaceText, caseSensitive);
             testCase.setFlakyScore(flakyScoreOutcome.updatedValue());
             caseChanged = caseChanged || flakyScoreOutcome.changed();
             totalReplacements += flakyScoreOutcome.replacementCount();
+
+            if (requestedStatusValue != null && !requestedStatusValue.equals(testCase.getStatus())) {
+                testCase.setStatus(requestedStatusValue);
+                caseChanged = true;
+            }
 
             if (caseChanged) {
                 updatedCaseCount++;
             }
 
             for (TestStep step : testCase.getSteps()) {
-                boolean stepChanged = false;
+                boolean currentStepChanged = false;
 
-                ReplaceOutcome stepSummaryOutcome = updateIfRequested(requestedFields.contains("stepSummary"), step.getStepSummary(), findText, replaceText);
+                ReplaceOutcome stepSummaryOutcome = updateIfRequested(requestedFields.contains("stepSummary"), step.getStepSummary(), findText, replaceText, caseSensitive);
                 step.setStepSummary(stepSummaryOutcome.updatedValue());
-                stepChanged = stepChanged || stepSummaryOutcome.changed();
+                currentStepChanged = currentStepChanged || stepSummaryOutcome.changed();
                 totalReplacements += stepSummaryOutcome.replacementCount();
 
-                ReplaceOutcome testDataOutcome = updateIfRequested(requestedFields.contains("testData"), step.getTestData(), findText, replaceText);
+                ReplaceOutcome testDataOutcome = updateIfRequested(requestedFields.contains("testData"), step.getTestData(), findText, replaceText, caseSensitive);
                 step.setTestData(testDataOutcome.updatedValue());
-                stepChanged = stepChanged || testDataOutcome.changed();
+                currentStepChanged = currentStepChanged || testDataOutcome.changed();
                 totalReplacements += testDataOutcome.replacementCount();
 
-                ReplaceOutcome expectedResultOutcome = updateIfRequested(requestedFields.contains("expectedResult"), step.getExpectedResult(), findText, replaceText);
+                ReplaceOutcome expectedResultOutcome = updateIfRequested(requestedFields.contains("expectedResult"), step.getExpectedResult(), findText, replaceText, caseSensitive);
                 step.setExpectedResult(expectedResultOutcome.updatedValue());
-                stepChanged = stepChanged || expectedResultOutcome.changed();
+                currentStepChanged = currentStepChanged || expectedResultOutcome.changed();
                 totalReplacements += expectedResultOutcome.replacementCount();
 
-                if (stepChanged) {
+                if (currentStepChanged) {
                     updatedStepCount++;
+                    stepChanged = true;
                 }
+            }
+
+            if (caseChanged || stepChanged) {
+                testCase.setUpdatedOn(updatedOnValue);
             }
         }
 
@@ -368,18 +371,22 @@ public class TestCaseBulkEditService {
     /**
      * Performs one literal replacement operation for a field when it is requested.
      */
-    private ReplaceOutcome updateIfRequested(boolean shouldEdit, String source, String findText, String replaceText) {
+    private ReplaceOutcome updateIfRequested(boolean shouldEdit, String source, String findText, String replaceText, boolean caseSensitive) {
         if (!shouldEdit || source == null || findText == null || findText.isEmpty()) {
             return new ReplaceOutcome(source, 0, false);
         }
 
-        int occurrences = countOccurrences(source, findText);
-        if (occurrences == 0) {
-            return new ReplaceOutcome(source, 0, false);
+        if (caseSensitive) {
+            int occurrences = countOccurrences(source, findText);
+            if (occurrences == 0) {
+                return new ReplaceOutcome(source, 0, false);
+            }
+
+            String updated = source.replace(findText, replaceText == null ? "" : replaceText);
+            return new ReplaceOutcome(updated, occurrences, true);
         }
 
-        String updated = source.replace(findText, replaceText == null ? "" : replaceText);
-        return new ReplaceOutcome(updated, occurrences, true);
+        return replaceLiteralIgnoreCase(source, findText, replaceText);
     }
 
     /**
@@ -400,6 +407,47 @@ public class TestCaseBulkEditService {
             count++;
             index = found + token.length();
         }
+    }
+
+    private ReplaceOutcome replaceLiteralIgnoreCase(String source, String findText, String replaceText) {
+        String needle = findText.toLowerCase(Locale.ROOT);
+        String haystack = source.toLowerCase(Locale.ROOT);
+        int searchIndex = 0;
+        int occurrences = 0;
+        int matchIndex;
+        String replacement = replaceText == null ? "" : replaceText;
+        StringBuilder builder = new StringBuilder(source.length());
+
+        while ((matchIndex = haystack.indexOf(needle, searchIndex)) >= 0) {
+            builder.append(source, searchIndex, matchIndex);
+            builder.append(replacement);
+            searchIndex = matchIndex + findText.length();
+            occurrences++;
+        }
+
+        if (occurrences == 0) {
+            return new ReplaceOutcome(source, 0, false);
+        }
+
+        builder.append(source, searchIndex, source.length());
+        return new ReplaceOutcome(builder.toString(), occurrences, true);
+    }
+
+    private String normalizeStatusValue(String rawStatusValue) {
+        if (rawStatusValue == null) {
+            return null;
+        }
+
+        String trimmed = rawStatusValue.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+
+        if (!ALLOWED_STATUS_VALUES.contains(trimmed)) {
+            throw new IllegalArgumentException("Unsupported status: " + trimmed);
+        }
+
+        return trimmed;
     }
 
     /**

--- a/src/main/resources/static/js/workspace/bulk-edit.js
+++ b/src/main/resources/static/js/workspace/bulk-edit.js
@@ -4,7 +4,6 @@ const CURATED_FIELDS = [
     { key: 'summary', label: 'Summary', description: 'Case title and headline text' },
     { key: 'description', label: 'Description', description: 'Main case description' },
     { key: 'precondition', label: 'Precondition', description: 'Required setup text' },
-    { key: 'status', label: 'Status', description: 'Case workflow status' },
     { key: 'priority', label: 'Priority', description: 'Case priority value' },
     { key: 'folder', label: 'Folder', description: 'Repository folder path' },
     { key: 'labels', label: 'Labels', description: 'Case labels and tags' },
@@ -29,14 +28,55 @@ function escapeHtml(value) {
         .replace(/"/g, '&quot;');
 }
 
-function buildHighlightedSnippet(text, token) {
+function findMatchIndex(source, needle, caseSensitive) {
+    const haystack = String(source || '');
+    const search = String(needle || '');
+    if (!haystack || !search) {
+        return -1;
+    }
+
+    if (caseSensitive) {
+        return haystack.indexOf(search);
+    }
+
+    return haystack.toLowerCase().indexOf(search.toLowerCase());
+}
+
+function findMatchSpans(source, needle, caseSensitive) {
+    const haystack = String(source || '');
+    const search = String(needle || '');
+    if (!haystack || !search) {
+        return [];
+    }
+
+    const spans = [];
+    const loweredHaystack = caseSensitive ? '' : haystack.toLowerCase();
+    const loweredNeedle = caseSensitive ? '' : search.toLowerCase();
+    let searchIndex = 0;
+
+    while (searchIndex < haystack.length) {
+        const matchIndex = caseSensitive
+            ? haystack.indexOf(search, searchIndex)
+            : loweredHaystack.indexOf(loweredNeedle, searchIndex);
+        if (matchIndex < 0) {
+            break;
+        }
+
+        spans.push({ start: matchIndex, end: matchIndex + search.length });
+        searchIndex = matchIndex + Math.max(search.length, 1);
+    }
+
+    return spans;
+}
+
+function buildHighlightedSnippet(text, token, caseSensitive) {
     const source = String(text || '');
     const needle = String(token || '');
     if (!source || !needle) {
         return escapeHtml(source);
     }
 
-    const matchIndex = source.indexOf(needle);
+    const matchIndex = findMatchIndex(source, needle, caseSensitive);
     if (matchIndex < 0) {
         return escapeHtml(source);
     }
@@ -57,7 +97,7 @@ function buildHighlightedSnippet(text, token) {
         + suffix;
 }
 
-function buildHighlightedHtml(text, token) {
+function buildHighlightedHtml(text, token, caseSensitive) {
     const source = String(text || '');
     const needle = String(token || '');
     if (!source) {
@@ -67,21 +107,21 @@ function buildHighlightedHtml(text, token) {
         return escapeHtml(source);
     }
 
+    const spans = findMatchSpans(source, needle, caseSensitive);
+    if (spans.length === 0) {
+        return escapeHtml(source);
+    }
+
     let html = '';
     let searchIndex = 0;
 
-    while (searchIndex < source.length) {
-        const matchIndex = source.indexOf(needle, searchIndex);
-        if (matchIndex < 0) {
-            html += escapeHtml(source.slice(searchIndex));
-            break;
-        }
-
-        html += escapeHtml(source.slice(searchIndex, matchIndex));
-        html += '<mark class="bg-[#E7FF02] text-black px-0.5">' + escapeHtml(needle) + '</mark>';
-        searchIndex = matchIndex + needle.length;
+    for (const span of spans) {
+        html += escapeHtml(source.slice(searchIndex, span.start));
+        html += '<mark class="bg-[#E7FF02] text-black px-0.5">' + escapeHtml(source.slice(span.start, span.end)) + '</mark>';
+        searchIndex = span.end;
     }
 
+    html += escapeHtml(source.slice(searchIndex));
     return html;
 }
 
@@ -112,7 +152,7 @@ function buildFieldValues(testCase, fieldKey) {
     }];
 }
 
-function buildCasePreviewRows(testCase, fieldKeys, findText, isExpanded) {
+function buildCasePreviewRows(testCase, fieldKeys, findText, isExpanded, caseSensitive) {
     const allRows = [];
     const matchingRows = [];
     const searchText = String(findText || '');
@@ -120,7 +160,7 @@ function buildCasePreviewRows(testCase, fieldKeys, findText, isExpanded) {
     for (const fieldKey of fieldKeys) {
         for (const row of buildFieldValues(testCase, fieldKey)) {
             allRows.push(row);
-            if (searchText && row.value.indexOf(searchText) >= 0) {
+            if (searchText && findMatchIndex(row.value, searchText, caseSensitive) >= 0) {
                 matchingRows.push(row);
             }
         }
@@ -131,8 +171,8 @@ function buildCasePreviewRows(testCase, fieldKeys, findText, isExpanded) {
     const visibleRows = sourceRows.map((row) => ({
         label: row.label,
         valueHtml: isExpanded
-            ? buildHighlightedHtml(row.value, searchText)
-            : (searchText ? buildHighlightedSnippet(row.value, searchText) : escapeHtml(row.value))
+            ? buildHighlightedHtml(row.value, searchText, caseSensitive)
+            : (searchText ? buildHighlightedSnippet(row.value, searchText, caseSensitive) : escapeHtml(row.value))
     }));
     const canToggleExpanded = allRows.length > sourceRows.length
         || (searchText && matchingRows.length > 0 && allRows.length > compactRows.length)
@@ -148,23 +188,42 @@ function buildCasePreviewRows(testCase, fieldKeys, findText, isExpanded) {
     };
 }
 
-function buildResultMessage(result) {
+function buildResultMessage(result, payload) {
     const updatedTargets = Number(result?.updatedCaseCount || 0) + Number(result?.updatedStepCount || 0);
     const replacements = Number(result?.totalReplacements || 0);
     const failureCount = Array.isArray(result?.failures) ? result.failures.length : 0;
+    const statusValue = String(payload?.statusValue || '').trim();
 
     if (replacements === 0 && updatedTargets === 0) {
+        if (statusValue) {
+            let message = 'No selected test cases needed a status change.';
+            if (failureCount > 0) {
+                message += ' ' + failureCount + ' selected item' + (failureCount === 1 ? ' was' : 's were') + ' skipped.';
+            }
+            return message;
+        }
         if (failureCount > 0) {
             return 'No matching text was replaced. Some selected test cases could not be edited.';
         }
         return 'No matching text was found in the selected fields.';
     }
 
-    let message = 'Applied ' + replacements + ' replacement' + (replacements === 1 ? '' : 's')
-        + ' across ' + Number(result?.updatedCaseCount || 0) + ' case'
-        + (Number(result?.updatedCaseCount || 0) === 1 ? '' : 's')
-        + ' and ' + Number(result?.updatedStepCount || 0) + ' step'
-        + (Number(result?.updatedStepCount || 0) === 1 ? '' : 's') + '.';
+    let message;
+    if (replacements === 0 && statusValue) {
+        message = 'Updated status on ' + Number(result?.updatedCaseCount || 0) + ' case'
+            + (Number(result?.updatedCaseCount || 0) === 1 ? '' : 's')
+            + ' to ' + statusValue + '.';
+    } else {
+        message = 'Applied ' + replacements + ' replacement' + (replacements === 1 ? '' : 's')
+            + ' across ' + Number(result?.updatedCaseCount || 0) + ' case'
+            + (Number(result?.updatedCaseCount || 0) === 1 ? '' : 's')
+            + ' and ' + Number(result?.updatedStepCount || 0) + ' step'
+            + (Number(result?.updatedStepCount || 0) === 1 ? '' : 's') + '.';
+
+        if (statusValue) {
+            message += ' Status set to ' + statusValue + '.';
+        }
+    }
 
     if (failureCount > 0) {
         message += ' ' + failureCount + ' selected item' + (failureCount === 1 ? ' was' : 's were') + ' skipped.';
@@ -192,13 +251,16 @@ export function createBulkEdit(options) {
     const applyButton = document.getElementById('bulkEditApply');
     const findInput = document.getElementById('bulkEditFindText');
     const replaceInput = document.getElementById('bulkEditReplaceText');
+    const caseSensitiveInput = document.getElementById('bulkEditCaseSensitive');
+    const statusSelect = document.getElementById('bulkEditStatusValue');
     const fieldsContainer = document.getElementById('bulkEditFields');
+    const toggleAllFieldsButton = document.getElementById('bulkEditToggleAllFields');
     const inlineError = document.getElementById('bulkEditInlineError');
     const previewInfo = document.getElementById('bulkEditPreviewInfo');
     const previewList = document.getElementById('bulkEditPreviewList');
     const selectedCount = document.getElementById('bulkEditSelectedCount');
 
-    if (!modal || !panel || !applyButton || !findInput || !replaceInput || !fieldsContainer || !previewInfo || !previewList || !selectedCount) {
+    if (!modal || !panel || !applyButton || !findInput || !replaceInput || !caseSensitiveInput || !statusSelect || !fieldsContainer || !toggleAllFieldsButton || !previewInfo || !previewList || !selectedCount) {
         return createNoopApi();
     }
 
@@ -239,13 +301,14 @@ export function createBulkEdit(options) {
             const label = document.createElement('label');
             label.className = 'flex items-start gap-3 rounded-lg border border-white/10 bg-zinc-800/70 px-3 py-3 text-sm text-white/85 hover:border-white/20 hover:bg-zinc-800';
             label.innerHTML =
-                '<input type="checkbox" class="bulk-edit-field h-4 w-4 mt-0.5 accent-[#E7FF02]" value="' + escapeHtml(field.key) + '" />' +
+                '<input type="checkbox" class="bulk-edit-field h-4 w-4 mt-0.5 accent-[#E7FF02]" value="' + escapeHtml(field.key) + '" checked />' +
                 '<span class="min-w-0">' +
                     '<span class="block text-white/92">' + escapeHtml(field.label) + '</span>' +
                     '<span class="block text-xs text-white/50 mt-1">' + escapeHtml(field.description) + '</span>' +
                 '</span>';
             fieldsContainer.appendChild(label);
         }
+        syncFieldToggleLabel();
     }
 
     function setInlineError(message) {
@@ -274,27 +337,69 @@ export function createBulkEdit(options) {
             .map((input) => String(input.value || '').trim())
             .filter(Boolean);
 
-        return checked.length > 0 ? checked : CURATED_FIELDS.map((field) => field.key);
+        return checked;
     }
 
-    function syncSelectedCount() {
+    function hasTextOperation() {
+        return String(findInput.value || '').trim().length > 0;
+    }
+
+    function hasStatusOperation() {
+        return String(statusSelect.value || '').trim().length > 0;
+    }
+
+    function canSubmitCurrentState() {
+        if (state.selectedIds.length === 0 || state.isSubmitting) {
+            return false;
+        }
+
+        const textRequested = hasTextOperation();
+        const statusRequested = hasStatusOperation();
+        if (!textRequested && !statusRequested) {
+            return false;
+        }
+
+        if (textRequested) {
+            return getFieldSelection().length > 0;
+        }
+
+        return statusRequested;
+    }
+
+    function syncFieldToggleLabel() {
+        const allChecked = Array.from(fieldsContainer.querySelectorAll('.bulk-edit-field')).every((input) => input.checked);
+        toggleAllFieldsButton.textContent = allChecked ? 'Deselect all' : 'Select all';
+    }
+
+    function syncActionState() {
         const count = state.selectedIds.length;
         selectedCount.textContent = count + ' selected on this page';
-        applyButton.disabled = state.isSubmitting || count === 0;
+        applyButton.disabled = !canSubmitCurrentState();
         applyButton.classList.toggle('opacity-60', applyButton.disabled);
         applyButton.classList.toggle('cursor-not-allowed', applyButton.disabled);
+        syncFieldToggleLabel();
+    }
+
+    function setAllFieldsChecked(checked) {
+        fieldsContainer.querySelectorAll('.bulk-edit-field').forEach((input) => {
+            input.checked = Boolean(checked);
+        });
+        syncFieldToggleLabel();
     }
 
     function setSubmitting(isSubmitting) {
         state.isSubmitting = Boolean(isSubmitting);
         const disabled = state.isSubmitting;
-        applyButton.disabled = disabled || state.selectedIds.length === 0;
+        applyButton.disabled = disabled || !canSubmitCurrentState();
         applyButton.textContent = disabled ? 'Applying...' : 'Apply';
         findInput.disabled = disabled;
         replaceInput.disabled = disabled;
+        caseSensitiveInput.disabled = disabled;
+        statusSelect.disabled = disabled;
         fieldsContainer.querySelectorAll('input').forEach((input) => {
             input.disabled = disabled;
         });
+        toggleAllFieldsButton.disabled = disabled;
         if (closeButton) {
             closeButton.disabled = disabled;
         }
@@ -324,6 +429,8 @@ export function createBulkEdit(options) {
             .filter(Boolean);
         const findText = String(findInput.value || '').trim();
         const fieldKeys = getFieldSelection();
+        const caseSensitive = Boolean(caseSensitiveInput.checked);
+        const statusValue = String(statusSelect.value || '').trim();
 
         if (selectedCases.length === 0) {
             previewInfo.textContent = 'Select test cases on the current page to preview the edit.';
@@ -331,21 +438,36 @@ export function createBulkEdit(options) {
             return;
         }
 
-        previewInfo.textContent = findText
-            ? 'Showing ' + selectedCases.length + ' selected case' + (selectedCases.length === 1 ? '' : 's') + ' on this page. Matching text is highlighted when found.'
-            : 'Showing ' + selectedCases.length + ' selected case' + (selectedCases.length === 1 ? '' : 's') + ' on this page. Enter find text to highlight exact matches.';
+        if (findText) {
+            previewInfo.textContent = 'Showing ' + selectedCases.length + ' selected case' + (selectedCases.length === 1 ? '' : 's')
+                + ' on this page. Matching text is highlighted with ' + (caseSensitive ? 'exact-case' : 'case-insensitive') + ' search.';
+        } else if (statusValue) {
+            previewInfo.textContent = 'Showing ' + selectedCases.length + ' selected case' + (selectedCases.length === 1 ? '' : 's')
+                + ' on this page. Previewing a status update to ' + statusValue + '.';
+        } else {
+            previewInfo.textContent = 'Showing ' + selectedCases.length + ' selected case' + (selectedCases.length === 1 ? '' : 's') + ' on this page. Enter find text or choose a status to preview changes.';
+        }
 
         previewList.innerHTML = selectedCases.map((testCase) => {
             const workKey = String(testCase.workKey || '');
             const isExpanded = state.expandedCaseIds.has(workKey);
-            const preview = buildCasePreviewRows(testCase, fieldKeys, findText, isExpanded);
+            const preview = buildCasePreviewRows(testCase, fieldKeys, findText, isExpanded, caseSensitive);
             let stateHtml = '';
 
             if (!preview.hasAnyContent) {
                 stateHtml = '<p class="mt-3 text-xs text-white/45">No content found in the targeted fields for this case.</p>';
             } else if (findText && !preview.hasMatch) {
-                stateHtml = '<p class="mt-3 text-xs text-white/50">No exact matches in the selected fields for this case.</p>';
+                stateHtml = '<p class="mt-3 text-xs text-white/50">No matches in the selected fields for this case.</p>';
             }
+
+            const currentStatus = String(testCase.status || '').trim();
+            const statusIntentHtml = statusValue
+                ? '<p class="mt-3 text-xs ' + (currentStatus === statusValue ? 'text-amber-200' : 'text-[#E7FF02]') + '">'
+                    + (currentStatus === statusValue
+                        ? 'Status will remain ' + escapeHtml(statusValue) + '.'
+                        : 'Status will change from ' + escapeHtml(currentStatus || 'unset') + ' to ' + escapeHtml(statusValue) + '.')
+                + '</p>'
+                : '';
 
             const rowsHtml = preview.rows.map((row) =>
                 '<div class="mt-2 rounded-lg border border-zinc-700/80 bg-zinc-800/85 px-3 py-3">'
@@ -364,7 +486,7 @@ export function createBulkEdit(options) {
                 + '</button>'
                 : '';
             const previewButtonHtml = workKey
-                ? '<button type="button" class="px-3 py-2 border border-white/15 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs text-white/70" data-action="open-case-preview" data-work-key="' + escapeHtml(workKey) + '">Open full case</button>'
+                ? '<button type="button" class="px-3 py-2 border border-white/15 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs text-white/70" data-action="open-case-preview" data-work-key="' + escapeHtml(workKey) + '">Preview in Drawer</button>'
                 : '';
 
             return '<article class="rounded-xl border border-zinc-700/80 bg-zinc-900/85 px-4 py-4">'
@@ -379,6 +501,7 @@ export function createBulkEdit(options) {
                     + '</div>'
                 + '</div>'
                 + stateHtml
+                + statusIntentHtml
                 + rowsHtml
                 + hiddenHtml
             + '</article>';
@@ -388,7 +511,10 @@ export function createBulkEdit(options) {
     function open() {
         state.selectedIds = getSelectedIds();
         state.expandedCaseIds.clear();
-        syncSelectedCount();
+        setAllFieldsChecked(true);
+        caseSensitiveInput.checked = true;
+        statusSelect.value = '';
+        syncActionState();
 
         if (state.selectedIds.length === 0) {
             if (typeof config.showNotice === 'function') {
@@ -427,27 +553,35 @@ export function createBulkEdit(options) {
     }
 
     function buildPayload() {
-        const workKeys = state.selectedIds.slice();
         const findText = String(findInput.value || '').trim();
         const replaceText = String(replaceInput.value || '');
+        const statusValue = String(statusSelect.value || '').trim();
         const fields = getFieldSelection();
+        const caseSensitive = Boolean(caseSensitiveInput.checked);
 
-        if (workKeys.length === 0) {
+        if (state.selectedIds.length === 0) {
             setInlineError('Select at least one test case on this page before applying a bulk edit.');
             return null;
         }
 
-        if (!findText) {
-            setInlineError('Find text is required.');
+        if (!findText && !statusValue) {
+            setInlineError('Choose a status or enter find text before applying a bulk edit.');
+            return null;
+        }
+
+        if (findText && fields.length === 0) {
+            setInlineError('Select at least one text field when using find and replace.');
             return null;
         }
 
         setInlineError('');
         return {
-            workKeys,
-            findText,
-            replaceText,
-            fields
+            workKeys: state.selectedIds.slice(),
+            findText: findText,
+            replaceText: findText ? replaceText : '',
+            fields: findText ? fields : [],
+            caseSensitive,
+            statusValue
         };
     }
 
@@ -489,7 +623,7 @@ export function createBulkEdit(options) {
             }
 
             const result = await response.json();
-            const message = buildResultMessage(result);
+            const message = buildResultMessage(result, payload);
             const didChange = Number(result?.totalReplacements || 0) > 0 || Number(result?.updatedCaseCount || 0) > 0 || Number(result?.updatedStepCount || 0) > 0;
 
             if (typeof config.showNotice === 'function') {
@@ -512,7 +646,7 @@ export function createBulkEdit(options) {
             }
         } finally {
             setSubmitting(false);
-            syncSelectedCount();
+            syncActionState();
             if (state.isOpen) {
                 renderPreview();
             }
@@ -527,14 +661,15 @@ export function createBulkEdit(options) {
                 state.expandedCaseIds.delete(workKey);
             }
         }
-        syncSelectedCount();
+        syncActionState();
         if (state.isOpen) {
             renderPreview();
         }
     }
 
     renderFieldOptions();
-    syncSelectedCount();
+    setAllFieldsChecked(true);
+    syncActionState();
 
     if (bulkEditButton) {
         bulkEditButton.addEventListener('click', open);
@@ -552,15 +687,38 @@ export function createBulkEdit(options) {
     findInput.addEventListener('input', () => {
         setInlineError('');
         if (state.isOpen) {
+            syncActionState();
             renderPreview();
         }
     });
     replaceInput.addEventListener('input', () => {
         if (state.isOpen) {
+            syncActionState();
+            renderPreview();
+        }
+    });
+    caseSensitiveInput.addEventListener('change', () => {
+        if (state.isOpen) {
+            syncActionState();
+            renderPreview();
+        }
+    });
+    statusSelect.addEventListener('change', () => {
+        if (state.isOpen) {
+            syncActionState();
             renderPreview();
         }
     });
     fieldsContainer.addEventListener('change', () => {
+        syncActionState();
+        if (state.isOpen) {
+            renderPreview();
+        }
+    });
+    toggleAllFieldsButton.addEventListener('click', () => {
+        const allChecked = Array.from(fieldsContainer.querySelectorAll('.bulk-edit-field')).every((input) => input.checked);
+        setAllFieldsChecked(!allChecked);
+        syncActionState();
         if (state.isOpen) {
             renderPreview();
         }

--- a/src/main/resources/static/js/workspace/bulk-edit.js
+++ b/src/main/resources/static/js/workspace/bulk-edit.js
@@ -453,8 +453,9 @@ export function createBulkEdit(options) {
             const isExpanded = state.expandedCaseIds.has(workKey);
             const preview = buildCasePreviewRows(testCase, fieldKeys, findText, isExpanded, caseSensitive);
             let stateHtml = '';
+            const hasStatusIntent = Boolean(statusValue);
 
-            if (!preview.hasAnyContent) {
+            if (!preview.hasAnyContent && !hasStatusIntent) {
                 stateHtml = '<p class="mt-3 text-xs text-white/45">No content found in the targeted fields for this case.</p>';
             } else if (findText && !preview.hasMatch) {
                 stateHtml = '<p class="mt-3 text-xs text-white/50">No matches in the selected fields for this case.</p>';
@@ -511,6 +512,8 @@ export function createBulkEdit(options) {
     function open() {
         state.selectedIds = getSelectedIds();
         state.expandedCaseIds.clear();
+        findInput.value = '';
+        replaceInput.value = '';
         setAllFieldsChecked(true);
         caseSensitiveInput.checked = true;
         statusSelect.value = '';
@@ -606,7 +609,7 @@ export function createBulkEdit(options) {
             if (!response.ok) {
                 let message = 'Bulk edit failed. Please try again.';
                 if (response.status === 400) {
-                    message = 'Bulk edit request was invalid. Check the selected fields and search text.';
+                    message = 'Bulk edit request was invalid. Check the selected fields, search text, and status selection.';
                 } else if (response.status === 401) {
                     message = 'You must be logged in to bulk edit test cases.';
                 } else if (response.status === 403) {

--- a/src/main/resources/templates/workspace-bulk-edit-modal.html
+++ b/src/main/resources/templates/workspace-bulk-edit-modal.html
@@ -9,8 +9,8 @@
 					<div class="flex items-start justify-between gap-4">
 						<div class="min-w-0">
 							<p class="text-[11px] uppercase tracking-[0.18em] text-[#E7FF02]/80" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Bulk Edit</p>
-							<h3 class="text-xl font-semibold text-white mt-2 leading-tight">Search &amp; replace selected test cases</h3>
-							<p class="text-xs text-white/55 mt-2">Apply one exact text replacement across selected cases on the current page.</p>
+							<h3 class="text-xl font-semibold text-white mt-2 leading-tight">Search, replace, or set status</h3>
+							<p class="text-xs text-white/55 mt-2">Apply exact text replacements or a fixed status update across selected cases on the current page.</p>
 						</div>
 						<button id="bulkEditClose" type="button" class="px-3 py-2 border border-white/25 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs uppercase tracking-wider text-white/70">
 							Close
@@ -30,18 +30,44 @@
 								</div>
 							</div>
 
+							<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+								<label class="flex items-start gap-3 rounded-lg border border-zinc-700/80 bg-zinc-800/70 px-4 py-3 text-sm text-white/85">
+									<input id="bulkEditCaseSensitive" type="checkbox" checked class="mt-1 h-4 w-4 accent-[#E7FF02]" />
+									<span class="min-w-0">
+										<span class="block text-white/92">Case sensitive</span>
+										<span class="block text-xs text-white/50 mt-1">Match the exact casing of the find text.</span>
+									</span>
+								</label>
+
+								<div>
+									<label for="bulkEditStatusValue" class="block text-[11px] uppercase tracking-[0.14em] text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Set status</label>
+									<select id="bulkEditStatusValue" class="mt-2 w-full border border-zinc-600 bg-zinc-800/95 px-4 py-3.5 text-sm text-white/90 focus:outline-none focus:border-[#E7FF02] focus:ring-2 focus:ring-[#E7FF02]/20">
+										<option value="">Keep current</option>
+										<option value="Done">Done</option>
+										<option value="Draft">Draft</option>
+										<option value="Pass">Pass</option>
+										<option value="Fail">Fail</option>
+									</select>
+								</div>
+							</div>
+
 							<div>
 								<div class="flex items-center justify-between gap-3">
 									<div>
 										<p class="text-[11px] uppercase tracking-[0.14em] text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Fields</p>
-										<p class="text-xs text-white/45 mt-2">Leave all unchecked to target the full curated phase-1 field set.</p>
 									</div>
-									<p id="bulkEditSelectedCount" class="text-xs text-white/55">0 selected</p>
+									<div class="flex items-center gap-3">
+										<p id="bulkEditSelectedCount" class="text-xs text-white/55">0 selected</p>
+										<button id="bulkEditToggleAllFields" type="button" class="px-3 py-2 border border-white/15 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs text-white/70">
+											Deselect all
+										</button>
+									</div>
 								</div>
+								<p class="text-xs text-white/45 mt-2">Bulk edit applies only to checked text fields. Status changes use the dropdown above.</p>
 								<div id="bulkEditFields" class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2"></div>
 							</div>
 
-							<p id="bulkEditInlineError" class="hidden text-xs text-rose-300" aria-live="polite">A search term is required.</p>
+							<p id="bulkEditInlineError" class="hidden text-xs text-rose-300" aria-live="polite">Choose a status or enter find text.</p>
 						</section>
 
 						<section class="flex min-h-0 flex-col border border-zinc-700/70 bg-zinc-800/60 p-4 sm:p-5">

--- a/src/test/java/com/formswim/teststream/bulk/BulkEditIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/bulk/BulkEditIntegrationTests.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -110,9 +111,125 @@ class BulkEditIntegrationTests {
         assertThat(edited.getDescription()).isEqualTo("Description has Click but should stay unchanged when field is excluded.");
         assertThat(edited.getSteps().get(0).getStepSummary()).isEqualTo("Tap submit");
         assertThat(edited.getSteps().get(0).getExpectedResult()).isEqualTo("Click confirmation appears");
+        assertThat(edited.getUpdatedOn()).isEqualTo(LocalDate.now().toString());
 
         assertThat(untouchedSameTeam.getSummary()).isEqualTo("Click in second case");
         assertThat(untouchedOtherTeam.getSummary()).isEqualTo("Click from another team");
+    }
+
+    @Test
+    void bulkEditSupportsStatusOnlyMutationsAndRefreshesUpdatedOn() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("statusValue", "Pass");
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.requestedCount").value(1))
+            .andExpect(jsonPath("$.candidateCount").value(1))
+            .andExpect(jsonPath("$.updatedCaseCount").value(1))
+            .andExpect(jsonPath("$.updatedStepCount").value(0))
+            .andExpect(jsonPath("$.totalReplacements").value(0));
+
+        TestCase edited = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn("TEAM1", List.of("TC-101")).get(0);
+        assertThat(edited.getStatus()).isEqualTo("Pass");
+        assertThat(edited.getUpdatedOn()).isEqualTo(LocalDate.now().toString());
+        assertThat(edited.getSummary()).isEqualTo("Please Click the button. Click once.");
+    }
+
+    @Test
+    void bulkEditRejectsInvalidFixedStatusValues() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("statusValue", "Open");
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isBadRequest());
+
+        TestCase untouched = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn("TEAM1", List.of("TC-101")).get(0);
+        assertThat(untouched.getStatus()).isEqualTo("Draft");
+        assertThat(untouched.getUpdatedOn()).isEqualTo("2026-03-18");
+    }
+
+    @Test
+    void bulkEditDefaultsToCaseSensitiveReplacement() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "click");
+        payload.put("replaceText", "Tap");
+        payload.put("fields", List.of("summary"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(0))
+            .andExpect(jsonPath("$.updatedStepCount").value(0))
+            .andExpect(jsonPath("$.totalReplacements").value(0));
+
+        TestCase untouched = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn("TEAM1", List.of("TC-101")).get(0);
+        assertThat(untouched.getSummary()).isEqualTo("Please Click the button. Click once.");
+        assertThat(untouched.getUpdatedOn()).isEqualTo("2026-03-18");
+    }
+
+    @Test
+    void bulkEditCanIgnoreCaseWhenRequested() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "click");
+        payload.put("replaceText", "Tap");
+        payload.put("fields", List.of("summary", "stepSummary"));
+        payload.put("caseSensitive", false);
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1))
+            .andExpect(jsonPath("$.updatedStepCount").value(1))
+            .andExpect(jsonPath("$.totalReplacements").value(3));
+
+        TestCase edited = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn("TEAM1", List.of("TC-101")).get(0);
+        assertThat(edited.getSummary()).isEqualTo("Please Tap the button. Tap once.");
+        assertThat(edited.getSteps().get(0).getStepSummary()).isEqualTo("Tap submit");
+        assertThat(edited.getUpdatedOn()).isEqualTo(LocalDate.now().toString());
+    }
+
+    @Test
+    void bulkEditCanCombineTextReplacementAndStatusAssignment() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "Click");
+        payload.put("replaceText", "Tap");
+        payload.put("fields", List.of("summary", "stepSummary"));
+        payload.put("statusValue", "Fail");
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1))
+            .andExpect(jsonPath("$.updatedStepCount").value(1))
+            .andExpect(jsonPath("$.totalReplacements").value(3));
+
+        TestCase edited = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn("TEAM1", List.of("TC-101")).get(0);
+        assertThat(edited.getSummary()).isEqualTo("Please Tap the button. Tap once.");
+        assertThat(edited.getStatus()).isEqualTo("Fail");
+        assertThat(edited.getUpdatedOn()).isEqualTo(LocalDate.now().toString());
     }
 
     @Test
@@ -161,6 +278,35 @@ class BulkEditIntegrationTests {
     }
 
     @Test
+    void bulkEditReturnsBadRequestWhenRequestHasNoTextOrStatusOperation() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("replaceText", "Tap");
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void bulkEditReturnsBadRequestWhenPayloadHasNoTextOrStatusOperation() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "   ");
+        payload.put("statusValue", "   ");
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void bulkEditReturnsBadRequestWhenWorkKeyCountExceedsLimit() throws Exception {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("workKeys", List.of("K-1", "K-2", "K-3", "K-4", "K-5", "K-6", "K-7", "K-8", "K-9", "K-10", "K-11"));
@@ -197,6 +343,7 @@ class BulkEditIntegrationTests {
         assertThat(edited.getSummary()).isEqualTo("Please Click the button. Click once.");
         assertThat(edited.getSteps().get(0).getStepSummary()).isEqualTo("Tap submit");
         assertThat(edited.getSteps().get(0).getExpectedResult()).isEqualTo("Tap confirmation appears");
+        assertThat(edited.getUpdatedOn()).isEqualTo(LocalDate.now().toString());
     }
 
     @Test
@@ -243,6 +390,45 @@ class BulkEditIntegrationTests {
     }
 
     @Test
+    void bulkEditRejectsLegacyStatusTextFieldAndDoesNotMutate() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "Draft");
+        payload.put("replaceText", "Pass");
+        payload.put("fields", List.of("status"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isBadRequest());
+
+        TestCase untouched = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101").orElseThrow();
+        assertThat(untouched.getStatus()).isEqualTo("Draft");
+        assertThat(untouched.getUpdatedOn()).isEqualTo("2026-03-18");
+    }
+
+    @Test
+    void bulkEditRejectsSystemManagedUpdatedOnFieldAndDoesNotMutate() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "2026");
+        payload.put("replaceText", "2025");
+        payload.put("fields", List.of("updated_on"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isBadRequest());
+
+        TestCase untouched = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101").orElseThrow();
+        assertThat(untouched.getUpdatedOn()).isEqualTo("2026-03-18");
+    }
+
+    @Test
     void bulkEditRollsBackAllChangesWhenSaveFailsMidOperation() throws Exception {
         String oversizedReplacement = "X".repeat(300);
 
@@ -266,5 +452,7 @@ class BulkEditIntegrationTests {
 
         assertThat(first.getAssignee()).isEqualTo("Assignee");
         assertThat(second.getAssignee()).isEqualTo("Assignee");
+        assertThat(first.getUpdatedOn()).isEqualTo("2026-03-18");
+        assertThat(second.getUpdatedOn()).isEqualTo("2026-03-18");
     }
 }

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFilteringIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFilteringIntegrationTests.java
@@ -170,6 +170,10 @@ class WorkspaceFilteringIntegrationTests {
             .andExpect(content().string(containsString("id=\"bulkEditOpen\"")))
             .andExpect(content().string(containsString("id=\"bulkOrganize\"")))
             .andExpect(content().string(containsString("id=\"bulkEditModal\"")))
+            .andExpect(content().string(containsString("id=\"bulkEditCaseSensitive\"")))
+            .andExpect(content().string(containsString("id=\"bulkEditStatusValue\"")))
+            .andExpect(content().string(containsString("id=\"bulkEditToggleAllFields\"")))
+            .andExpect(content().string(containsString("Search, replace, or set status")))
             .andExpect(content().string(containsString("id=\"organizeModal\"")))
             .andExpect(content().string(containsString("id=\"drawer\"")))
             .andExpect(content().string(containsString("id=\"workspaceAccountToggle\"")));

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFilteringIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFilteringIntegrationTests.java
@@ -174,6 +174,8 @@ class WorkspaceFilteringIntegrationTests {
             .andExpect(content().string(containsString("id=\"bulkEditStatusValue\"")))
             .andExpect(content().string(containsString("id=\"bulkEditToggleAllFields\"")))
             .andExpect(content().string(containsString("Search, replace, or set status")))
+            .andExpect(content().string(containsString("<option value=\"Done\">Done</option>")))
+            .andExpect(content().string(containsString("<option value=\"Fail\">Fail</option>")))
             .andExpect(content().string(containsString("id=\"organizeModal\"")))
             .andExpect(content().string(containsString("id=\"drawer\"")))
             .andExpect(content().string(containsString("id=\"workspaceAccountToggle\"")));


### PR DESCRIPTION
Summary
This PR refined the bulk edit across backend, workspace UI, tests, and project context.

Bulk edit now supports:

fixed status assignment with Done, Draft, Pass, and Fail
optional case-sensitive or case-insensitive literal text replacement
automatic Last updated / updatedOn refresh when a bulk edit changes a case
clearer modal controls and preview behavior

Expanded the integration tests, and ensured no other features are broken. Changes were made to both backend and frontend. 
