### PR TITLE
Improve workspace row selection with shift click

### DIFF
--- a/src/main/resources/static/js/workspace/features/workspace-row-actions.js
+++ b/src/main/resources/static/js/workspace/features/workspace-row-actions.js
@@ -2,6 +2,30 @@ function isInteractiveTarget(target) {
     return Boolean(target?.closest?.('.ws-interactive, a, button, input, select, textarea, label'));
 }
 
+function clearBrowserTextSelection() {
+    if (typeof window === 'undefined' || typeof window.getSelection !== 'function') {
+        return;
+    }
+
+    const selection = window.getSelection();
+    if (selection && typeof selection.removeAllRanges === 'function') {
+        selection.removeAllRanges();
+    }
+}
+
+function isModifierToggle(event) {
+    return Boolean(event?.ctrlKey || event?.metaKey);
+}
+
+function syncCheckboxElement(selection, checkbox) {
+    if (!checkbox) {
+        return;
+    }
+
+    const workKey = checkbox.dataset.workKey || '';
+    checkbox.checked = selection.isSelected(workKey);
+}
+
 export function bindWorkspaceRowActions(options) {
     const tbody = options.tbody;
     const selection = options.selection;
@@ -21,6 +45,11 @@ export function bindWorkspaceRowActions(options) {
             const workKey = row.dataset.workKey || '';
             const isSelected = selection.isSelected(workKey);
             row.classList.toggle('ws-row-selected', isSelected);
+
+            const checkbox = row.querySelector('.ws-row-check');
+            if (checkbox) {
+                checkbox.checked = isSelected;
+            }
         });
 
         const previewCards = tbody.querySelectorAll('[data-preview-card-for]');
@@ -37,15 +66,82 @@ export function bindWorkspaceRowActions(options) {
         });
     }
 
+    function applyRowSelection(workKey, event) {
+        if (!workKey) {
+            return;
+        }
+
+        const hasShift = Boolean(event?.shiftKey);
+        const hasModifier = isModifierToggle(event);
+        const anchor = selection.getSelectionAnchor();
+        const isAlreadySelected = selection.isSelected(workKey);
+        const selectedCount = selection.getSelectedIds().length;
+
+        if (hasShift && anchor) {
+            selection.selectRange(anchor, workKey);
+            syncRowSelectionUi();
+            return;
+        }
+
+        if (hasShift) {
+            selection.selectOnly(workKey);
+            syncRowSelectionUi();
+            return;
+        }
+
+        if (hasModifier) {
+            selection.toggleSingle(workKey);
+            syncRowSelectionUi();
+            return;
+        }
+
+        if (isAlreadySelected && selectedCount === 1) {
+            selection.clearSelection();
+            syncRowSelectionUi();
+            return;
+        }
+
+        selection.selectOnly(workKey);
+        syncRowSelectionUi();
+    }
+
     if (tbody) {
-        tbody.addEventListener('change', (event) => {
-            const target = event.target;
-            if (!target || !target.classList || !target.classList.contains('ws-row-check')) {
+        tbody.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) {
                 return;
             }
 
-            selection.toggleSelection(target.dataset.workKey || '', target.checked);
-            syncRowSelectionUi();
+            const row = event.target?.closest?.('tr[data-work-key]');
+            if (!row) {
+                return;
+            }
+
+            const isCheckbox = Boolean(event.target?.closest?.('.ws-row-check'));
+            if (isCheckbox) {
+                return;
+            }
+
+            if (isInteractiveTarget(event.target)) {
+                return;
+            }
+
+            event.preventDefault();
+            clearBrowserTextSelection();
+        });
+
+        tbody.addEventListener('change', (event) => {
+            const checkbox = event.target?.closest?.('.ws-row-check');
+            if (!checkbox) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            syncCheckboxElement(selection, checkbox);
+            window.requestAnimationFrame(() => {
+                syncCheckboxElement(selection, checkbox);
+                syncRowSelectionUi();
+            });
         });
 
         tbody.addEventListener('click', (event) => {
@@ -93,6 +189,20 @@ export function bindWorkspaceRowActions(options) {
                 return;
             }
 
+            const checkbox = event.target?.closest?.('.ws-row-check');
+            if (checkbox) {
+                event.preventDefault();
+                event.stopPropagation();
+                clearBrowserTextSelection();
+                applyRowSelection(checkbox.dataset.workKey || '', event);
+                syncCheckboxElement(selection, checkbox);
+                window.requestAnimationFrame(() => {
+                    syncCheckboxElement(selection, checkbox);
+                    syncRowSelectionUi();
+                });
+                return;
+            }
+
             if (isInteractiveTarget(event.target)) {
                 return;
             }
@@ -102,19 +212,8 @@ export function bindWorkspaceRowActions(options) {
                 return;
             }
 
-            const workKey = row.dataset.workKey || '';
-            if (!workKey) {
-                return;
-            }
-
-            const nextChecked = !selection.isSelected(workKey);
-            selection.setSelected(workKey, nextChecked);
-
-            const check = row.querySelector('.ws-row-check');
-            if (check) {
-                check.checked = nextChecked;
-            }
-            syncRowSelectionUi();
+            clearBrowserTextSelection();
+            applyRowSelection(row.dataset.workKey || '', event);
         });
     }
 

--- a/src/main/resources/static/js/workspace/features/workspace-row-actions.js
+++ b/src/main/resources/static/js/workspace/features/workspace-row-actions.js
@@ -13,10 +13,6 @@ function clearBrowserTextSelection() {
     }
 }
 
-function isModifierToggle(event) {
-    return Boolean(event?.ctrlKey || event?.metaKey);
-}
-
 function syncCheckboxElement(selection, checkbox) {
     if (!checkbox) {
         return;
@@ -72,36 +68,22 @@ export function bindWorkspaceRowActions(options) {
         }
 
         const hasShift = Boolean(event?.shiftKey);
-        const hasModifier = isModifierToggle(event);
-        const anchor = selection.getSelectionAnchor();
-        const isAlreadySelected = selection.isSelected(workKey);
         const selectedCount = selection.getSelectedIds().length;
 
-        if (hasShift && anchor) {
-            selection.selectRange(anchor, workKey);
-            syncRowSelectionUi();
-            return;
-        }
-
         if (hasShift) {
-            selection.selectOnly(workKey);
-            syncRowSelectionUi();
-            return;
+            const anchor = selectedCount === 0
+                ? selection.getFirstVisibleId()
+                : (selection.getSelectionAnchor() || selection.getFirstVisibleId());
+
+            if (anchor) {
+                selection.selectRange(anchor, workKey);
+                syncRowSelectionUi();
+                return;
+            }
         }
 
-        if (hasModifier) {
-            selection.toggleSingle(workKey);
-            syncRowSelectionUi();
-            return;
-        }
-
-        if (isAlreadySelected && selectedCount === 1) {
-            selection.clearSelection();
-            syncRowSelectionUi();
-            return;
-        }
-
-        selection.selectOnly(workKey);
+        selection.toggleSingle(workKey);
+        selection.setSelectionAnchor(workKey);
         syncRowSelectionUi();
     }
 

--- a/src/main/resources/static/js/workspace/page.js
+++ b/src/main/resources/static/js/workspace/page.js
@@ -109,6 +109,8 @@ const drawer = createDrawer({
     getTestCaseById: grid.getTestCaseById
 });
 
+const bulkDeselectAll = document.getElementById('bulkDeselectAll');
+
 let syncRowSelectionUi = () => {};
 let importController = {
     clearNotice() {},
@@ -304,3 +306,10 @@ if (nextPageButton) {
 dataController.loadCurrentPage();
 dataController.loadFilterOptions();
 folderTreeController.loadFolders();
+
+
+if (bulkDeselectAll) {
+    bulkDeselectAll.addEventListener('click', () => {
+        selection.clearSelection();
+    });
+}

--- a/src/main/resources/static/js/workspace/selection.js
+++ b/src/main/resources/static/js/workspace/selection.js
@@ -1,6 +1,7 @@
 export function createSelection(selectAll, bulkBar, bulkCount) {
     const selectedIds = new Set();
     let visibleIds = [];
+    let selectionAnchor = null;
     let onSelectionChange = null;
 
     function setSelectionChangeHandler(handler) {
@@ -9,6 +10,24 @@ export function createSelection(selectAll, bulkBar, bulkCount) {
 
     function setVisibleIds(ids) {
         visibleIds = Array.isArray(ids) ? ids.slice() : [];
+
+        if (selectionAnchor && !visibleIds.includes(selectionAnchor)) {
+            selectionAnchor = null;
+        }
+
+        syncMasterCheckbox();
+        updateBulkBar();
+    }
+
+    function setSelectionAnchor(workKey) {
+        selectionAnchor = workKey ? String(workKey) : null;
+    }
+
+    function getSelectionAnchor() {
+        return selectionAnchor;
+    }
+
+    function updateSelectionState() {
         syncMasterCheckbox();
         updateBulkBar();
     }
@@ -24,8 +43,40 @@ export function createSelection(selectAll, bulkBar, bulkCount) {
             selectedIds.delete(workKey);
         }
 
-        syncMasterCheckbox();
-        updateBulkBar();
+        updateSelectionState();
+    }
+
+    function toggleSingle(workKey) {
+        if (!workKey) {
+            return;
+        }
+
+        if (selectedIds.has(workKey)) {
+            selectedIds.delete(workKey);
+        } else {
+            selectedIds.add(workKey);
+        }
+
+        setSelectionAnchor(workKey);
+        updateSelectionState();
+    }
+
+    function selectOnly(workKey) {
+        if (!workKey) {
+            clearSelection();
+            return;
+        }
+
+        selectedIds.clear();
+        selectedIds.add(workKey);
+        setSelectionAnchor(workKey);
+        updateSelectionState();
+    }
+
+    function clearSelection() {
+        selectedIds.clear();
+        selectionAnchor = null;
+        updateSelectionState();
     }
 
     function isSelected(workKey) {
@@ -38,6 +89,35 @@ export function createSelection(selectAll, bulkBar, bulkCount) {
 
     function setSelected(workKey, shouldBeSelected) {
         toggleSelection(workKey, Boolean(shouldBeSelected));
+    }
+
+    function selectRange(anchorWorkKey, targetWorkKey) {
+        const anchor = anchorWorkKey ? String(anchorWorkKey) : '';
+        const target = targetWorkKey ? String(targetWorkKey) : '';
+        if (!anchor || !target) {
+            return;
+        }
+
+        const anchorIndex = visibleIds.indexOf(anchor);
+        const targetIndex = visibleIds.indexOf(target);
+        if (anchorIndex === -1 || targetIndex === -1) {
+            selectOnly(target);
+            return;
+        }
+
+        const start = Math.min(anchorIndex, targetIndex);
+        const end = Math.max(anchorIndex, targetIndex);
+
+        selectedIds.clear();
+        for (let index = start; index <= end; index += 1) {
+            const visibleId = visibleIds[index];
+            if (visibleId) {
+                selectedIds.add(visibleId);
+            }
+        }
+
+        setSelectionAnchor(anchor);
+        updateSelectionState();
     }
 
     function removeSelectedIds(workKeys) {
@@ -55,12 +135,15 @@ export function createSelection(selectAll, bulkBar, bulkCount) {
             }
         }
 
+        if (selectionAnchor && !selectedIds.has(selectionAnchor) && !visibleIds.includes(selectionAnchor)) {
+            selectionAnchor = null;
+        }
+
         if (!changed) {
             return;
         }
 
-        syncMasterCheckbox();
-        updateBulkBar();
+        updateSelectionState();
     }
 
     function retainSelectedIds(workKeys) {
@@ -75,14 +158,16 @@ export function createSelection(selectAll, bulkBar, bulkCount) {
             changed = true;
         }
 
+        if (selectionAnchor && !allowed.has(selectionAnchor)) {
+            selectionAnchor = null;
+        }
+
         if (!changed) {
-            syncMasterCheckbox();
-            updateBulkBar();
+            updateSelectionState();
             return;
         }
 
-        syncMasterCheckbox();
-        updateBulkBar();
+        updateSelectionState();
     }
 
     function bindRowCheckboxes(root) {
@@ -144,20 +229,25 @@ export function createSelection(selectAll, bulkBar, bulkCount) {
                 }
             }
             bindRowCheckboxes(document);
-            syncMasterCheckbox();
-            updateBulkBar();
+            updateSelectionState();
         });
     }
 
     return {
         bindRowCheckboxes,
+        clearSelection,
         getSelectedIds,
+        getSelectionAnchor,
         isSelected,
         removeSelectedIds,
         retainSelectedIds,
+        selectOnly,
+        selectRange,
         setSelected,
+        setSelectionAnchor,
         setSelectionChangeHandler,
         setVisibleIds,
-        toggleSelection
+        toggleSelection,
+        toggleSingle
     };
 }

--- a/src/main/resources/static/js/workspace/selection.js
+++ b/src/main/resources/static/js/workspace/selection.js
@@ -19,6 +19,10 @@ export function createSelection(selectAll, bulkBar, bulkCount) {
         updateBulkBar();
     }
 
+    function getFirstVisibleId() {
+        return visibleIds.length > 0 ? visibleIds[0] : null;
+    }
+
     function setSelectionAnchor(workKey) {
         selectionAnchor = workKey ? String(workKey) : null;
     }
@@ -236,6 +240,7 @@ export function createSelection(selectAll, bulkBar, bulkCount) {
     return {
         bindRowCheckboxes,
         clearSelection,
+        getFirstVisibleId,
         getSelectedIds,
         getSelectionAnchor,
         isSelected,

--- a/src/main/resources/templates/workspace/_bulk-bar.html
+++ b/src/main/resources/templates/workspace/_bulk-bar.html
@@ -14,6 +14,9 @@
 						</p>
 					</div>
 					<div class="flex items-center gap-3">
+						<button id="bulkDeselectAll" type="button" class="px-4 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-sm">
+							Deselect all
+						</button>
 						<button id="bulkExportSelected" type="button" class="px-4 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-sm">
 							Export selected
 						</button>


### PR DESCRIPTION
### This updates row selection in the workspace to work more like a normal file explorer.

- Shift+click now selects all rows between the starting row and the clicked row
- If nothing is selected, Shift+click starts from the first visible row
- Text highlighting no longer gets in the way while selecting rows
- Checkbox and row selection stay matched
- If multiple rows are already selected, if you Shift+click it uses the last clicked row as the starting point for the range selection

### Tested manually by:
- clicking multiple rows one by one
- clicking a selected row again to deselect it
- using Shift+click up and down the list
- using Shift+click when nothing is selected
- checking that checkbox and row selection stay matched
