### PR TITLE
42 folder management

### DIFF
--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated: 2026-04-01
+Last updated: 2026-04-02
 
 ## Summary
 
@@ -34,6 +34,14 @@ TestStream is a working Spring Boot and Thymeleaf application with core authenti
 ## Iteration 3 Focus
 
 Iteration 3 is in progress.
+
+Recent delivery:
+
+- folders are now first-class entities in a dedicated `folders` table with parent-child relationships (`parent_id`)
+- startup backfill now hydrates folder rows from legacy slash-delimited `test_case.folder` values
+- `GET /api/folders` now reads derived paths from the folder table while keeping the existing `List<String>` response shape
+- folder APIs now support create, rename/reparent with cycle rejection, and explicit delete with conflict safeguards
+- workspace sidebar now supports New Folder, folder context-menu actions, and folder drag/reparent behavior
 
 Primary active goals:
 

--- a/src/main/java/com/formswim/teststream/bulk/controllers/BulkMutationController.java
+++ b/src/main/java/com/formswim/teststream/bulk/controllers/BulkMutationController.java
@@ -2,6 +2,7 @@ package com.formswim.teststream.bulk.controllers;
 
 import java.util.Optional;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -27,6 +28,10 @@ import jakarta.validation.Valid;
 @RequestMapping
 public class BulkMutationController {
 
+    private static final String BULK_MOVE_INVALID_REQUEST = "INVALID_REQUEST";
+    private static final String BULK_MOVE_CONFLICT = "CONFLICT";
+    private static final String BULK_EDIT_INVALID_REQUEST = "INVALID_REQUEST";
+    private static final String BULK_EDIT_CONFLICT = "CONFLICT";
 
 
     private final CurrentUserService currentUserService;
@@ -74,7 +79,9 @@ public class BulkMutationController {
             BulkMoveResult result = testCaseBulkMoveService.bulkMoveByWorkKeys(user.getTeamKey(), request);
             return ResponseEntity.ok(result);
         } catch (IllegalArgumentException exception) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(buildBulkMoveErrorResult(request, BULK_MOVE_INVALID_REQUEST));
+        } catch (DataIntegrityViolationException exception) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(buildBulkMoveErrorResult(request, BULK_MOVE_CONFLICT));
         }
     }
 
@@ -116,8 +123,28 @@ public class BulkMutationController {
             BulkEditResult result = testCaseBulkEditService.bulkEditByWorkKeys(user.getTeamKey(), request);
             return ResponseEntity.ok(result);
         } catch (IllegalArgumentException exception) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(buildBulkEditErrorResult(request, BULK_EDIT_INVALID_REQUEST));
+        } catch (DataIntegrityViolationException exception) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(buildBulkEditErrorResult(request, BULK_EDIT_CONFLICT));
         }
+    }
+
+    private BulkMoveResult buildBulkMoveErrorResult(BulkMoveRequest request, String reason) {
+        BulkMoveResult result = new BulkMoveResult();
+        int requestedCount = request == null || request.getWorkKeys() == null ? 0 : request.getWorkKeys().size();
+        result.setRequestedCount(requestedCount);
+        result.setInvalidCount(requestedCount);
+        result.getFailures().add(new BulkMoveResult.BulkMoveFailure(null, reason));
+        return result;
+    }
+
+    private BulkEditResult buildBulkEditErrorResult(BulkEditRequest request, String reason) {
+        BulkEditResult result = new BulkEditResult();
+        int requestedCount = request == null || request.getWorkKeys() == null ? 0 : request.getWorkKeys().size();
+        result.setRequestedCount(requestedCount);
+        result.setInvalidCount(requestedCount);
+        result.getFailures().add(new BulkEditResult.BulkEditFailure(null, reason));
+        return result;
     }
 
 }

--- a/src/main/java/com/formswim/teststream/bulk/controllers/BulkMutationController.java
+++ b/src/main/java/com/formswim/teststream/bulk/controllers/BulkMutationController.java
@@ -70,8 +70,12 @@ public class BulkMutationController {
             return ResponseEntity.badRequest().build();
         }
 
-        BulkMoveResult result = testCaseBulkMoveService.bulkMoveByWorkKeys(user.getTeamKey(), request);
-        return ResponseEntity.ok(result);
+        try {
+            BulkMoveResult result = testCaseBulkMoveService.bulkMoveByWorkKeys(user.getTeamKey(), request);
+            return ResponseEntity.ok(result);
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     /**

--- a/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
+++ b/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
@@ -5,6 +5,7 @@ import com.formswim.teststream.bulk.dto.BulkEditResult;
 import com.formswim.teststream.shared.domain.TestCase;
 import com.formswim.teststream.shared.domain.TestStep;
 import com.formswim.teststream.shared.domain.TestCaseRepository;
+import com.formswim.teststream.workspace.services.FolderPathSyncService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -87,11 +88,14 @@ public class TestCaseBulkEditService {
     );
 
     private final TestCaseRepository testCaseRepository;
+    private final FolderPathSyncService folderPathSyncService;
     private final int maxWorkKeys;
 
     public TestCaseBulkEditService(TestCaseRepository testCaseRepository,
+                                   FolderPathSyncService folderPathSyncService,
                                    @Value("${teststream.bulk-edit.max-work-keys:5000}") int maxWorkKeys) {
         this.testCaseRepository = testCaseRepository;
+        this.folderPathSyncService = folderPathSyncService;
         this.maxWorkKeys = maxWorkKeys;
     }
 
@@ -176,6 +180,7 @@ public class TestCaseBulkEditService {
         int updatedCaseCount = 0;
         int updatedStepCount = 0;
         int totalReplacements = 0;
+        Set<String> syncedFolders = new LinkedHashSet<>();
 
         for (TestCase testCase : cases) {
             boolean caseChanged = false;
@@ -249,6 +254,9 @@ public class TestCaseBulkEditService {
             testCase.setFolder(folderOutcome.updatedValue());
             caseChanged = caseChanged || folderOutcome.changed();
             totalReplacements += folderOutcome.replacementCount();
+            if (folderOutcome.changed() && folderOutcome.updatedValue() != null && !folderOutcome.updatedValue().isBlank()) {
+                syncedFolders.add(folderOutcome.updatedValue());
+            }
 
             ReplaceOutcome testCaseTypeOutcome = updateIfRequested(requestedFields.contains("testCaseType"), testCase.getTestCaseType(), findText, replaceText);
             testCase.setTestCaseType(testCaseTypeOutcome.updatedValue());
@@ -318,6 +326,7 @@ public class TestCaseBulkEditService {
             }
         }
 
+        folderPathSyncService.ensureFolderPathsExist(teamKey, syncedFolders, "bulk-edit");
         testCaseRepository.saveAll(cases);
 
         result.setUpdatedCaseCount(updatedCaseCount);

--- a/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkMoveService.java
+++ b/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkMoveService.java
@@ -3,6 +3,7 @@ package com.formswim.teststream.bulk.service;
 import com.formswim.teststream.bulk.dto.BulkMoveRequest;
 import com.formswim.teststream.bulk.dto.BulkMoveResult;
 import com.formswim.teststream.shared.domain.TestCaseRepository;
+import com.formswim.teststream.workspace.services.FolderPathSyncService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,11 +19,15 @@ public class TestCaseBulkMoveService {
     private static final String FAILURE_INVALID = "INVALID_WORK_KEY";
     private static final String FAILURE_FORBIDDEN = "FORBIDDEN";
     private static final String FAILURE_NOT_FOUND = "NOT_FOUND";
+    private static final String FOLDER_SYNC_ACTOR = "bulk-move";
 
     private final TestCaseRepository testCaseRepository;
+    private final FolderPathSyncService folderPathSyncService;
 
-    public TestCaseBulkMoveService(TestCaseRepository testCaseRepository) {
+    public TestCaseBulkMoveService(TestCaseRepository testCaseRepository,
+                                   FolderPathSyncService folderPathSyncService) {
         this.testCaseRepository = testCaseRepository;
+        this.folderPathSyncService = folderPathSyncService;
     }
 
     @Transactional
@@ -79,6 +84,7 @@ public class TestCaseBulkMoveService {
         }
 
         String trimmedTargetFolder = request.getTargetFolder().trim();
+        folderPathSyncService.ensureFolderPathExists(teamKey, trimmedTargetFolder, FOLDER_SYNC_ACTOR);
         // Apply one scoped update statement for all eligible keys in this request.
         int movedCount = testCaseRepository.bulkMoveToFolderByTeamKeyAndWorkKeys(teamKey, allowedWorkKeys, trimmedTargetFolder);
         result.setMovedCount(movedCount);

--- a/src/main/java/com/formswim/teststream/ingestion/services/TestIngestionService.java
+++ b/src/main/java/com/formswim/teststream/ingestion/services/TestIngestionService.java
@@ -23,6 +23,7 @@ import com.formswim.teststream.ingestion.model.UploadHistory;
 import com.formswim.teststream.ingestion.model.UploadReviewSession;
 import com.formswim.teststream.ingestion.repository.UploadHistoryRepository;
 import com.formswim.teststream.ingestion.repository.UploadReviewSessionRepository;
+import com.formswim.teststream.workspace.services.FolderPathSyncService;
 
 @Service
 public class TestIngestionService {
@@ -37,6 +38,7 @@ public class TestIngestionService {
     private final FileHashService fileHashService;
     private final UploadDiffService uploadDiffService;
     private final UploadReviewService uploadReviewService;
+    private final FolderPathSyncService folderPathSyncService;
     private final TransactionTemplate transactionTemplate;
 
     public TestIngestionService(ExcelParserService excelParserService,
@@ -47,6 +49,7 @@ public class TestIngestionService {
                                 FileHashService fileHashService,
                                 UploadDiffService uploadDiffService,
                                 UploadReviewService uploadReviewService,
+                                FolderPathSyncService folderPathSyncService,
                                 PlatformTransactionManager transactionManager) {
         this.excelParserService = excelParserService;
         this.csvParserService = csvParserService;
@@ -56,6 +59,7 @@ public class TestIngestionService {
         this.fileHashService = fileHashService;
         this.uploadDiffService = uploadDiffService;
         this.uploadReviewService = uploadReviewService;
+        this.folderPathSyncService = folderPathSyncService;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
@@ -157,6 +161,11 @@ public class TestIngestionService {
         parsed.setStagedNewCount(stagedNewCases.size());
 
         if (changedConflicts.isEmpty()) {
+            folderPathSyncService.ensureFolderPathsExist(
+                teamKey,
+                newCasesToSave.stream().map(TestCase::getFolder).toList(),
+                "upload-direct"
+            );
             testCaseRepository.saveAll(newCasesToSave);
             uploadHistoryRepository.save(new UploadHistory(teamKey, file.getOriginalFilename() == null ? "upload" : file.getOriginalFilename(), fileHash));
             parsed.setImportedCount(newCasesToSave.size());

--- a/src/main/java/com/formswim/teststream/ingestion/services/UploadReviewService.java
+++ b/src/main/java/com/formswim/teststream/ingestion/services/UploadReviewService.java
@@ -31,18 +31,15 @@ import com.formswim.teststream.shared.domain.TestStep;
 public class UploadReviewService {
 
     private final ObjectMapper objectMapper;
-    private final UploadDiffService uploadDiffService;
     private final UploadReviewSessionRepository uploadReviewSessionRepository;
     private final UploadHistoryRepository uploadHistoryRepository;
     private final TestCaseRepository testCaseRepository;
 
     public UploadReviewService(ObjectMapper objectMapper,
-                               UploadDiffService uploadDiffService,
                                UploadReviewSessionRepository uploadReviewSessionRepository,
                                UploadHistoryRepository uploadHistoryRepository,
                                TestCaseRepository testCaseRepository) {
         this.objectMapper = objectMapper;
-        this.uploadDiffService = uploadDiffService;
         this.uploadReviewSessionRepository = uploadReviewSessionRepository;
         this.uploadHistoryRepository = uploadHistoryRepository;
         this.testCaseRepository = testCaseRepository;

--- a/src/main/java/com/formswim/teststream/ingestion/services/UploadReviewService.java
+++ b/src/main/java/com/formswim/teststream/ingestion/services/UploadReviewService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -114,7 +115,7 @@ public class UploadReviewService {
         for (UploadReviewItem item : session.getItems()) {
             if (UploadReviewItem.TYPE_NEW.equals(item.getConflictType())) {
                 ReviewCaseSnapshot newSnapshot = readSnapshot(item.getIncomingSnapshotJson());
-                folderPathSyncService.ensureFolderPathExists(teamKey, newSnapshot.getFolder(), "upload-review");
+                ensureFolderPathOrThrowValidation(teamKey, newSnapshot.getFolder());
                 testCaseRepository.save(toEntity(teamKey, newSnapshot));
                 importedNewCount++;
                 continue;
@@ -126,7 +127,7 @@ public class UploadReviewService {
             if (UploadReviewItem.ACTION_MERGE.equals(action)) {
                 ReviewCaseSnapshot editedSnapshot = buildEditedSnapshot(readSnapshot(item.getIncomingSnapshotJson()), parameters, item.getId());
                 item.setEditedSnapshotJson(writeJson(editedSnapshot));
-                folderPathSyncService.ensureFolderPathExists(teamKey, editedSnapshot.getFolder(), "upload-review");
+                ensureFolderPathOrThrowValidation(teamKey, editedSnapshot.getFolder());
                 mergeIntoExisting(teamKey, editedSnapshot);
                 mergedCount++;
             } else {
@@ -139,6 +140,16 @@ public class UploadReviewService {
         uploadHistoryRepository.save(new UploadHistory(session.getTeamKey(), session.getOriginalFilename(), session.getFileHash()));
 
         return new ReviewApplyResult(importedNewCount, mergedCount, skippedCount);
+    }
+
+    private void ensureFolderPathOrThrowValidation(String teamKey, String folderPath) {
+        try {
+            folderPathSyncService.ensureFolderPathExists(teamKey, folderPath, "upload-review");
+        } catch (IllegalArgumentException exception) {
+            throw exception;
+        } catch (DataIntegrityViolationException exception) {
+            throw new IllegalArgumentException("Folder path could not be synchronized due to a concurrent update. Please retry.");
+        }
     }
 
     @Transactional

--- a/src/main/java/com/formswim/teststream/ingestion/services/UploadReviewService.java
+++ b/src/main/java/com/formswim/teststream/ingestion/services/UploadReviewService.java
@@ -26,6 +26,7 @@ import com.formswim.teststream.ingestion.repository.UploadReviewSessionRepositor
 import com.formswim.teststream.shared.domain.TestCase;
 import com.formswim.teststream.shared.domain.TestCaseRepository;
 import com.formswim.teststream.shared.domain.TestStep;
+import com.formswim.teststream.workspace.services.FolderPathSyncService;
 
 @Service
 public class UploadReviewService {
@@ -34,15 +35,18 @@ public class UploadReviewService {
     private final UploadReviewSessionRepository uploadReviewSessionRepository;
     private final UploadHistoryRepository uploadHistoryRepository;
     private final TestCaseRepository testCaseRepository;
+    private final FolderPathSyncService folderPathSyncService;
 
     public UploadReviewService(ObjectMapper objectMapper,
                                UploadReviewSessionRepository uploadReviewSessionRepository,
                                UploadHistoryRepository uploadHistoryRepository,
-                               TestCaseRepository testCaseRepository) {
+                               TestCaseRepository testCaseRepository,
+                               FolderPathSyncService folderPathSyncService) {
         this.objectMapper = objectMapper;
         this.uploadReviewSessionRepository = uploadReviewSessionRepository;
         this.uploadHistoryRepository = uploadHistoryRepository;
         this.testCaseRepository = testCaseRepository;
+        this.folderPathSyncService = folderPathSyncService;
     }
 
     @Transactional
@@ -110,6 +114,7 @@ public class UploadReviewService {
         for (UploadReviewItem item : session.getItems()) {
             if (UploadReviewItem.TYPE_NEW.equals(item.getConflictType())) {
                 ReviewCaseSnapshot newSnapshot = readSnapshot(item.getIncomingSnapshotJson());
+                folderPathSyncService.ensureFolderPathExists(teamKey, newSnapshot.getFolder(), "upload-review");
                 testCaseRepository.save(toEntity(teamKey, newSnapshot));
                 importedNewCount++;
                 continue;
@@ -121,6 +126,7 @@ public class UploadReviewService {
             if (UploadReviewItem.ACTION_MERGE.equals(action)) {
                 ReviewCaseSnapshot editedSnapshot = buildEditedSnapshot(readSnapshot(item.getIncomingSnapshotJson()), parameters, item.getId());
                 item.setEditedSnapshotJson(writeJson(editedSnapshot));
+                folderPathSyncService.ensureFolderPathExists(teamKey, editedSnapshot.getFolder(), "upload-review");
                 mergeIntoExisting(teamKey, editedSnapshot);
                 mergedCount++;
             } else {

--- a/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
+++ b/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
@@ -51,6 +51,7 @@ public class SchemaAlterRunner implements ApplicationRunner {
         // Older schemas enforced work_key uniqueness globally. The application model is
         // (team_key, work_key) unique, so migrate the constraint for Postgres.
         ensureTestCaseWorkKeyUniquePerTeam();
+        ensureRootFolderUniquePerTeam();
 
         if (!folderBackfillOnStartup) {
             log.info("Folder backfill skipped: teststream.folders.backfill-on-startup=false");
@@ -82,6 +83,25 @@ public class SchemaAlterRunner implements ApplicationRunner {
             }
         } catch (Exception e) {
             log.warn("Could not migrate test_case work_key uniqueness constraint: {}", e.getMessage());
+        }
+    }
+
+    private void ensureRootFolderUniquePerTeam() {
+        if (!isPostgres()) {
+            return;
+        }
+
+        try {
+            // UNIQUE(team_key, parent_id, name) allows duplicate roots on Postgres because
+            // parent_id is NULL at the root level. Enforce root uniqueness explicitly.
+            jdbc.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS uk_folders_team_root_lower_name
+                ON folders (team_key, lower(name))
+                WHERE parent_id IS NULL
+                """);
+            log.info("Ensured index uk_folders_team_root_lower_name on folders(team_key, lower(name)) where parent_id is null");
+        } catch (Exception exception) {
+            log.warn("Could not enforce root folder uniqueness index: {}", exception.getMessage());
         }
     }
 

--- a/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
+++ b/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
@@ -52,6 +52,7 @@ public class SchemaAlterRunner implements ApplicationRunner {
         // (team_key, work_key) unique, so migrate the constraint for Postgres.
         ensureTestCaseWorkKeyUniquePerTeam();
         ensureRootFolderUniquePerTeam();
+        ensureChildFolderUniquePerTeam();
 
         if (!folderBackfillOnStartup) {
             log.info("Folder backfill skipped: teststream.folders.backfill-on-startup=false");
@@ -102,6 +103,24 @@ public class SchemaAlterRunner implements ApplicationRunner {
             log.info("Ensured index uk_folders_team_root_lower_name on folders(team_key, lower(name)) where parent_id is null");
         } catch (Exception exception) {
             log.warn("Could not enforce root folder uniqueness index: {}", exception.getMessage());
+        }
+    }
+
+    private void ensureChildFolderUniquePerTeam() {
+        if (!isPostgres()) {
+            return;
+        }
+
+        try {
+            // Keep DB semantics aligned with NameIgnoreCase sibling checks for non-root folders.
+            jdbc.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS uk_folders_team_parent_lower_name
+                ON folders (team_key, parent_id, lower(name))
+                WHERE parent_id IS NOT NULL
+                """);
+            log.info("Ensured index uk_folders_team_parent_lower_name on folders(team_key, parent_id, lower(name)) where parent_id is not null");
+        } catch (Exception exception) {
+            log.warn("Could not enforce child folder uniqueness index: {}", exception.getMessage());
         }
     }
 

--- a/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
+++ b/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
@@ -10,6 +10,8 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import com.formswim.teststream.workspace.services.FolderBackfillService;
+
 /**
  * Runs once on startup to widen any varchar(255) columns that need to be TEXT.
  * Hibernate's ddl-auto=update never alters existing column types, so this
@@ -22,9 +24,12 @@ public class SchemaAlterRunner implements ApplicationRunner {
     private static final Logger log = LoggerFactory.getLogger(SchemaAlterRunner.class);
 
     private final JdbcTemplate jdbc;
+    private final FolderBackfillService folderBackfillService;
 
-    public SchemaAlterRunner(JdbcTemplate jdbc) {
+    public SchemaAlterRunner(JdbcTemplate jdbc,
+                             FolderBackfillService folderBackfillService) {
         this.jdbc = jdbc;
+        this.folderBackfillService = folderBackfillService;
     }
 
     @Override
@@ -42,6 +47,13 @@ public class SchemaAlterRunner implements ApplicationRunner {
         // Older schemas enforced work_key uniqueness globally. The application model is
         // (team_key, work_key) unique, so migrate the constraint for Postgres.
         ensureTestCaseWorkKeyUniquePerTeam();
+
+        try {
+            int createdFolders = folderBackfillService.backfillFoldersFromTestCases();
+            log.info("Folder backfill completed. Created {} folder rows.", createdFolders);
+        } catch (Exception exception) {
+            log.warn("Folder backfill failed: {}", exception.getMessage());
+        }
     }
 
     private void ensureTestCaseWorkKeyUniquePerTeam() {

--- a/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
+++ b/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -25,11 +26,14 @@ public class SchemaAlterRunner implements ApplicationRunner {
 
     private final JdbcTemplate jdbc;
     private final FolderBackfillService folderBackfillService;
+    private final boolean folderBackfillOnStartup;
 
     public SchemaAlterRunner(JdbcTemplate jdbc,
-                             FolderBackfillService folderBackfillService) {
+                             FolderBackfillService folderBackfillService,
+                             @Value("${teststream.folders.backfill-on-startup:true}") boolean folderBackfillOnStartup) {
         this.jdbc = jdbc;
         this.folderBackfillService = folderBackfillService;
+        this.folderBackfillOnStartup = folderBackfillOnStartup;
     }
 
     @Override
@@ -47,6 +51,11 @@ public class SchemaAlterRunner implements ApplicationRunner {
         // Older schemas enforced work_key uniqueness globally. The application model is
         // (team_key, work_key) unique, so migrate the constraint for Postgres.
         ensureTestCaseWorkKeyUniquePerTeam();
+
+        if (!folderBackfillOnStartup) {
+            log.info("Folder backfill skipped: teststream.folders.backfill-on-startup=false");
+            return;
+        }
 
         try {
             int createdFolders = folderBackfillService.backfillFoldersFromTestCases();

--- a/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
+++ b/src/main/java/com/formswim/teststream/shared/config/SchemaAlterRunner.java
@@ -52,7 +52,7 @@ public class SchemaAlterRunner implements ApplicationRunner {
             int createdFolders = folderBackfillService.backfillFoldersFromTestCases();
             log.info("Folder backfill completed. Created {} folder rows.", createdFolders);
         } catch (Exception exception) {
-            log.warn("Folder backfill failed: {}", exception.getMessage());
+            log.warn("Folder backfill failed.", exception);
         }
     }
 

--- a/src/main/java/com/formswim/teststream/shared/domain/TestCaseRepository.java
+++ b/src/main/java/com/formswim/teststream/shared/domain/TestCaseRepository.java
@@ -203,7 +203,7 @@ public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
                                                 where testCase.teamKey = :teamKey
                                                         and (
                                                                                 lower(trim(function('replace', coalesce(testCase.folder, ''), '\\', '/'))) = lower(:folderPath)
-                                                                                or lower(trim(function('replace', coalesce(testCase.folder, ''), '\\', '/'))) like lower(concat(:folderPath, '/%'))
+                                                                                or lower(trim(function('replace', coalesce(testCase.folder, ''), '\\', '/'))) like lower(concat(function('replace', function('replace', function('replace', :folderPath, '\\', '\\\\'), '%', '\\%'), '_', '\\_'), '/%')) escape '\\'
                                                         )
                                                 """)
                 long countByTeamKeyAndFolderPathHierarchy(@Param("teamKey") String teamKey,

--- a/src/main/java/com/formswim/teststream/shared/domain/TestCaseRepository.java
+++ b/src/main/java/com/formswim/teststream/shared/domain/TestCaseRepository.java
@@ -209,5 +209,30 @@ public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
                 long countByTeamKeyAndFolderPathHierarchy(@Param("teamKey") String teamKey,
                                                                                                                                                                                         @Param("folderPath") String folderPath);
 
+                @Modifying(clearAutomatically = true, flushAutomatically = true)
+                @Query("""
+                                                update TestCase testCase
+                                                set testCase.folder = :nextPath
+                                                where testCase.teamKey = :teamKey
+                                                        and lower(trim(function('replace', coalesce(testCase.folder, ''), '\\', '/'))) = lower(:previousPath)
+                                                """)
+                int bulkRepathExact(@Param("teamKey") String teamKey,
+                                                                                                @Param("previousPath") String previousPath,
+                                                                                                @Param("nextPath") String nextPath);
+
+                @Modifying(clearAutomatically = true, flushAutomatically = true)
+                @Query("""
+                                                update TestCase testCase
+                                                set testCase.folder = concat(:nextPath,
+                                                                                                                                                                 substring(trim(function('replace', coalesce(testCase.folder, ''), '\\', '/')),
+                                                                                                                                                                                                         :suffixStartIndex))
+                                                where testCase.teamKey = :teamKey
+                                                        and lower(trim(function('replace', coalesce(testCase.folder, ''), '\\', '/'))) like lower(concat(function('replace', function('replace', function('replace', :previousPath, '\\', '\\\\'), '%', '\\%'), '_', '\\_'), '/%')) escape '\\'
+                                                """)
+                int bulkRepathDescendants(@Param("teamKey") String teamKey,
+                                                                                                                        @Param("previousPath") String previousPath,
+                                                                                                                        @Param("nextPath") String nextPath,
+                                                                                                                        @Param("suffixStartIndex") int suffixStartIndex);
+
     List<TestCase> findByTeamKeyAndStatus(String teamKey, String status);
 }

--- a/src/main/java/com/formswim/teststream/shared/domain/TestCaseRepository.java
+++ b/src/main/java/com/formswim/teststream/shared/domain/TestCaseRepository.java
@@ -144,6 +144,16 @@ public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
     List<String> findDistinctFolderByTeamKey(String teamKey);
 
     @Query("""
+            select distinct testCase.teamKey
+            from TestCase testCase
+            where testCase.teamKey is not null
+              and trim(testCase.teamKey) <> ''
+              and testCase.folder is not null
+              and trim(testCase.folder) <> ''
+            """)
+    List<String> findDistinctTeamKeysWithFolders();
+
+    @Query("""
             select distinct trim(testCase.components)
             from TestCase testCase
             where testCase.teamKey = :teamKey
@@ -186,6 +196,18 @@ public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
     boolean existsByTeamKeyAndWorkKey(String teamKey, String workKey);
 
     List<TestCase> findByTeamKeyAndFolder(String teamKey, String folder);
+
+                @Query("""
+                                                select count(testCase)
+                                                from TestCase testCase
+                                                where testCase.teamKey = :teamKey
+                                                        and (
+                                                                                lower(trim(function('replace', coalesce(testCase.folder, ''), '\\', '/'))) = lower(:folderPath)
+                                                                                or lower(trim(function('replace', coalesce(testCase.folder, ''), '\\', '/'))) like lower(concat(:folderPath, '/%'))
+                                                        )
+                                                """)
+                long countByTeamKeyAndFolderPathHierarchy(@Param("teamKey") String teamKey,
+                                                                                                                                                                                        @Param("folderPath") String folderPath);
 
     List<TestCase> findByTeamKeyAndStatus(String teamKey, String status);
 }

--- a/src/main/java/com/formswim/teststream/workspace/controllers/WorkspaceMetadataController.java
+++ b/src/main/java/com/formswim/teststream/workspace/controllers/WorkspaceMetadataController.java
@@ -28,6 +28,7 @@ import com.formswim.teststream.workspace.dto.FolderResponse;
 import com.formswim.teststream.workspace.dto.FolderUpdateRequest;
 import com.formswim.teststream.workspace.services.FolderBadRequestException;
 import com.formswim.teststream.workspace.services.FolderConflictException;
+import com.formswim.teststream.workspace.services.FolderNotFoundException;
 import com.formswim.teststream.workspace.services.WorkspaceFolderService;
 import com.formswim.teststream.workspace.services.WorkspaceFolderMutationService;
 import com.formswim.teststream.workspace.services.WorkspaceQueryService;
@@ -116,6 +117,8 @@ public class WorkspaceMetadataController {
         try {
             FolderResponse created = workspaceFolderMutationService.createFolder(user.getTeamKey(), user.getEmail(), request);
             return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (FolderNotFoundException ex) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", ex.getMessage()));
         } catch (FolderBadRequestException ex) {
             return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
         } catch (FolderConflictException ex) {
@@ -142,6 +145,8 @@ public class WorkspaceMetadataController {
         try {
             FolderResponse updated = workspaceFolderMutationService.updateFolder(user.getTeamKey(), id, request);
             return ResponseEntity.ok(updated);
+        } catch (FolderNotFoundException ex) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", ex.getMessage()));
         } catch (FolderBadRequestException ex) {
             return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
         } catch (FolderConflictException ex) {
@@ -167,6 +172,8 @@ public class WorkspaceMetadataController {
         try {
             workspaceFolderMutationService.deleteFolder(user.getTeamKey(), id);
             return ResponseEntity.noContent().build();
+        } catch (FolderNotFoundException ex) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", ex.getMessage()));
         } catch (FolderBadRequestException ex) {
             return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
         } catch (FolderConflictException ex) {

--- a/src/main/java/com/formswim/teststream/workspace/controllers/WorkspaceMetadataController.java
+++ b/src/main/java/com/formswim/teststream/workspace/controllers/WorkspaceMetadataController.java
@@ -7,10 +7,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -123,6 +125,11 @@ public class WorkspaceMetadataController {
             return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
         } catch (FolderConflictException ex) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", ex.getMessage()));
+        } catch (DataIntegrityViolationException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Map.of("message", "Folder could not be created due to a conflicting update. Please retry."));
+        } catch (TransactionSystemException ex) {
+            return ResponseEntity.badRequest().body(Map.of("message", "Folder request failed validation."));
         }
     }
 
@@ -151,6 +158,11 @@ public class WorkspaceMetadataController {
             return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
         } catch (FolderConflictException ex) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", ex.getMessage()));
+        } catch (DataIntegrityViolationException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Map.of("message", "Folder update conflicted with another request. Please retry."));
+        } catch (TransactionSystemException ex) {
+            return ResponseEntity.badRequest().body(Map.of("message", "Folder update failed validation."));
         }
     }
 
@@ -178,6 +190,11 @@ public class WorkspaceMetadataController {
             return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
         } catch (FolderConflictException ex) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", ex.getMessage()));
+        } catch (DataIntegrityViolationException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Map.of("message", "Folder could not be deleted because it is still referenced."));
+        } catch (TransactionSystemException ex) {
+            return ResponseEntity.badRequest().body(Map.of("message", "Folder delete request failed validation."));
         }
     }
 

--- a/src/main/java/com/formswim/teststream/workspace/controllers/WorkspaceMetadataController.java
+++ b/src/main/java/com/formswim/teststream/workspace/controllers/WorkspaceMetadataController.java
@@ -2,20 +2,34 @@ package com.formswim.teststream.workspace.controllers;
 
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.service.CurrentUserService;
 import com.formswim.teststream.shared.domain.TestCaseRepository;
+import com.formswim.teststream.workspace.dto.FolderCreateRequest;
+import com.formswim.teststream.workspace.dto.FolderResponse;
+import com.formswim.teststream.workspace.dto.FolderUpdateRequest;
+import com.formswim.teststream.workspace.services.FolderBadRequestException;
+import com.formswim.teststream.workspace.services.FolderConflictException;
+import com.formswim.teststream.workspace.services.WorkspaceFolderService;
+import com.formswim.teststream.workspace.services.WorkspaceFolderMutationService;
 import com.formswim.teststream.workspace.services.WorkspaceQueryService;
 
 import jakarta.servlet.http.HttpSession;
@@ -28,15 +42,21 @@ public class WorkspaceMetadataController {
     private final TestCaseRepository testCaseRepository;
     private final CurrentUserService currentUserService;
     private final WorkspaceQueryService workspaceQueryService;
+    private final WorkspaceFolderService workspaceFolderService;
+    private final WorkspaceFolderMutationService workspaceFolderMutationService;
 
 
     public WorkspaceMetadataController(TestCaseRepository testCaseRepository,
                                        CurrentUserService currentUserService,
-                                        WorkspaceQueryService workspaceQueryService
+                                        WorkspaceQueryService workspaceQueryService,
+                                       WorkspaceFolderService workspaceFolderService,
+                                       WorkspaceFolderMutationService workspaceFolderMutationService
     ) {
         this.testCaseRepository = testCaseRepository;
         this.currentUserService = currentUserService;
         this.workspaceQueryService = workspaceQueryService;
+        this.workspaceFolderService = workspaceFolderService;
+        this.workspaceFolderMutationService = workspaceFolderMutationService;
     }
     /**
      * GET /api/folders
@@ -57,11 +77,101 @@ public class WorkspaceMetadataController {
         if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
             return ResponseEntity.status(403).build();
         }
-        List<String> folders = testCaseRepository.findDistinctFolderByTeamKey(user.getTeamKey())
-            .stream()
-            .sorted()
-            .collect(Collectors.toList());
+        List<String> folders = workspaceFolderService.listFolderPathsByTeamKey(user.getTeamKey());
         return ResponseEntity.ok(folders);
+    }
+
+    @GetMapping("/api/folders/nodes")
+    @ResponseBody
+    public ResponseEntity<List<FolderResponse>> getFolderNodesByTeamKey(HttpSession session, Authentication authentication) {
+        Optional<AppUser> currentUser = currentUserService.resolveCurrentUser(session, authentication);
+        if (currentUser.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        AppUser user = currentUser.get();
+        if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        List<FolderResponse> folders = workspaceFolderMutationService.listFolderNodesByTeamKey(user.getTeamKey());
+        return ResponseEntity.ok(folders);
+    }
+
+    @PostMapping("/api/folders")
+    @ResponseBody
+    public ResponseEntity<?> createFolder(@RequestBody FolderCreateRequest request,
+                                          HttpSession session,
+                                          Authentication authentication) {
+        Optional<AppUser> currentUser = currentUserService.resolveCurrentUser(session, authentication);
+        if (currentUser.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        AppUser user = currentUser.get();
+        if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        try {
+            FolderResponse created = workspaceFolderMutationService.createFolder(user.getTeamKey(), user.getEmail(), request);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (FolderBadRequestException ex) {
+            return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
+        } catch (FolderConflictException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", ex.getMessage()));
+        }
+    }
+
+    @PatchMapping("/api/folders/{id}")
+    @ResponseBody
+    public ResponseEntity<?> updateFolder(@PathVariable Long id,
+                                          @RequestBody FolderUpdateRequest request,
+                                          HttpSession session,
+                                          Authentication authentication) {
+        Optional<AppUser> currentUser = currentUserService.resolveCurrentUser(session, authentication);
+        if (currentUser.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        AppUser user = currentUser.get();
+        if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        try {
+            FolderResponse updated = workspaceFolderMutationService.updateFolder(user.getTeamKey(), id, request);
+            return ResponseEntity.ok(updated);
+        } catch (FolderBadRequestException ex) {
+            return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
+        } catch (FolderConflictException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", ex.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/api/folders/{id}")
+    @ResponseBody
+    public ResponseEntity<?> deleteFolder(@PathVariable Long id,
+                                          HttpSession session,
+                                          Authentication authentication) {
+        Optional<AppUser> currentUser = currentUserService.resolveCurrentUser(session, authentication);
+        if (currentUser.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        AppUser user = currentUser.get();
+        if (user.getTeamKey() == null || user.getTeamKey().isBlank()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        try {
+            workspaceFolderMutationService.deleteFolder(user.getTeamKey(), id);
+            return ResponseEntity.noContent().build();
+        } catch (FolderBadRequestException ex) {
+            return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
+        } catch (FolderConflictException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", ex.getMessage()));
+        }
     }
 
     @GetMapping("/api/tags")

--- a/src/main/java/com/formswim/teststream/workspace/dto/FolderCreateRequest.java
+++ b/src/main/java/com/formswim/teststream/workspace/dto/FolderCreateRequest.java
@@ -1,0 +1,23 @@
+package com.formswim.teststream.workspace.dto;
+
+public class FolderCreateRequest {
+
+    private String name;
+    private Long parentId;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(Long parentId) {
+        this.parentId = parentId;
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/dto/FolderResponse.java
+++ b/src/main/java/com/formswim/teststream/workspace/dto/FolderResponse.java
@@ -1,0 +1,4 @@
+package com.formswim.teststream.workspace.dto;
+
+public record FolderResponse(Long id, String name, Long parentId, String path) {
+}

--- a/src/main/java/com/formswim/teststream/workspace/dto/FolderUpdateRequest.java
+++ b/src/main/java/com/formswim/teststream/workspace/dto/FolderUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.formswim.teststream.workspace.dto;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+public class FolderUpdateRequest {
+
+    private String name;
+    private Long parentId;
+    private boolean nameProvided;
+    private boolean parentIdProvided;
+
+    public String getName() {
+        return name;
+    }
+
+    @JsonSetter("name")
+    public void setName(String name) {
+        this.name = name;
+        this.nameProvided = true;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    @JsonSetter("parentId")
+    public void setParentId(Long parentId) {
+        this.parentId = parentId;
+        this.parentIdProvided = true;
+    }
+
+    public boolean isNameProvided() {
+        return nameProvided;
+    }
+
+    public boolean isParentIdProvided() {
+        return parentIdProvided;
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/model/Folder.java
+++ b/src/main/java/com/formswim/teststream/workspace/model/Folder.java
@@ -1,0 +1,102 @@
+package com.formswim.teststream.workspace.model;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "folders",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_folders_team_parent_name", columnNames = { "team_key", "parent_id", "name" })
+    }
+)
+public class Folder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Folder parent;
+
+    @Column(name = "team_key", nullable = false, length = 100)
+    private String teamKey;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "created_by", nullable = false, length = 320)
+    private String createdBy;
+
+    protected Folder() {
+    }
+
+    public Folder(String name, Folder parent, String teamKey, String createdBy) {
+        this.name = name;
+        this.parent = parent;
+        this.teamKey = teamKey;
+        this.createdBy = createdBy;
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Folder getParent() {
+        return parent;
+    }
+
+    public void setParent(Folder parent) {
+        this.parent = parent;
+    }
+
+    public String getTeamKey() {
+        return teamKey;
+    }
+
+    public void setTeamKey(String teamKey) {
+        this.teamKey = teamKey;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/repository/FolderRepository.java
+++ b/src/main/java/com/formswim/teststream/workspace/repository/FolderRepository.java
@@ -1,0 +1,21 @@
+package com.formswim.teststream.workspace.repository;
+
+import java.util.Optional;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.formswim.teststream.workspace.model.Folder;
+
+@Repository
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+
+    List<Folder> findByTeamKeyOrderByIdAsc(String teamKey);
+
+    Optional<Folder> findByTeamKeyAndId(String teamKey, Long id);
+
+    Optional<Folder> findByTeamKeyAndParent_IdAndNameIgnoreCase(String teamKey, Long parentId, String name);
+
+    boolean existsByTeamKeyAndParent_Id(String teamKey, Long parentId);
+}

--- a/src/main/java/com/formswim/teststream/workspace/repository/FolderRepository.java
+++ b/src/main/java/com/formswim/teststream/workspace/repository/FolderRepository.java
@@ -17,5 +17,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     Optional<Folder> findByTeamKeyAndParent_IdAndNameIgnoreCase(String teamKey, Long parentId, String name);
 
+        Optional<Folder> findByTeamKeyAndParentIsNullAndNameIgnoreCase(String teamKey, String name);
+
     boolean existsByTeamKeyAndParent_Id(String teamKey, Long parentId);
 }

--- a/src/main/java/com/formswim/teststream/workspace/repository/FolderRepository.java
+++ b/src/main/java/com/formswim/teststream/workspace/repository/FolderRepository.java
@@ -17,7 +17,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     Optional<Folder> findByTeamKeyAndParent_IdAndNameIgnoreCase(String teamKey, Long parentId, String name);
 
-        Optional<Folder> findByTeamKeyAndParentIsNullAndNameIgnoreCase(String teamKey, String name);
+    Optional<Folder> findByTeamKeyAndParentIsNullAndNameIgnoreCase(String teamKey, String name);
 
     boolean existsByTeamKeyAndParent_Id(String teamKey, Long parentId);
 }

--- a/src/main/java/com/formswim/teststream/workspace/repository/FolderRepository.java
+++ b/src/main/java/com/formswim/teststream/workspace/repository/FolderRepository.java
@@ -17,7 +17,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     Optional<Folder> findByTeamKeyAndParent_IdAndNameIgnoreCase(String teamKey, Long parentId, String name);
 
-    Optional<Folder> findByTeamKeyAndParentIsNullAndNameIgnoreCase(String teamKey, String name);
+        Optional<Folder> findByTeamKeyAndParentIsNullAndNameIgnoreCase(String teamKey, String name);
 
     boolean existsByTeamKeyAndParent_Id(String teamKey, Long parentId);
 }

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
@@ -3,7 +3,6 @@ package com.formswim.teststream.workspace.services;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -52,7 +51,7 @@ public class FolderBackfillService {
             for (Folder folder : existing) {
                 String path = derivePath(folder, pathMemo, byId);
                 if (!path.isBlank()) {
-                    byPath.put(canonicalPathKey(path), folder);
+                    byPath.put(path, folder);
                 }
             }
 
@@ -67,7 +66,7 @@ public class FolderBackfillService {
                 String currentPath = "";
                 for (String segment : segments) {
                     currentPath = currentPath.isEmpty() ? segment : currentPath + "/" + segment;
-                    String lookupPath = canonicalPathKey(currentPath);
+                    String lookupPath = currentPath;
 
                     Folder node = byPath.get(lookupPath);
                     if (node == null) {
@@ -107,13 +106,6 @@ public class FolderBackfillService {
         String path = parentPath.isBlank() ? current : parentPath + "/" + current;
         pathMemo.put(folder.getId(), path);
         return path;
-    }
-
-    private String canonicalPathKey(String path) {
-        if (path == null || path.isBlank()) {
-            return "";
-        }
-        return path.toLowerCase(Locale.ROOT);
     }
 
     private List<String> parseSegments(String rawPath) {

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
@@ -1,0 +1,133 @@
+package com.formswim.teststream.workspace.services;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.formswim.teststream.shared.domain.TestCaseRepository;
+import com.formswim.teststream.workspace.model.Folder;
+import com.formswim.teststream.workspace.repository.FolderRepository;
+
+@Service
+public class FolderBackfillService {
+
+    private static final String BACKFILL_ACTOR = "system-backfill";
+
+    private final TestCaseRepository testCaseRepository;
+    private final FolderRepository folderRepository;
+
+    public FolderBackfillService(TestCaseRepository testCaseRepository,
+                                 FolderRepository folderRepository) {
+        this.testCaseRepository = testCaseRepository;
+        this.folderRepository = folderRepository;
+    }
+
+    @Transactional
+    public int backfillFoldersFromTestCases() {
+        int createdCount = 0;
+        List<String> teamKeys = testCaseRepository.findDistinctTeamKeysWithFolders();
+
+        for (String teamKey : teamKeys) {
+            if (teamKey == null || teamKey.isBlank()) {
+                continue;
+            }
+
+            List<Folder> existing = folderRepository.findByTeamKeyOrderByIdAsc(teamKey);
+            Map<Long, Folder> byId = new HashMap<>();
+            for (Folder folder : existing) {
+                byId.put(folder.getId(), folder);
+            }
+
+            Map<String, Folder> byPath = new HashMap<>();
+            Map<Long, String> pathMemo = new HashMap<>();
+            for (Folder folder : existing) {
+                String path = derivePath(folder, pathMemo, byId);
+                if (!path.isBlank()) {
+                    byPath.put(path, folder);
+                }
+            }
+
+            List<String> folderPaths = testCaseRepository.findDistinctFolderByTeamKey(teamKey);
+            for (String rawPath : folderPaths) {
+                List<String> segments = parseSegments(rawPath);
+                if (segments.isEmpty()) {
+                    continue;
+                }
+
+                Folder parent = null;
+                String currentPath = "";
+                for (String segment : segments) {
+                    currentPath = currentPath.isEmpty() ? segment : currentPath + "/" + segment;
+                    String lookupPath = currentPath;
+
+                    Folder node = byPath.get(lookupPath);
+                    if (node == null) {
+                        node = new Folder(segment, parent, teamKey, BACKFILL_ACTOR);
+                        node = folderRepository.save(node);
+                        byId.put(node.getId(), node);
+                        byPath.put(lookupPath, node);
+                        createdCount++;
+                    }
+
+                    parent = node;
+                }
+            }
+        }
+
+        return createdCount;
+    }
+
+    private String derivePath(Folder folder, Map<Long, String> pathMemo, Map<Long, Folder> byId) {
+        if (folder == null || folder.getId() == null) {
+            return "";
+        }
+
+        String memoized = pathMemo.get(folder.getId());
+        if (memoized != null) {
+            return memoized;
+        }
+
+        Folder parent = folder.getParent();
+        String parentPath = "";
+        if (parent != null && parent.getId() != null) {
+            Folder resolvedParent = byId.getOrDefault(parent.getId(), parent);
+            parentPath = derivePath(resolvedParent, pathMemo, byId);
+        }
+
+        String current = (folder.getName() == null ? "" : folder.getName().trim());
+        String path = parentPath.isBlank() ? current : parentPath + "/" + current;
+        pathMemo.put(folder.getId(), path);
+        return path;
+    }
+
+    private List<String> parseSegments(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return List.of();
+        }
+
+        String normalized = rawPath.trim()
+            .replace('\\', '/')
+            .replaceAll("/+", "/")
+            .replaceAll("^/+", "")
+            .replaceAll("/+$", "");
+
+        if (normalized.isBlank()) {
+            return List.of();
+        }
+
+        String[] rawSegments = normalized.split("/");
+        List<String> segments = new ArrayList<>(rawSegments.length);
+        for (String part : rawSegments) {
+            String segment = part == null ? "" : part.trim();
+            if (!segment.isBlank()) {
+                segments.add(segment);
+            }
+        }
+
+        return segments;
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
@@ -32,10 +32,6 @@ public class FolderBackfillService {
 
     @Transactional
     public int backfillFoldersFromTestCases() {
-        if (folderRepository.count() > 0) {
-            return 0;
-        }
-
         int createdCount = 0;
         List<String> teamKeys = testCaseRepository.findDistinctTeamKeysWithFolders();
 

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,7 +17,9 @@ import com.formswim.teststream.workspace.repository.FolderRepository;
 @Service
 public class FolderBackfillService {
 
+    private static final Logger log = LoggerFactory.getLogger(FolderBackfillService.class);
     private static final String BACKFILL_ACTOR = "system-backfill";
+    private static final int MAX_FOLDER_NAME_LENGTH = 255;
 
     private final TestCaseRepository testCaseRepository;
     private final FolderRepository folderRepository;
@@ -128,6 +132,10 @@ public class FolderBackfillService {
         for (String part : rawSegments) {
             String segment = part == null ? "" : part.trim();
             if (!segment.isBlank()) {
+                if (segment.length() > MAX_FOLDER_NAME_LENGTH) {
+                    log.warn("Skipping backfill path with oversized segment (>{} chars): {}", MAX_FOLDER_NAME_LENGTH, rawPath);
+                    return List.of();
+                }
                 segments.add(segment);
             }
         }

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
@@ -28,6 +28,10 @@ public class FolderBackfillService {
 
     @Transactional
     public int backfillFoldersFromTestCases() {
+        if (folderRepository.count() > 0) {
+            return 0;
+        }
+
         int createdCount = 0;
         List<String> teamKeys = testCaseRepository.findDistinctTeamKeysWithFolders();
 

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderBackfillService.java
@@ -3,6 +3,7 @@ package com.formswim.teststream.workspace.services;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -51,7 +52,7 @@ public class FolderBackfillService {
             for (Folder folder : existing) {
                 String path = derivePath(folder, pathMemo, byId);
                 if (!path.isBlank()) {
-                    byPath.put(path, folder);
+                    byPath.put(canonicalPathKey(path), folder);
                 }
             }
 
@@ -66,7 +67,7 @@ public class FolderBackfillService {
                 String currentPath = "";
                 for (String segment : segments) {
                     currentPath = currentPath.isEmpty() ? segment : currentPath + "/" + segment;
-                    String lookupPath = currentPath;
+                    String lookupPath = canonicalPathKey(currentPath);
 
                     Folder node = byPath.get(lookupPath);
                     if (node == null) {
@@ -106,6 +107,13 @@ public class FolderBackfillService {
         String path = parentPath.isBlank() ? current : parentPath + "/" + current;
         pathMemo.put(folder.getId(), path);
         return path;
+    }
+
+    private String canonicalPathKey(String path) {
+        if (path == null || path.isBlank()) {
+            return "";
+        }
+        return path.toLowerCase(Locale.ROOT);
     }
 
     private List<String> parseSegments(String rawPath) {

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderBadRequestException.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderBadRequestException.java
@@ -1,0 +1,8 @@
+package com.formswim.teststream.workspace.services;
+
+public class FolderBadRequestException extends RuntimeException {
+
+    public FolderBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderConflictException.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderConflictException.java
@@ -1,0 +1,8 @@
+package com.formswim.teststream.workspace.services;
+
+public class FolderConflictException extends RuntimeException {
+
+    public FolderConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderNotFoundException.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderNotFoundException.java
@@ -1,0 +1,8 @@
+package com.formswim.teststream.workspace.services;
+
+public class FolderNotFoundException extends RuntimeException {
+
+    public FolderNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderPathSyncService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderPathSyncService.java
@@ -1,0 +1,102 @@
+package com.formswim.teststream.workspace.services;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.formswim.teststream.workspace.model.Folder;
+import com.formswim.teststream.workspace.repository.FolderRepository;
+
+@Service
+public class FolderPathSyncService {
+
+    private static final int MAX_FOLDER_NAME_LENGTH = 255;
+
+    private final FolderRepository folderRepository;
+
+    public FolderPathSyncService(FolderRepository folderRepository) {
+        this.folderRepository = folderRepository;
+    }
+
+    @Transactional
+    public void ensureFolderPathExists(String teamKey, String rawFolderPath, String actor) {
+        if (teamKey == null || teamKey.isBlank()) {
+            return;
+        }
+
+        List<String> segments = parseSegments(rawFolderPath);
+        if (segments.isEmpty()) {
+            return;
+        }
+
+        Folder parent = null;
+        for (String segment : segments) {
+            Folder existing;
+            if (parent == null) {
+                existing = folderRepository.findByTeamKeyAndParentIsNullAndNameIgnoreCase(teamKey, segment)
+                    .orElse(null);
+            } else {
+                existing = folderRepository.findByTeamKeyAndParent_IdAndNameIgnoreCase(teamKey, parent.getId(), segment)
+                    .orElse(null);
+            }
+
+            if (existing == null) {
+                existing = folderRepository.save(new Folder(segment, parent, teamKey, normalizeActor(actor)));
+            }
+
+            parent = existing;
+        }
+    }
+
+    @Transactional
+    public void ensureFolderPathsExist(String teamKey, Collection<String> rawFolderPaths, String actor) {
+        if (rawFolderPaths == null || rawFolderPaths.isEmpty()) {
+            return;
+        }
+
+        for (String rawFolderPath : rawFolderPaths) {
+            ensureFolderPathExists(teamKey, rawFolderPath, actor);
+        }
+    }
+
+    private List<String> parseSegments(String rawPath) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return List.of();
+        }
+
+        String normalized = rawPath.trim()
+            .replace('\\', '/')
+            .replaceAll("/+", "/")
+            .replaceAll("^/+", "")
+            .replaceAll("/+$", "");
+
+        if (normalized.isBlank()) {
+            return List.of();
+        }
+
+        String[] rawSegments = normalized.split("/");
+        List<String> segments = new ArrayList<>(rawSegments.length);
+        for (String part : rawSegments) {
+            String segment = part == null ? "" : part.trim();
+            if (segment.isBlank()) {
+                continue;
+            }
+            if (segment.length() > MAX_FOLDER_NAME_LENGTH) {
+                throw new IllegalArgumentException("Folder segment exceeds max length of 255 characters.");
+            }
+            segments.add(segment);
+        }
+
+        return segments;
+    }
+
+    private String normalizeActor(String createdBy) {
+        if (createdBy == null || createdBy.isBlank()) {
+            return "system-sync";
+        }
+        return createdBy.trim();
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/services/FolderPathSyncService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/FolderPathSyncService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,17 +35,18 @@ public class FolderPathSyncService {
 
         Folder parent = null;
         for (String segment : segments) {
-            Folder existing;
-            if (parent == null) {
-                existing = folderRepository.findByTeamKeyAndParentIsNullAndNameIgnoreCase(teamKey, segment)
-                    .orElse(null);
-            } else {
-                existing = folderRepository.findByTeamKeyAndParent_IdAndNameIgnoreCase(teamKey, parent.getId(), segment)
-                    .orElse(null);
-            }
+            Folder existing = findSibling(teamKey, parent, segment);
 
             if (existing == null) {
-                existing = folderRepository.save(new Folder(segment, parent, teamKey, normalizeActor(actor)));
+                try {
+                    existing = folderRepository.save(new Folder(segment, parent, teamKey, normalizeActor(actor)));
+                } catch (DataIntegrityViolationException exception) {
+                    // Another request may have created this segment concurrently; refetch and continue.
+                    existing = findSibling(teamKey, parent, segment);
+                    if (existing == null) {
+                        throw exception;
+                    }
+                }
             }
 
             parent = existing;
@@ -91,6 +93,16 @@ public class FolderPathSyncService {
         }
 
         return segments;
+    }
+
+    private Folder findSibling(String teamKey, Folder parent, String segment) {
+        if (parent == null) {
+            return folderRepository.findByTeamKeyAndParentIsNullAndNameIgnoreCase(teamKey, segment)
+                .orElse(null);
+        }
+
+        return folderRepository.findByTeamKeyAndParent_IdAndNameIgnoreCase(teamKey, parent.getId(), segment)
+            .orElse(null);
     }
 
     private String normalizeActor(String createdBy) {

--- a/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderMutationService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderMutationService.java
@@ -1,0 +1,252 @@
+package com.formswim.teststream.workspace.services;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.formswim.teststream.shared.domain.TestCaseRepository;
+import com.formswim.teststream.workspace.dto.FolderCreateRequest;
+import com.formswim.teststream.workspace.dto.FolderResponse;
+import com.formswim.teststream.workspace.dto.FolderUpdateRequest;
+import com.formswim.teststream.workspace.model.Folder;
+import com.formswim.teststream.workspace.repository.FolderRepository;
+import com.formswim.teststream.shared.domain.TestCase;
+
+@Service
+public class WorkspaceFolderMutationService {
+
+    private final FolderRepository folderRepository;
+    private final TestCaseRepository testCaseRepository;
+
+    public WorkspaceFolderMutationService(FolderRepository folderRepository,
+                                          TestCaseRepository testCaseRepository) {
+        this.folderRepository = folderRepository;
+        this.testCaseRepository = testCaseRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<FolderResponse> listFolderNodesByTeamKey(String teamKey) {
+        List<Folder> folders = folderRepository.findByTeamKeyOrderByIdAsc(teamKey);
+        Map<Long, Folder> byId = indexById(folders);
+        Map<Long, String> pathMemo = new HashMap<>();
+
+        return folders.stream()
+            .map(folder -> toResponse(folder, byId, pathMemo))
+            .toList();
+    }
+
+    @Transactional
+    public FolderResponse createFolder(String teamKey, String createdBy, FolderCreateRequest request) {
+        if (request == null) {
+            throw new FolderBadRequestException("Request body is required.");
+        }
+
+        String name = normalizeName(request.getName());
+        Folder parent = resolveParent(teamKey, request.getParentId());
+        ensureSiblingNameAvailable(teamKey, parent, name, null);
+
+        Folder folder = new Folder(name, parent, teamKey, normalizeActor(createdBy));
+        Folder saved = folderRepository.save(folder);
+
+        Map<Long, Folder> byId = indexById(folderRepository.findByTeamKeyOrderByIdAsc(teamKey));
+        return toResponse(saved, byId, new HashMap<>());
+    }
+
+    @Transactional
+    public FolderResponse updateFolder(String teamKey, Long id, FolderUpdateRequest request) {
+        if (request == null || (!request.isNameProvided() && !request.isParentIdProvided())) {
+            throw new FolderBadRequestException("At least one field is required: name or parentId.");
+        }
+
+        Folder folder = folderRepository.findByTeamKeyAndId(teamKey, id)
+            .orElseThrow(() -> new FolderBadRequestException("Folder not found."));
+
+        Map<Long, Folder> byId = indexById(folderRepository.findByTeamKeyOrderByIdAsc(teamKey));
+
+        String nextName = folder.getName();
+        if (request.isNameProvided()) {
+            nextName = normalizeName(request.getName());
+        }
+
+        Folder nextParent = folder.getParent();
+        if (request.isParentIdProvided()) {
+            nextParent = resolveParent(teamKey, request.getParentId());
+            if (nextParent != null && isDescendantOf(nextParent, folder.getId(), byId)) {
+                throw new FolderBadRequestException("Cannot move a folder into one of its descendants.");
+            }
+        }
+
+        String previousPath = derivePath(folder, byId, new HashMap<>());
+        String nextParentPath = nextParent == null ? "" : derivePath(nextParent, byId, new HashMap<>());
+        String nextPath = nextParentPath.isBlank() ? nextName : nextParentPath + "/" + nextName;
+
+        ensureSiblingNameAvailable(teamKey, nextParent, nextName, folder.getId());
+        folder.setName(nextName);
+        folder.setParent(nextParent);
+
+        Folder saved = folderRepository.save(folder);
+
+        if (!previousPath.equals(nextPath)) {
+            migrateTestCaseFolderPaths(teamKey, previousPath, nextPath);
+        }
+
+        byId = indexById(folderRepository.findByTeamKeyOrderByIdAsc(teamKey));
+        return toResponse(saved, byId, new HashMap<>());
+    }
+
+    @Transactional
+    public void deleteFolder(String teamKey, Long id) {
+        Folder folder = folderRepository.findByTeamKeyAndId(teamKey, id)
+            .orElseThrow(() -> new FolderBadRequestException("Folder not found."));
+
+        if (folderRepository.existsByTeamKeyAndParent_Id(teamKey, folder.getId())) {
+            throw new FolderConflictException("Folder cannot be deleted because it contains subfolders.");
+        }
+
+        Map<Long, Folder> byId = indexById(folderRepository.findByTeamKeyOrderByIdAsc(teamKey));
+        String folderPath = derivePath(folder, byId, new HashMap<>());
+        long boundCases = testCaseRepository.countByTeamKeyAndFolderPathHierarchy(teamKey, folderPath);
+        if (boundCases > 0) {
+            throw new FolderConflictException("Folder cannot be deleted because it contains test cases.");
+        }
+
+        folderRepository.delete(folder);
+    }
+
+    private Folder resolveParent(String teamKey, Long parentId) {
+        if (parentId == null) {
+            return null;
+        }
+
+        return folderRepository.findByTeamKeyAndId(teamKey, parentId)
+            .orElseThrow(() -> new FolderBadRequestException("Parent folder not found."));
+    }
+
+    private void ensureSiblingNameAvailable(String teamKey, Folder parent, String name, Long selfId) {
+        Long parentId = parent == null ? null : parent.getId();
+        folderRepository.findByTeamKeyAndParent_IdAndNameIgnoreCase(teamKey, parentId, name)
+            .ifPresent(existing -> {
+                if (selfId == null || !existing.getId().equals(selfId)) {
+                    throw new FolderConflictException("A folder with this name already exists in the target location.");
+                }
+            });
+    }
+
+    private String normalizeName(String rawName) {
+        String name = rawName == null ? "" : rawName.trim();
+        if (name.isBlank()) {
+            throw new FolderBadRequestException("Folder name is required.");
+        }
+
+        if (name.contains("/") || name.contains("\\")) {
+            throw new FolderBadRequestException("Folder name cannot include path separators.");
+        }
+
+        return name;
+    }
+
+    private String normalizeActor(String createdBy) {
+        if (createdBy == null || createdBy.isBlank()) {
+            return "unknown";
+        }
+        return createdBy.trim();
+    }
+
+    private boolean isDescendantOf(Folder candidateParent, Long folderId, Map<Long, Folder> byId) {
+        Folder current = candidateParent;
+        while (current != null) {
+            if (current.getId() != null && current.getId().equals(folderId)) {
+                return true;
+            }
+            Folder parent = current.getParent();
+            if (parent == null || parent.getId() == null) {
+                return false;
+            }
+            current = byId.getOrDefault(parent.getId(), parent);
+        }
+        return false;
+    }
+
+    private Map<Long, Folder> indexById(List<Folder> folders) {
+        Map<Long, Folder> byId = new HashMap<>();
+        for (Folder folder : folders) {
+            byId.put(folder.getId(), folder);
+        }
+        return byId;
+    }
+
+    private void migrateTestCaseFolderPaths(String teamKey, String previousPath, String nextPath) {
+        if (previousPath == null || previousPath.isBlank() || nextPath == null || nextPath.isBlank()) {
+            return;
+        }
+
+        List<TestCase> cases = testCaseRepository.findByTeamKey(teamKey);
+        for (TestCase testCase : cases) {
+            String currentFolder = testCase.getFolder();
+            String normalizedCurrent = normalizeFolderPath(currentFolder);
+            if (normalizedCurrent.isBlank()) {
+                continue;
+            }
+
+            if (normalizedCurrent.equals(previousPath)) {
+                testCase.setFolder(nextPath);
+                continue;
+            }
+
+            String prefix = previousPath + "/";
+            if (normalizedCurrent.startsWith(prefix)) {
+                String suffix = normalizedCurrent.substring(previousPath.length());
+                testCase.setFolder(nextPath + suffix);
+            }
+        }
+
+        testCaseRepository.saveAll(cases);
+    }
+
+    private String normalizeFolderPath(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.trim()
+            .replace('\\', '/')
+            .replaceAll("/+", "/")
+            .replaceAll("^/+", "")
+            .replaceAll("/+$", "");
+    }
+
+    private FolderResponse toResponse(Folder folder, Map<Long, Folder> byId, Map<Long, String> pathMemo) {
+        Long parentId = folder.getParent() == null ? null : folder.getParent().getId();
+        String path = derivePath(folder, byId, pathMemo);
+        return new FolderResponse(folder.getId(), folder.getName(), parentId, path);
+    }
+
+    private String derivePath(Folder folder, Map<Long, Folder> byId, Map<Long, String> pathMemo) {
+        if (folder == null || folder.getId() == null) {
+            return "";
+        }
+
+        String cached = pathMemo.get(folder.getId());
+        if (cached != null) {
+            return cached;
+        }
+
+        String name = folder.getName() == null ? "" : folder.getName().trim();
+        String path = name;
+
+        Folder parent = folder.getParent();
+        if (parent != null && parent.getId() != null) {
+            Folder resolvedParent = byId.getOrDefault(parent.getId(), parent);
+            String parentPath = derivePath(resolvedParent, byId, pathMemo);
+            if (!parentPath.isBlank()) {
+                path = parentPath + "/" + name;
+            }
+        }
+
+        pathMemo.put(folder.getId(), path);
+        return path;
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderMutationService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderMutationService.java
@@ -17,6 +17,8 @@ import com.formswim.teststream.workspace.repository.FolderRepository;
 @Service
 public class WorkspaceFolderMutationService {
 
+    private static final int MAX_FOLDER_NAME_LENGTH = 255;
+
     private final FolderRepository folderRepository;
     private final TestCaseRepository testCaseRepository;
 
@@ -148,6 +150,10 @@ public class WorkspaceFolderMutationService {
         String name = rawName == null ? "" : rawName.trim();
         if (name.isBlank()) {
             throw new FolderBadRequestException("Folder name is required.");
+        }
+
+        if (name.length() > MAX_FOLDER_NAME_LENGTH) {
+            throw new FolderBadRequestException("Folder name cannot exceed 255 characters.");
         }
 
         if (name.contains("/") || name.contains("\\")) {

--- a/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderMutationService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderMutationService.java
@@ -2,6 +2,7 @@ package com.formswim.teststream.workspace.services;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
@@ -109,12 +110,46 @@ public class WorkspaceFolderMutationService {
 
         Map<Long, Folder> byId = indexById(folderRepository.findByTeamKeyOrderByIdAsc(teamKey));
         String folderPath = derivePath(folder, byId, new HashMap<>());
-        long boundCases = testCaseRepository.countByTeamKeyAndFolderPathHierarchy(teamKey, folderPath);
+        long boundCases = countTestCasesInHierarchy(teamKey, folderPath);
         if (boundCases > 0) {
             throw new FolderConflictException("Folder cannot be deleted because it contains test cases.");
         }
 
         folderRepository.delete(folder);
+    }
+
+    private long countTestCasesInHierarchy(String teamKey, String folderPath) {
+        String normalizedTarget = normalizeFolderPath(folderPath);
+        if (normalizedTarget.isBlank()) {
+            return 0L;
+        }
+
+        long count = 0L;
+        String hierarchyPrefix = normalizedTarget + "/";
+        for (var testCase : testCaseRepository.findByTeamKey(teamKey)) {
+            String normalizedCaseFolder = normalizeFolderPath(testCase.getFolder());
+            if (normalizedCaseFolder.isBlank()) {
+                continue;
+            }
+            if (normalizedCaseFolder.equals(normalizedTarget)
+                || normalizedCaseFolder.startsWith(hierarchyPrefix)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private String normalizeFolderPath(String rawPath) {
+        if (rawPath == null) {
+            return "";
+        }
+
+        String normalized = rawPath.trim().replace('\\', '/');
+        while (normalized.contains("//")) {
+            normalized = normalized.replace("//", "/");
+        }
+        normalized = normalized.replaceAll("^/+", "").replaceAll("/+$", "");
+        return normalized.toLowerCase(Locale.ROOT);
     }
 
     private Folder resolveParent(String teamKey, Long parentId) {

--- a/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderMutationService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderMutationService.java
@@ -13,7 +13,6 @@ import com.formswim.teststream.workspace.dto.FolderResponse;
 import com.formswim.teststream.workspace.dto.FolderUpdateRequest;
 import com.formswim.teststream.workspace.model.Folder;
 import com.formswim.teststream.workspace.repository.FolderRepository;
-import com.formswim.teststream.shared.domain.TestCase;
 
 @Service
 public class WorkspaceFolderMutationService {
@@ -62,7 +61,7 @@ public class WorkspaceFolderMutationService {
         }
 
         Folder folder = folderRepository.findByTeamKeyAndId(teamKey, id)
-            .orElseThrow(() -> new FolderBadRequestException("Folder not found."));
+            .orElseThrow(() -> new FolderNotFoundException("Folder not found."));
 
         Map<Long, Folder> byId = indexById(folderRepository.findByTeamKeyOrderByIdAsc(teamKey));
 
@@ -100,7 +99,7 @@ public class WorkspaceFolderMutationService {
     @Transactional
     public void deleteFolder(String teamKey, Long id) {
         Folder folder = folderRepository.findByTeamKeyAndId(teamKey, id)
-            .orElseThrow(() -> new FolderBadRequestException("Folder not found."));
+            .orElseThrow(() -> new FolderNotFoundException("Folder not found."));
 
         if (folderRepository.existsByTeamKeyAndParent_Id(teamKey, folder.getId())) {
             throw new FolderConflictException("Folder cannot be deleted because it contains subfolders.");
@@ -122,17 +121,27 @@ public class WorkspaceFolderMutationService {
         }
 
         return folderRepository.findByTeamKeyAndId(teamKey, parentId)
-            .orElseThrow(() -> new FolderBadRequestException("Parent folder not found."));
+            .orElseThrow(() -> new FolderNotFoundException("Parent folder not found."));
     }
 
     private void ensureSiblingNameAvailable(String teamKey, Folder parent, String name, Long selfId) {
         Long parentId = parent == null ? null : parent.getId();
+        if (parentId == null) {
+            folderRepository.findByTeamKeyAndParentIsNullAndNameIgnoreCase(teamKey, name)
+                .ifPresent(existing -> {
+                    if (selfId == null || !existing.getId().equals(selfId)) {
+                        throw new FolderConflictException("A folder with this name already exists in the target location.");
+                    }
+                });
+            return;
+        }
+
         folderRepository.findByTeamKeyAndParent_IdAndNameIgnoreCase(teamKey, parentId, name)
-            .ifPresent(existing -> {
-                if (selfId == null || !existing.getId().equals(selfId)) {
-                    throw new FolderConflictException("A folder with this name already exists in the target location.");
-                }
-            });
+                .ifPresent(existing -> {
+                    if (selfId == null || !existing.getId().equals(selfId)) {
+                        throw new FolderConflictException("A folder with this name already exists in the target location.");
+                    }
+                });
     }
 
     private String normalizeName(String rawName) {
@@ -183,39 +192,8 @@ public class WorkspaceFolderMutationService {
             return;
         }
 
-        List<TestCase> cases = testCaseRepository.findByTeamKey(teamKey);
-        for (TestCase testCase : cases) {
-            String currentFolder = testCase.getFolder();
-            String normalizedCurrent = normalizeFolderPath(currentFolder);
-            if (normalizedCurrent.isBlank()) {
-                continue;
-            }
-
-            if (normalizedCurrent.equals(previousPath)) {
-                testCase.setFolder(nextPath);
-                continue;
-            }
-
-            String prefix = previousPath + "/";
-            if (normalizedCurrent.startsWith(prefix)) {
-                String suffix = normalizedCurrent.substring(previousPath.length());
-                testCase.setFolder(nextPath + suffix);
-            }
-        }
-
-        testCaseRepository.saveAll(cases);
-    }
-
-    private String normalizeFolderPath(String value) {
-        if (value == null) {
-            return "";
-        }
-
-        return value.trim()
-            .replace('\\', '/')
-            .replaceAll("/+", "/")
-            .replaceAll("^/+", "")
-            .replaceAll("/+$", "");
+        testCaseRepository.bulkRepathExact(teamKey, previousPath, nextPath);
+        testCaseRepository.bulkRepathDescendants(teamKey, previousPath, nextPath, previousPath.length() + 1);
     }
 
     private FolderResponse toResponse(Folder folder, Map<Long, Folder> byId, Map<Long, String> pathMemo) {

--- a/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderService.java
@@ -1,0 +1,80 @@
+package com.formswim.teststream.workspace.services;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.formswim.teststream.workspace.model.Folder;
+import com.formswim.teststream.workspace.repository.FolderRepository;
+
+@Service
+public class WorkspaceFolderService {
+
+    private final FolderRepository folderRepository;
+
+    public WorkspaceFolderService(FolderRepository folderRepository) {
+        this.folderRepository = folderRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> listFolderPathsByTeamKey(String teamKey) {
+        if (teamKey == null || teamKey.isBlank()) {
+            return List.of();
+        }
+
+        List<Folder> folders = folderRepository.findByTeamKeyOrderByIdAsc(teamKey);
+        if (folders.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Folder> byId = new HashMap<>();
+        for (Folder folder : folders) {
+            byId.put(folder.getId(), folder);
+        }
+
+        Map<Long, String> pathMemo = new HashMap<>();
+        List<String> paths = new ArrayList<>(folders.size());
+        for (Folder folder : folders) {
+            String path = derivePath(folder, pathMemo, byId);
+            if (!path.isBlank()) {
+                paths.add(path);
+            }
+        }
+
+        paths.sort(String::compareToIgnoreCase);
+        return Collections.unmodifiableList(paths);
+    }
+
+    private String derivePath(Folder folder, Map<Long, String> pathMemo, Map<Long, Folder> byId) {
+        if (folder == null || folder.getId() == null) {
+            return "";
+        }
+
+        String cached = pathMemo.get(folder.getId());
+        if (cached != null) {
+            return cached;
+        }
+
+        String name = folder.getName() == null ? "" : folder.getName().trim();
+        if (name.isBlank()) {
+            pathMemo.put(folder.getId(), "");
+            return "";
+        }
+
+        Folder parent = folder.getParent();
+        String parentPath = "";
+        if (parent != null && parent.getId() != null) {
+            Folder resolvedParent = byId.getOrDefault(parent.getId(), parent);
+            parentPath = derivePath(resolvedParent, pathMemo, byId);
+        }
+
+        String path = parentPath.isBlank() ? name : parentPath + "/" + name;
+        pathMemo.put(folder.getId(), path);
+        return path;
+    }
+}

--- a/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderService.java
+++ b/src/main/java/com/formswim/teststream/workspace/services/WorkspaceFolderService.java
@@ -46,7 +46,7 @@ public class WorkspaceFolderService {
             }
         }
 
-        paths.sort(String::compareToIgnoreCase);
+        paths.sort(String::compareTo);
         return Collections.unmodifiableList(paths);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ server.servlet.session.timeout=30m
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
-# spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Safety cap for number of requested work keys in one bulk edit call.
 teststream.bulk-edit.max-work-keys=5000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ server.servlet.session.timeout=30m
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
-spring.datasource.driver-class-name=org.postgresql.Driver
+# spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Safety cap for number of requested work keys in one bulk edit call.
 teststream.bulk-edit.max-work-keys=5000

--- a/src/main/resources/static/js/workspace/api/workspace-page-api.js
+++ b/src/main/resources/static/js/workspace/api/workspace-page-api.js
@@ -21,6 +21,36 @@ function fetchOptionValues(url) {
         .then((data) => uniqueSorted(Array.isArray(data) ? data : []));
 }
 
+function getCsrfHeaders() {
+    const headerName = document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN';
+    const token = document.querySelector('meta[name="_csrf"]')?.content || '';
+    return {
+        [headerName]: token
+    };
+}
+
+async function parseJsonOrEmpty(response) {
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+        return null;
+    }
+
+    try {
+        return await response.json();
+    } catch (error) {
+        return null;
+    }
+}
+
+async function toApiError(response, fallbackMessage) {
+    const payload = await parseJsonOrEmpty(response);
+    const message = payload?.message || fallbackMessage || ('Request failed with status ' + response.status);
+    const error = new Error(message);
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+}
+
 export function createWorkspacePageApi(options) {
     const apiBaseUrl = options.apiBaseUrl;
     const componentsBaseUrl = options.componentsBaseUrl;
@@ -58,6 +88,75 @@ export function createWorkspacePageApi(options) {
                 return response.json();
             })
             .then((data) => (Array.isArray(data) ? data : []));
+    }
+
+    function fetchFolderNodes() {
+        return fetch('/api/folders/nodes')
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Folder nodes failed with status ' + response.status);
+                }
+                return response.json();
+            })
+            .then((data) => (Array.isArray(data) ? data : []));
+    }
+
+    async function createFolder(input) {
+        const response = await fetch('/api/folders', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...getCsrfHeaders()
+            },
+            body: JSON.stringify({
+                name: input?.name || '',
+                parentId: Object.prototype.hasOwnProperty.call(input || {}, 'parentId') ? input.parentId : undefined
+            })
+        });
+
+        if (!response.ok) {
+            return toApiError(response, 'Failed to create folder.');
+        }
+
+        return parseJsonOrEmpty(response);
+    }
+
+    async function updateFolder(folderId, input) {
+        const payload = {};
+        if (Object.prototype.hasOwnProperty.call(input || {}, 'name')) {
+            payload.name = input.name;
+        }
+        if (Object.prototype.hasOwnProperty.call(input || {}, 'parentId')) {
+            payload.parentId = input.parentId;
+        }
+
+        const response = await fetch('/api/folders/' + encodeURIComponent(String(folderId)), {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+                ...getCsrfHeaders()
+            },
+            body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+            return toApiError(response, 'Failed to update folder.');
+        }
+
+        return parseJsonOrEmpty(response);
+    }
+
+    async function deleteFolder(folderId) {
+        const response = await fetch('/api/folders/' + encodeURIComponent(String(folderId)), {
+            method: 'DELETE',
+            headers: {
+                ...getCsrfHeaders()
+            }
+        });
+
+        if (!response.ok) {
+            return toApiError(response, 'Failed to delete folder.');
+        }
     }
 
     function fetchFilterOptions() {
@@ -129,9 +228,13 @@ export function createWorkspacePageApi(options) {
 
     return {
         bulkMove,
+        createFolder,
+        deleteFolder,
         fetchFilterOptions,
         fetchFolders,
+        fetchFolderNodes,
         fetchPage,
+        updateFolder,
         uploadFile
     };
 }

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -414,6 +414,7 @@ export function createWorkspaceFolderTree(options) {
         if (activeFolderDropTargetEl) {
             activeFolderDropTargetEl.classList.remove('ws-folder-drop-hover');
             activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-top');
+            activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-bottom');
         }
 
         activeFolderDropTargetEl = targetEl;
@@ -431,6 +432,7 @@ export function createWorkspaceFolderTree(options) {
         if (activeFolderDropTargetEl) {
             activeFolderDropTargetEl.classList.remove('ws-folder-drop-hover');
             activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-top');
+            activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-bottom');
             activeFolderDropTargetEl = null;
         }
         activeFolderDropMode = null;

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -25,6 +25,7 @@ export function createWorkspaceFolderTree(options) {
     let activeFolderDropTargetEl = null;
     let activeFolderDropMode = null;
     let isFolderLoading = false;
+    let pendingDeletePrompt = null;
 
     function snapshotExpandedState(model) {
         const expandedByPath = new Map();
@@ -167,7 +168,7 @@ export function createWorkspaceFolderTree(options) {
                             path: currentPath,
                             parentPath,
                             children: new Map(),
-                            expanded: true
+                            expanded: false
                         });
                     }
 
@@ -205,7 +206,7 @@ export function createWorkspaceFolderTree(options) {
                         path: currentPath,
                         parentPath,
                         children: new Map(),
-                        expanded: true
+                        expanded: false
                     });
                 }
                 current = current.children.get(part);
@@ -242,6 +243,106 @@ export function createWorkspaceFolderTree(options) {
         if (message) {
             window.alert(String(message));
         }
+    }
+
+    function dismissDeletePrompt(confirmed) {
+        if (!pendingDeletePrompt) {
+            return;
+        }
+
+        const { root, resolve, onKeyDown } = pendingDeletePrompt;
+        pendingDeletePrompt = null;
+
+        if (onKeyDown) {
+            document.removeEventListener('keydown', onKeyDown);
+        }
+        if (root && root.parentNode) {
+            root.parentNode.removeChild(root);
+        }
+        resolve(Boolean(confirmed));
+    }
+
+    function confirmDeleteFolder(path) {
+        if (pendingDeletePrompt) {
+            dismissDeletePrompt(false);
+        }
+
+        return new Promise((resolve) => {
+            const root = document.createElement('div');
+            root.className = 'fixed right-4 top-4 z-[1400] w-[min(28rem,calc(100vw-2rem))]';
+
+            const notice = document.createElement('div');
+            notice.className = 'border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80 shadow-[0_18px_48px_rgba(0,0,0,0.55)]';
+            notice.style.borderColor = 'rgba(255, 255, 255, 0.15)';
+
+            const headingRow = document.createElement('div');
+            headingRow.className = 'flex items-start justify-between gap-3';
+
+            const headingWrap = document.createElement('div');
+            headingWrap.className = 'min-w-0';
+
+            const badge = document.createElement('span');
+            badge.className = 'font-bold text-black px-2 py-1 mr-3 bg-white/70';
+            badge.textContent = 'Confirm';
+
+            const heading = document.createElement('span');
+            heading.className = 'font-medium text-white';
+            heading.textContent = 'Delete folder?';
+
+            const message = document.createElement('p');
+            message.className = 'mt-2 break-words text-white/75';
+            message.textContent = 'Delete "' + String(path || '') + '"? Only empty folders can be deleted.';
+
+            const actions = document.createElement('div');
+            actions.className = 'mt-3 flex items-center justify-end gap-2';
+
+            const cancelButton = document.createElement('button');
+            cancelButton.type = 'button';
+            cancelButton.className = 'px-3 py-1.5 border border-white/20 hover:border-white/40 text-white/85 hover:text-white transition-colors text-xs';
+            cancelButton.textContent = 'Cancel';
+
+            const deleteButton = document.createElement('button');
+            deleteButton.type = 'button';
+            deleteButton.className = 'px-3 py-1.5 border text-black font-semibold text-xs transition-colors';
+            deleteButton.style.borderColor = '#E7FF02';
+            deleteButton.style.backgroundColor = '#E7FF02';
+            deleteButton.textContent = 'Delete';
+
+            headingWrap.appendChild(badge);
+            headingWrap.appendChild(heading);
+            headingWrap.appendChild(message);
+
+            actions.appendChild(cancelButton);
+            actions.appendChild(deleteButton);
+
+            headingRow.appendChild(headingWrap);
+            notice.appendChild(headingRow);
+            notice.appendChild(actions);
+            root.appendChild(notice);
+            document.body.appendChild(root);
+
+            const onKeyDown = (event) => {
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    dismissDeletePrompt(false);
+                }
+            };
+
+            pendingDeletePrompt = {
+                root,
+                resolve,
+                onKeyDown
+            };
+
+            document.addEventListener('keydown', onKeyDown);
+
+            cancelButton.addEventListener('click', () => dismissDeletePrompt(false));
+            deleteButton.addEventListener('click', () => dismissDeletePrompt(true));
+
+            window.requestAnimationFrame(() => {
+                deleteButton.focus();
+            });
+        });
     }
 
     function closeContextMenu() {
@@ -421,13 +522,18 @@ export function createWorkspaceFolderTree(options) {
     }
 
     async function handleDeleteFolder(node) {
+        if (node?.children && node.children.size > 0) {
+            notify('error', 'Folder cannot be deleted because it contains subfolders.');
+            return;
+        }
+
         const meta = getNodeMetaByPath(node.path);
         if (!meta?.id) {
             notify('error', 'Cannot delete this folder because its id is unavailable.');
             return;
         }
 
-        const confirmed = window.confirm('Delete folder "' + node.path + '"?');
+        const confirmed = await confirmDeleteFolder(node.path);
         if (!confirmed) {
             return;
         }

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -24,6 +24,7 @@ export function createWorkspaceFolderTree(options) {
     let activeFolderDrag = null;
     let activeFolderDropTargetEl = null;
     let activeFolderDropMode = null;
+    let isFolderLoading = false;
 
     function setSidebarExpanded(expanded) {
         uiState.setSidebarExpanded(expanded);
@@ -547,6 +548,17 @@ export function createWorkspaceFolderTree(options) {
             '</span>' +
             '<span class="min-w-0 truncate">Show all files</span>';
 
+        if (isFolderLoading) {
+            const loadingSpinner = document.createElement('span');
+            loadingSpinner.className = 'shrink-0 inline-flex items-center justify-center text-white/55';
+            loadingSpinner.setAttribute('aria-label', 'Loading folders');
+            loadingSpinner.innerHTML =
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-3.5 h-3.5 animate-spin" aria-hidden="true" focusable="false">' +
+                '<path d="M12 3a9 9 0 1 0 9 9" />' +
+                '</svg>';
+            showAllButton.appendChild(loadingSpinner);
+        }
+
         showAllButton.addEventListener('click', () => {
             if (!uiState.getSelectedFolder()) {
                 return;
@@ -844,13 +856,16 @@ export function createWorkspaceFolderTree(options) {
     }
 
     function loadFolders() {
+        isFolderLoading = true;
         if (folderLoading) {
-            folderLoading.classList.remove('hidden');
+            folderLoading.classList.add('hidden');
         }
         if (folderEmpty) {
             folderEmpty.classList.add('hidden');
             folderEmpty.textContent = 'No folders found.';
         }
+
+        renderFolderTree();
 
         const folderNodesPromise = typeof api.fetchFolderNodes === 'function'
             ? api.fetchFolderNodes().catch(() => [])
@@ -858,6 +873,7 @@ export function createWorkspaceFolderTree(options) {
 
         return Promise.all([api.fetchFolders(), folderNodesPromise])
             .then(([folders, nodes]) => {
+                isFolderLoading = false;
                 folderNodeByPath = new Map();
                 for (const node of nodes || []) {
                     const normalizedPath = uiState.normalizeFolder(node?.path || '');
@@ -882,6 +898,7 @@ export function createWorkspaceFolderTree(options) {
             })
             .catch((error) => {
                 console.error('Failed to load folders', error);
+                isFolderLoading = false;
                 folderTreeModel = createFolderTreeModel([], []);
                 folderNodeByPath = new Map();
                 if (folderLoading) {

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -26,6 +26,53 @@ export function createWorkspaceFolderTree(options) {
     let activeFolderDropMode = null;
     let isFolderLoading = false;
 
+    function snapshotExpandedState(model) {
+        const expandedByPath = new Map();
+        if (!model || !model.pathIndex) {
+            return expandedByPath;
+        }
+
+        for (const [path, node] of model.pathIndex.entries()) {
+            if (!path || !node) {
+                continue;
+            }
+            expandedByPath.set(path, Boolean(node.expanded));
+        }
+        return expandedByPath;
+    }
+
+    function applyExpandedState(model, expandedByPath) {
+        if (!model || !model.pathIndex || !expandedByPath) {
+            return;
+        }
+
+        for (const [path, node] of model.pathIndex.entries()) {
+            if (!path || !node) {
+                continue;
+            }
+            if (expandedByPath.has(path)) {
+                node.expanded = expandedByPath.get(path);
+            }
+        }
+    }
+
+    function expandPath(path) {
+        const normalized = uiState.normalizeFolder(path || '');
+        if (!normalized || !folderTreeModel || !folderTreeModel.pathIndex) {
+            return;
+        }
+
+        const segments = normalized.split('/').filter(Boolean);
+        let currentPath = '';
+        for (const segment of segments) {
+            currentPath = currentPath ? currentPath + '/' + segment : segment;
+            const node = folderTreeModel.pathIndex.get(currentPath);
+            if (node) {
+                node.expanded = true;
+            }
+        }
+    }
+
     function setSidebarExpanded(expanded) {
         uiState.setSidebarExpanded(expanded);
         const isSidebarExpanded = uiState.isSidebarExpanded();
@@ -286,6 +333,9 @@ export function createWorkspaceFolderTree(options) {
             parentId: parentMeta?.id ?? null,
             value: ''
         };
+        if (parentPath) {
+            expandPath(parentPath);
+        }
         renderFolderTree();
     }
 
@@ -856,6 +906,8 @@ export function createWorkspaceFolderTree(options) {
     }
 
     function loadFolders() {
+        const expandedByPath = snapshotExpandedState(folderTreeModel);
+
         isFolderLoading = true;
         if (folderLoading) {
             folderLoading.classList.add('hidden');
@@ -883,6 +935,7 @@ export function createWorkspaceFolderTree(options) {
                 }
 
                 folderTreeModel = createFolderTreeModel(folders, nodes);
+                applyExpandedState(folderTreeModel, expandedByPath);
 
                 if (folderLoading) {
                     folderLoading.classList.add('hidden');

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -678,14 +678,6 @@ export function createWorkspaceFolderTree(options) {
                 toggle.innerHTML = '<span class="block w-4 h-4"></span>';
             }
 
-            const selectButton = document.createElement('button');
-            selectButton.type = 'button';
-            selectButton.className = rowSelectButtonClasses;
-            selectButton.setAttribute('aria-label', 'Filter by folder ' + node.path);
-            if (isSelected) {
-                selectButton.setAttribute('aria-current', 'true');
-            }
-
             const iconHtml = isOpen
                 ? '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4"><path d="M3 8a2 2 0 0 1 2-2h4l2 2h9a2 2 0 0 1 2 2v1" /><path d="M3 11h18l-1.5 8.5a2 2 0 0 1-2 1.5H6.5a2 2 0 0 1-2-1.5L3 11z" /></svg>'
                 : '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4"><path d="M3 7a2 2 0 0 1 2-2h5l2 2h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" /></svg>';
@@ -698,8 +690,15 @@ export function createWorkspaceFolderTree(options) {
             labelSpan.className = 'min-w-0 truncate';
             labelSpan.textContent = node.name;
 
-            selectButton.appendChild(iconSpan);
-            if (inlineEditorState && inlineEditorState.mode === 'rename' && inlineEditorState.targetPath === node.path) {
+            const isRenameEditing = Boolean(inlineEditorState && inlineEditorState.mode === 'rename' && inlineEditorState.targetPath === node.path);
+
+            if (isRenameEditing) {
+                const editContainer = document.createElement('div');
+                editContainer.className = rowSelectButtonClasses;
+                editContainer.setAttribute('role', 'group');
+                editContainer.setAttribute('aria-label', 'Rename folder ' + node.path);
+                editContainer.appendChild(iconSpan);
+
                 const editInput = document.createElement('input');
                 editInput.type = 'text';
                 editInput.value = inlineEditorState.value || node.name;
@@ -722,21 +721,39 @@ export function createWorkspaceFolderTree(options) {
                     }
                     await submitInlineEditor(editInput.value);
                 });
-                selectButton.appendChild(editInput);
+                editContainer.appendChild(editInput);
+                rowInner.appendChild(toggle);
+                rowInner.appendChild(editContainer);
+                rowWrap.appendChild(rowInner);
+                folderTree.appendChild(rowWrap);
+
                 window.requestAnimationFrame(() => {
                     editInput.focus();
                     editInput.select();
                 });
             } else {
-                selectButton.appendChild(labelSpan);
-            }
+                const selectButton = document.createElement('button');
+                selectButton.type = 'button';
+                selectButton.className = rowSelectButtonClasses;
+                selectButton.setAttribute('aria-label', 'Filter by folder ' + node.path);
+                if (isSelected) {
+                    selectButton.setAttribute('aria-current', 'true');
+                }
 
-            selectButton.addEventListener('click', () => {
-                const next = uiState.getSelectedFolder() === node.path ? '' : node.path;
-                uiState.setSelectedFolder(next);
-                renderFolderTree();
-                emitFolderChanged(next);
-            });
+                selectButton.appendChild(iconSpan);
+                selectButton.appendChild(labelSpan);
+                selectButton.addEventListener('click', () => {
+                    const next = uiState.getSelectedFolder() === node.path ? '' : node.path;
+                    uiState.setSelectedFolder(next);
+                    renderFolderTree();
+                    emitFolderChanged(next);
+                });
+
+                rowInner.appendChild(toggle);
+                rowInner.appendChild(selectButton);
+                rowWrap.appendChild(rowInner);
+                folderTree.appendChild(rowWrap);
+            }
 
             rowInner.addEventListener('contextmenu', (event) => {
                 event.preventDefault();
@@ -805,11 +822,6 @@ export function createWorkspaceFolderTree(options) {
                 clearFolderDropHover();
                 await handleFolderDrop(dragPayload, targetNode, dropMode);
             });
-
-            rowInner.appendChild(toggle);
-            rowInner.appendChild(selectButton);
-            rowWrap.appendChild(rowInner);
-            folderTree.appendChild(rowWrap);
 
             if (inlineEditorState && inlineEditorState.mode === 'create' && inlineEditorState.parentPath === node.path) {
                 renderInlineEditorRow(node, depth + 1);

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -414,7 +414,6 @@ export function createWorkspaceFolderTree(options) {
         if (activeFolderDropTargetEl) {
             activeFolderDropTargetEl.classList.remove('ws-folder-drop-hover');
             activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-top');
-            activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-bottom');
         }
 
         activeFolderDropTargetEl = targetEl;
@@ -432,7 +431,6 @@ export function createWorkspaceFolderTree(options) {
         if (activeFolderDropTargetEl) {
             activeFolderDropTargetEl.classList.remove('ws-folder-drop-hover');
             activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-top');
-            activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-bottom');
             activeFolderDropTargetEl = null;
         }
         activeFolderDropMode = null;

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -4,6 +4,7 @@ export function createWorkspaceFolderTree(options) {
     const folderTree = options.folderTree;
     const folderLoading = options.folderLoading;
     const folderEmpty = options.folderEmpty;
+    const newFolderButton = options.newFolderButton;
     const sidebar = options.sidebar;
     const sidebarToggle = options.sidebarToggle;
     const sidebarContent = options.sidebarContent;
@@ -12,9 +13,17 @@ export function createWorkspaceFolderTree(options) {
     const sidebarHeader = options.sidebarHeader;
     const sidebarToggleExpandedHost = options.sidebarToggleExpandedHost;
     const sidebarToggleCollapsedHost = options.sidebarToggleCollapsedHost;
+    const showNotice = options.showNotice;
     const onFolderChanged = options.onFolderChanged;
 
-    let folderTreeModel = createFolderTreeModel([]);
+    let folderTreeModel = createFolderTreeModel([], []);
+    let folderNodeByPath = new Map();
+    let inlineEditorState = null;
+    let contextMenuEl = null;
+    let contextMenuCleanupBound = false;
+    let activeFolderDrag = null;
+    let activeFolderDropTargetEl = null;
+    let activeFolderDropMode = null;
 
     function setSidebarExpanded(expanded) {
         uiState.setSidebarExpanded(expanded);
@@ -71,13 +80,62 @@ export function createWorkspaceFolderTree(options) {
         }
     }
 
-    function createFolderTreeModel(folderNames) {
+    function createFolderTreeModel(folderNames, folderNodes) {
         const root = {
             name: '',
+            id: null,
             path: '',
+            parentPath: '',
             children: new Map(),
             expanded: true
         };
+
+        const pathIndex = new Map();
+        pathIndex.set('', root);
+
+        const normalizedNodes = Array.isArray(folderNodes) ? folderNodes : [];
+
+        if (normalizedNodes.length > 0) {
+            for (const rawNode of normalizedNodes) {
+                const normalized = uiState.normalizeFolder(rawNode?.path || '');
+                const name = String(rawNode?.name || '').trim();
+                if (!normalized || !name) {
+                    continue;
+                }
+
+                const parts = normalized.split('/').filter(Boolean);
+                let current = root;
+                let currentPath = '';
+
+                for (let index = 0; index < parts.length; index++) {
+                    const part = parts[index];
+                    const parentPath = currentPath;
+                    currentPath = currentPath ? currentPath + '/' + part : part;
+
+                    if (!current.children.has(part)) {
+                        current.children.set(part, {
+                            id: null,
+                            name: part,
+                            path: currentPath,
+                            parentPath,
+                            children: new Map(),
+                            expanded: true
+                        });
+                    }
+
+                    const child = current.children.get(part);
+                    if (index === parts.length - 1) {
+                        child.id = rawNode?.id ?? null;
+                        child.name = name;
+                    }
+
+                    pathIndex.set(currentPath, child);
+                    current = child;
+                }
+            }
+
+            return { root, pathIndex };
+        }
 
         for (const folderName of folderNames || []) {
             const normalized = uiState.normalizeFolder(folderName);
@@ -90,20 +148,369 @@ export function createWorkspaceFolderTree(options) {
             let currentPath = '';
 
             for (const part of parts) {
+                const parentPath = currentPath;
                 currentPath = currentPath ? currentPath + '/' + part : part;
                 if (!current.children.has(part)) {
                     current.children.set(part, {
+                        id: null,
                         name: part,
                         path: currentPath,
+                        parentPath,
                         children: new Map(),
                         expanded: true
                     });
                 }
                 current = current.children.get(part);
+                pathIndex.set(currentPath, current);
             }
         }
 
-        return root;
+        return { root, pathIndex };
+    }
+
+    function getNodeMetaByPath(path) {
+        const normalized = uiState.normalizeFolder(path || '');
+        if (!normalized) {
+            return null;
+        }
+        return folderNodeByPath.get(normalized) || null;
+    }
+
+    function clearInlineEditor() {
+        inlineEditorState = null;
+    }
+
+    function emitFolderChanged(path) {
+        if (typeof onFolderChanged === 'function') {
+            onFolderChanged(path || '');
+        }
+    }
+
+    function notify(type, message) {
+        if (typeof showNotice === 'function') {
+            showNotice(type, message);
+            return;
+        }
+        if (message) {
+            window.alert(String(message));
+        }
+    }
+
+    function closeContextMenu() {
+        if (contextMenuEl && contextMenuEl.parentNode) {
+            contextMenuEl.parentNode.removeChild(contextMenuEl);
+        }
+        contextMenuEl = null;
+    }
+
+    function bindContextMenuCleanup() {
+        if (contextMenuCleanupBound) {
+            return;
+        }
+        contextMenuCleanupBound = true;
+        document.addEventListener('click', () => closeContextMenu());
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                closeContextMenu();
+            }
+        });
+        window.addEventListener('resize', () => closeContextMenu());
+    }
+
+    function openContextMenu(node, event) {
+        closeContextMenu();
+        bindContextMenuCleanup();
+
+        const menu = document.createElement('div');
+        menu.className = 'fixed z-[1200] min-w-[10rem] border border-white/20 bg-black text-white shadow-xl';
+        menu.style.left = String(event.clientX) + 'px';
+        menu.style.top = String(event.clientY) + 'px';
+
+        const actions = [
+            {
+                label: 'New Folder',
+                handler: () => {
+                    startInlineCreate(node);
+                }
+            },
+            {
+                label: 'Rename',
+                disabled: !node.id,
+                handler: () => {
+                    startInlineRename(node);
+                }
+            },
+            {
+                label: 'Delete',
+                disabled: !node.id,
+                handler: () => {
+                    handleDeleteFolder(node);
+                }
+            }
+        ];
+
+        for (const action of actions) {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'block w-full px-3 py-2 text-left text-sm transition-colors';
+            button.classList.add(action.disabled ? 'text-white/35 cursor-not-allowed' : 'hover:bg-white/10');
+            button.textContent = action.label;
+            button.disabled = Boolean(action.disabled);
+            button.addEventListener('click', (clickEvent) => {
+                clickEvent.stopPropagation();
+                closeContextMenu();
+                if (!action.disabled) {
+                    action.handler();
+                }
+            });
+            menu.appendChild(button);
+        }
+
+        document.body.appendChild(menu);
+        contextMenuEl = menu;
+    }
+
+    function startInlineCreate(parentNode) {
+        const parentPath = parentNode?.path || '';
+        const parentMeta = parentPath ? getNodeMetaByPath(parentPath) : null;
+
+        if (parentPath && !parentMeta?.id) {
+            notify('error', 'Cannot create subfolder here because this folder id is unavailable.');
+            return;
+        }
+
+        inlineEditorState = {
+            mode: 'create',
+            parentPath,
+            parentId: parentMeta?.id ?? null,
+            value: ''
+        };
+        renderFolderTree();
+    }
+
+    function startInlineRename(node) {
+        const meta = getNodeMetaByPath(node.path);
+        if (!meta?.id) {
+            notify('error', 'Cannot rename this folder because its id is unavailable.');
+            return;
+        }
+
+        inlineEditorState = {
+            mode: 'rename',
+            targetId: meta.id,
+            targetPath: node.path,
+            value: node.name
+        };
+        renderFolderTree();
+    }
+
+    async function submitInlineEditor(value) {
+        if (!inlineEditorState) {
+            return;
+        }
+
+        const name = String(value || '').trim();
+        if (!name) {
+            clearInlineEditor();
+            renderFolderTree();
+            return;
+        }
+
+        try {
+            if (inlineEditorState.mode === 'create') {
+                const created = await api.createFolder({
+                    name,
+                    parentId: inlineEditorState.parentId
+                });
+
+                clearInlineEditor();
+                const currentSelection = uiState.getSelectedFolder();
+                await loadFolders();
+
+                if (created?.path) {
+                    uiState.setSelectedFolder(uiState.normalizeFolder(created.path));
+                    renderFolderTree();
+                    emitFolderChanged(uiState.getSelectedFolder());
+                    notify('success', 'Folder created.');
+                } else if (currentSelection) {
+                    emitFolderChanged(currentSelection);
+                }
+                return;
+            }
+
+            if (inlineEditorState.mode === 'rename') {
+                const updated = await api.updateFolder(inlineEditorState.targetId, { name });
+                const previousSelected = uiState.getSelectedFolder();
+                const renamedPath = inlineEditorState.targetPath;
+
+                clearInlineEditor();
+                await loadFolders();
+
+                if (previousSelected && renamedPath && updated?.path) {
+                    const normalizedRenamedPath = uiState.normalizeFolder(renamedPath);
+                    const normalizedUpdatedPath = uiState.normalizeFolder(updated.path);
+
+                    if (previousSelected === normalizedRenamedPath) {
+                        uiState.setSelectedFolder(normalizedUpdatedPath);
+                    } else if (previousSelected.startsWith(normalizedRenamedPath + '/')) {
+                        const suffix = previousSelected.slice(normalizedRenamedPath.length);
+                        uiState.setSelectedFolder(uiState.normalizeFolder(normalizedUpdatedPath + suffix));
+                    }
+                }
+
+                emitFolderChanged(uiState.getSelectedFolder());
+
+                notify('success', 'Folder renamed.');
+            }
+        } catch (error) {
+            notify('error', error?.message || 'Folder operation failed.');
+            clearInlineEditor();
+            renderFolderTree();
+        }
+    }
+
+    async function handleDeleteFolder(node) {
+        const meta = getNodeMetaByPath(node.path);
+        if (!meta?.id) {
+            notify('error', 'Cannot delete this folder because its id is unavailable.');
+            return;
+        }
+
+        const confirmed = window.confirm('Delete folder "' + node.path + '"?');
+        if (!confirmed) {
+            return;
+        }
+
+        try {
+            await api.deleteFolder(meta.id);
+            const selected = uiState.getSelectedFolder();
+            if (selected && (selected === node.path || selected.startsWith(node.path + '/'))) {
+                uiState.setSelectedFolder('');
+                emitFolderChanged('');
+            }
+            await loadFolders();
+            notify('success', 'Folder deleted.');
+        } catch (error) {
+            notify('error', error?.message || 'Folder delete failed.');
+        }
+    }
+
+    function isInvalidFolderDrop(sourcePath, candidateParentPath) {
+        if (!sourcePath) {
+            return true;
+        }
+        const normalizedParent = uiState.normalizeFolder(candidateParentPath || '');
+        if (sourcePath === normalizedParent) {
+            return true;
+        }
+        return Boolean(normalizedParent && normalizedParent.startsWith(sourcePath + '/'));
+    }
+
+    function setFolderDropHover(targetEl, mode) {
+        if (activeFolderDropTargetEl === targetEl && activeFolderDropMode === mode) {
+            return;
+        }
+        if (activeFolderDropTargetEl) {
+            activeFolderDropTargetEl.classList.remove('ws-folder-drop-hover');
+            activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-top');
+            activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-bottom');
+        }
+
+        activeFolderDropTargetEl = targetEl;
+        activeFolderDropMode = mode || null;
+        if (activeFolderDropTargetEl) {
+            if (activeFolderDropMode === 'sibling-before') {
+                activeFolderDropTargetEl.classList.add('ws-folder-drop-line-top');
+            } else {
+                activeFolderDropTargetEl.classList.add('ws-folder-drop-hover');
+            }
+        }
+    }
+
+    function clearFolderDropHover() {
+        if (activeFolderDropTargetEl) {
+            activeFolderDropTargetEl.classList.remove('ws-folder-drop-hover');
+            activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-top');
+            activeFolderDropTargetEl.classList.remove('ws-folder-drop-line-bottom');
+            activeFolderDropTargetEl = null;
+        }
+        activeFolderDropMode = null;
+    }
+
+    function resolveDropMode(event, rowEl) {
+        const rect = rowEl.getBoundingClientRect();
+        if (!rect || rect.height <= 0) {
+            return 'child';
+        }
+
+        const offsetY = event.clientY - rect.top;
+        const edgeThreshold = Math.min(8, Math.max(4, rect.height * 0.2));
+        if (offsetY <= edgeThreshold) {
+            return 'sibling-before';
+        }
+        return 'child';
+    }
+
+    function resolveCandidateParentPath(targetNode, dropMode) {
+        if (!targetNode) {
+            return '';
+        }
+        if (dropMode === 'sibling-before') {
+            return targetNode.parentPath || '';
+        }
+        return targetNode.path || '';
+    }
+
+    function isSelfTopDrop(sourcePath, targetPath, dropMode) {
+        return dropMode === 'sibling-before' && sourcePath && sourcePath === uiState.normalizeFolder(targetPath || '');
+    }
+
+    async function handleFolderDrop(dragPayload, targetNode, dropMode) {
+        if (!dragPayload || !targetNode) {
+            return;
+        }
+
+        const sourcePath = uiState.normalizeFolder(dragPayload.path || '');
+        const targetPath = uiState.normalizeFolder(targetNode.path || '');
+        if (isSelfTopDrop(sourcePath, targetPath, dropMode)) {
+            notify('error', 'Cannot drop a folder on its own top edge.');
+            return;
+        }
+
+        const candidateParentPath = uiState.normalizeFolder(resolveCandidateParentPath(targetNode, dropMode));
+        if (isInvalidFolderDrop(sourcePath, candidateParentPath)) {
+            notify('error', 'Cannot move a folder into itself or its descendants.');
+            return;
+        }
+
+        const targetMeta = getNodeMetaByPath(uiState.normalizeFolder(targetNode.path || ''));
+        if (!targetMeta) {
+            notify('error', 'Destination folder is unavailable.');
+            return;
+        }
+
+        let nextParentId = null;
+        if (dropMode === 'sibling-before') {
+            nextParentId = targetMeta.parentId ?? null;
+        } else if (targetMeta.id) {
+            nextParentId = targetMeta.id;
+        } else {
+            notify('error', 'Destination folder is unavailable.');
+            return;
+        }
+
+        try {
+            const updated = await api.updateFolder(dragPayload.id, { parentId: nextParentId });
+            const selected = uiState.getSelectedFolder();
+            if (selected && selected === sourcePath && updated?.path) {
+                uiState.setSelectedFolder(uiState.normalizeFolder(updated.path));
+                emitFolderChanged(uiState.getSelectedFolder());
+            }
+            await loadFolders();
+            notify('success', 'Folder moved.');
+        } catch (error) {
+            notify('error', error?.message || 'Folder move failed.');
+        }
     }
 
     function renderFolderTree() {
@@ -155,11 +562,66 @@ export function createWorkspaceFolderTree(options) {
         showAllWrap.appendChild(showAllInner);
         folderTree.appendChild(showAllWrap);
 
-        if (!folderTreeModel || !folderTreeModel.children || folderTreeModel.children.size === 0) {
+        if (!folderTreeModel || !folderTreeModel.root || !folderTreeModel.root.children || folderTreeModel.root.children.size === 0) {
+            if (inlineEditorState && inlineEditorState.mode === 'create' && !inlineEditorState.parentPath) {
+                renderInlineEditorRow(null, 0);
+            }
             return;
         }
 
         const sortedChildren = (node) => Array.from(node.children.values()).sort((a, b) => a.name.localeCompare(b.name));
+
+        function renderInlineEditorRow(parentNode, depth) {
+            const rowWrap = document.createElement('div');
+            rowWrap.className = rowWrapClasses;
+            rowWrap.style.paddingLeft = String(12 + depth * 16) + 'px';
+
+            const rowInner = document.createElement('div');
+            rowInner.className = rowInnerBaseClasses + ' text-white/90 bg-white/5';
+            rowInner.style.position = 'relative';
+            rowInner.style.zIndex = '1';
+
+            const spacer = document.createElement('span');
+            spacer.className = 'shrink-0 w-5 h-5 flex items-center justify-center text-white/50';
+            spacer.innerHTML =
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4"><path d="M12 5v14" /><path d="M5 12h14" /></svg>';
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.value = inlineEditorState?.value || '';
+            input.className = 'min-w-0 flex-1 bg-black border border-white/20 px-2 py-1 text-sm text-white focus:outline-none focus:border-[#E7FF02]';
+            input.placeholder = inlineEditorState?.mode === 'rename' ? 'Rename folder' : 'New folder';
+
+            input.addEventListener('keydown', async (event) => {
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    clearInlineEditor();
+                    renderFolderTree();
+                    return;
+                }
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    await submitInlineEditor(input.value);
+                }
+            });
+
+            input.addEventListener('blur', async () => {
+                if (!inlineEditorState) {
+                    return;
+                }
+                await submitInlineEditor(input.value);
+            });
+
+            rowInner.appendChild(spacer);
+            rowInner.appendChild(input);
+            rowWrap.appendChild(rowInner);
+            folderTree.appendChild(rowWrap);
+
+            window.requestAnimationFrame(() => {
+                input.focus();
+                input.select();
+            });
+        }
 
         const renderNode = (node, depth) => {
             const hasChildren = node.children && node.children.size > 0;
@@ -185,6 +647,13 @@ export function createWorkspaceFolderTree(options) {
             rowInner.style.zIndex = '1';
             rowInner.dataset.dropTarget = 'folder';
             rowInner.dataset.folderPath = node.path;
+
+            const nodeMeta = getNodeMetaByPath(node.path);
+            const canMutate = Boolean(nodeMeta?.id);
+            if (canMutate) {
+                rowInner.draggable = true;
+                rowInner.dataset.folderId = String(nodeMeta.id);
+            }
 
             let toggle;
             if (hasChildren) {
@@ -230,20 +699,121 @@ export function createWorkspaceFolderTree(options) {
             labelSpan.textContent = node.name;
 
             selectButton.appendChild(iconSpan);
-            selectButton.appendChild(labelSpan);
+            if (inlineEditorState && inlineEditorState.mode === 'rename' && inlineEditorState.targetPath === node.path) {
+                const editInput = document.createElement('input');
+                editInput.type = 'text';
+                editInput.value = inlineEditorState.value || node.name;
+                editInput.className = 'min-w-0 flex-1 bg-black border border-white/20 px-2 py-1 text-sm text-white focus:outline-none focus:border-[#E7FF02]';
+                editInput.addEventListener('keydown', async (event) => {
+                    if (event.key === 'Escape') {
+                        event.preventDefault();
+                        clearInlineEditor();
+                        renderFolderTree();
+                        return;
+                    }
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        await submitInlineEditor(editInput.value);
+                    }
+                });
+                editInput.addEventListener('blur', async () => {
+                    if (!inlineEditorState) {
+                        return;
+                    }
+                    await submitInlineEditor(editInput.value);
+                });
+                selectButton.appendChild(editInput);
+                window.requestAnimationFrame(() => {
+                    editInput.focus();
+                    editInput.select();
+                });
+            } else {
+                selectButton.appendChild(labelSpan);
+            }
+
             selectButton.addEventListener('click', () => {
                 const next = uiState.getSelectedFolder() === node.path ? '' : node.path;
                 uiState.setSelectedFolder(next);
                 renderFolderTree();
-                if (typeof onFolderChanged === 'function') {
-                    onFolderChanged(next);
+                emitFolderChanged(next);
+            });
+
+            rowInner.addEventListener('contextmenu', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                openContextMenu(node, event);
+            });
+
+            rowInner.addEventListener('dragstart', (event) => {
+                if (!canMutate || !event.dataTransfer) {
+                    return;
                 }
+                activeFolderDrag = {
+                    id: nodeMeta.id,
+                    path: node.path
+                };
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', node.path);
+            });
+
+            rowInner.addEventListener('dragend', () => {
+                activeFolderDrag = null;
+                clearFolderDropHover();
+            });
+
+            rowInner.addEventListener('dragover', (event) => {
+                if (!activeFolderDrag) {
+                    return;
+                }
+                const sourcePath = uiState.normalizeFolder(activeFolderDrag.path || '');
+                const dropMode = resolveDropMode(event, rowInner);
+                if (isSelfTopDrop(sourcePath, node.path, dropMode)) {
+                    clearFolderDropHover();
+                    return;
+                }
+                const candidateParentPath = resolveCandidateParentPath(node, dropMode);
+                if (isInvalidFolderDrop(sourcePath, candidateParentPath)) {
+                    clearFolderDropHover();
+                    return;
+                }
+                event.preventDefault();
+                if (event.dataTransfer) {
+                    event.dataTransfer.dropEffect = 'move';
+                }
+                setFolderDropHover(rowInner, dropMode);
+            });
+
+            rowInner.addEventListener('dragleave', (event) => {
+                if (!activeFolderDrag) {
+                    return;
+                }
+                const relatedTarget = event.relatedTarget;
+                if (!relatedTarget || !rowInner.contains(relatedTarget)) {
+                    clearFolderDropHover();
+                }
+            });
+
+            rowInner.addEventListener('drop', async (event) => {
+                if (!activeFolderDrag) {
+                    return;
+                }
+                event.preventDefault();
+                const targetNode = node;
+                const dropMode = resolveDropMode(event, rowInner);
+                const dragPayload = activeFolderDrag;
+                activeFolderDrag = null;
+                clearFolderDropHover();
+                await handleFolderDrop(dragPayload, targetNode, dropMode);
             });
 
             rowInner.appendChild(toggle);
             rowInner.appendChild(selectButton);
             rowWrap.appendChild(rowInner);
             folderTree.appendChild(rowWrap);
+
+            if (inlineEditorState && inlineEditorState.mode === 'create' && inlineEditorState.parentPath === node.path) {
+                renderInlineEditorRow(node, depth + 1);
+            }
 
             if (hasChildren && node.expanded) {
                 for (const child of sortedChildren(node)) {
@@ -252,7 +822,11 @@ export function createWorkspaceFolderTree(options) {
             }
         };
 
-        for (const child of sortedChildren(folderTreeModel)) {
+        if (inlineEditorState && inlineEditorState.mode === 'create' && !inlineEditorState.parentPath) {
+            renderInlineEditorRow(null, 0);
+        }
+
+        for (const child of sortedChildren(folderTreeModel.root)) {
             renderNode(child, 0);
         }
     }
@@ -266,15 +840,27 @@ export function createWorkspaceFolderTree(options) {
             folderEmpty.textContent = 'No folders found.';
         }
 
-        return api.fetchFolders()
-            .then((folders) => {
-                folderTreeModel = createFolderTreeModel(folders);
+        const folderNodesPromise = typeof api.fetchFolderNodes === 'function'
+            ? api.fetchFolderNodes().catch(() => [])
+            : Promise.resolve([]);
+
+        return Promise.all([api.fetchFolders(), folderNodesPromise])
+            .then(([folders, nodes]) => {
+                folderNodeByPath = new Map();
+                for (const node of nodes || []) {
+                    const normalizedPath = uiState.normalizeFolder(node?.path || '');
+                    if (normalizedPath) {
+                        folderNodeByPath.set(normalizedPath, node);
+                    }
+                }
+
+                folderTreeModel = createFolderTreeModel(folders, nodes);
 
                 if (folderLoading) {
                     folderLoading.classList.add('hidden');
                 }
 
-                const hasAny = folderTreeModel && folderTreeModel.children && folderTreeModel.children.size > 0;
+                const hasAny = folderTreeModel && folderTreeModel.root && folderTreeModel.root.children && folderTreeModel.root.children.size > 0;
                 if (folderEmpty) {
                     folderEmpty.classList.toggle('hidden', hasAny);
                 }
@@ -284,7 +870,8 @@ export function createWorkspaceFolderTree(options) {
             })
             .catch((error) => {
                 console.error('Failed to load folders', error);
-                folderTreeModel = createFolderTreeModel([]);
+                folderTreeModel = createFolderTreeModel([], []);
+                folderNodeByPath = new Map();
                 if (folderLoading) {
                     folderLoading.classList.add('hidden');
                 }
@@ -304,6 +891,24 @@ export function createWorkspaceFolderTree(options) {
     if (sidebarToggle) {
         sidebarToggle.addEventListener('click', () => {
             setSidebarExpanded(!uiState.isSidebarExpanded());
+        });
+    }
+
+    if (newFolderButton) {
+        newFolderButton.addEventListener('click', () => {
+            const selectedPath = uiState.getSelectedFolder();
+            if (!selectedPath) {
+                startInlineCreate(null);
+                return;
+            }
+
+            const selectedNode = folderTreeModel.pathIndex.get(selectedPath);
+            if (!selectedNode) {
+                startInlineCreate(null);
+                return;
+            }
+
+            startInlineCreate(selectedNode);
         });
     }
 

--- a/src/main/resources/static/js/workspace/page.js
+++ b/src/main/resources/static/js/workspace/page.js
@@ -51,6 +51,7 @@ const sidebarInner = document.getElementById('wsSidebarInner');
 const sidebarHeader = document.getElementById('wsSidebarHeader');
 const sidebarToggleExpandedHost = document.getElementById('wsSidebarToggleExpandedHost');
 const sidebarToggleCollapsedHost = document.getElementById('wsSidebarToggleCollapsedHost');
+const newFolderButton = document.getElementById('wsNewFolderButton');
 
 const organizeModal = document.getElementById('organizeModal');
 const organizeBackdrop = document.getElementById('organizeBackdrop');
@@ -114,6 +115,7 @@ let importController = {
     clearNotice() {},
     showNotice() {}
 };
+let showNotice = () => {};
 let previewControls = {
     refresh() {}
 };
@@ -144,6 +146,7 @@ const folderTreeController = createWorkspaceFolderTree({
     folderTree,
     folderLoading,
     folderEmpty,
+    newFolderButton,
     sidebar,
     sidebarToggle,
     sidebarContent,
@@ -152,6 +155,7 @@ const folderTreeController = createWorkspaceFolderTree({
     sidebarHeader,
     sidebarToggleExpandedHost,
     sidebarToggleCollapsedHost,
+    showNotice: (type, message) => showNotice(type, message),
     onFolderChanged: () => {
         dataController.applyFilters({ resetPage: true });
     }
@@ -190,6 +194,7 @@ importController = createWorkspaceImportController({
         ]);
     }
 });
+showNotice = (type, message) => importController.showNotice(type, message);
 
 const moveController = createWorkspaceMoveController({
     api,

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -28,6 +28,10 @@
 			transform: translateX(1px);
 		}
 
+		.ws-folder-drop-line-top {
+			box-shadow: inset 0 2px 0 rgba(231, 255, 2, 0.95);
+		}
+
 		/* Stronger grid-only borders for the test-case table. */
 		#wsGridTopBar {
 			border-bottom-color: rgba(255, 255, 255, 0.38) !important;

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -26,7 +26,16 @@
 				<aside id="wsSidebar" class="w-[18rem] sm:w-[20rem] border-r border-white/10 bg-black shrink-0">
 					<div id="wsSidebarInner" class="px-6 py-5">
 						<div id="wsSidebarHeader" class="flex items-center justify-between gap-3">
-							<p id="wsSidebarTitle" class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Directory</p>
+							<div class="flex items-center gap-2 min-w-0">
+								<p id="wsSidebarTitle" class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Directory</p>
+								<button
+									id="wsNewFolderButton"
+									type="button"
+									class="px-2 py-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-[10px] uppercase tracking-wider text-white/75"
+								>
+									New Folder
+								</button>
+							</div>
 							<div id="wsSidebarToggleExpandedHost" class="shrink-0">
 								<button
 									id="wsSidebarToggle"

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -52,7 +52,7 @@
 							</div>
 						</div>
 						<div id="wsSidebarContent" class="mt-4" aria-label="Folder tree">
-							<div id="wsFolderLoading" class="text-xs text-white/45">Loading folders...</div>
+							<div id="wsFolderLoading" class="hidden text-xs text-white/45" aria-hidden="true">Loading folders...</div>
 							<div id="wsFolderEmpty" class="hidden text-xs text-white/45">No folders found.</div>
 							<nav id="wsFolderTree" class="mt-2 space-y-1"></nav>
 						</div>

--- a/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
+++ b/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
@@ -99,9 +99,10 @@ class TeststreamApplicationTests {
 		mockMvc.perform(get("/api/folders")
 					.with(user("team1.user@example.com").roles("USER")))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$", hasSize(2)))
+				.andExpect(jsonPath("$", hasSize(3)))
 				.andExpect(jsonPath("$[0]").value("Billing"))
-				.andExpect(jsonPath("$[1]").value("UI"));
+				.andExpect(jsonPath("$[1]").value("UI"))
+				.andExpect(jsonPath("$[2]").value("ui"));
 	}
 
 	@Test

--- a/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
+++ b/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
@@ -21,6 +21,8 @@ import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
 import com.formswim.teststream.shared.domain.TestCaseRepository;
 import com.formswim.teststream.support.TestCaseFixtures;
+import com.formswim.teststream.workspace.repository.FolderRepository;
+import com.formswim.teststream.workspace.services.FolderBackfillService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -36,9 +38,16 @@ class TeststreamApplicationTests {
 	@Autowired
 	private UserRepository userRepository;
 
+	@Autowired
+	private FolderRepository folderRepository;
+
+	@Autowired
+	private FolderBackfillService folderBackfillService;
+
 	@BeforeEach
 	void setUp() {
 		testCaseRepository.deleteAll();
+		folderRepository.deleteAll();
 		userRepository.deleteAll();
 
 		userRepository.save(new AppUser("team1.user@example.com", "test-hash", "TEAM1"));
@@ -51,6 +60,7 @@ class TeststreamApplicationTests {
 				TestCaseFixtures.basicCase("TEAM2", "TC-201", "Auth/Login"),
 				TestCaseFixtures.basicCase("TEAM2", "TC-202", "Auth/Signup")
 		));
+		folderBackfillService.backfillFoldersFromTestCases();
 	}
 
 	@Test
@@ -58,8 +68,8 @@ class TeststreamApplicationTests {
 		mockMvc.perform(get("/api/folders")
 					.with(user("team1.user@example.com").roles("USER")))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$", hasSize(2)))
-				.andExpect(jsonPath("$", containsInAnyOrder("Payments/Core", "Billing/Refunds")));
+				.andExpect(jsonPath("$", hasSize(4)))
+				.andExpect(jsonPath("$", containsInAnyOrder("Billing", "Billing/Refunds", "Payments", "Payments/Core")));
 	}
 
 	@Test
@@ -67,13 +77,14 @@ class TeststreamApplicationTests {
 		mockMvc.perform(get("/api/folders")
 					.with(user("team2.user@example.com").roles("USER")))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$", hasSize(2)))
-				.andExpect(jsonPath("$", containsInAnyOrder("Auth/Login", "Auth/Signup")));
+				.andExpect(jsonPath("$", hasSize(3)))
+				.andExpect(jsonPath("$", containsInAnyOrder("Auth", "Auth/Login", "Auth/Signup")));
 	}
 
 	@Test
 	void getFoldersReturnsCleanSortedCaseSensitiveWhitespaceNormalizedArray() throws Exception {
 		testCaseRepository.deleteAll();
+		folderRepository.deleteAll();
 		testCaseRepository.saveAll(List.of(
 				TestCaseFixtures.basicCase("TEAM1", "TC-301", " UI "),
 				TestCaseFixtures.basicCase("TEAM1", "TC-302", "UI"),
@@ -83,6 +94,7 @@ class TeststreamApplicationTests {
 				TestCaseFixtures.basicCase("TEAM1", "TC-306", "   "),
 				TestCaseFixtures.basicCase("TEAM1", "TC-307", null)
 		));
+		folderBackfillService.backfillFoldersFromTestCases();
 
 		mockMvc.perform(get("/api/folders")
 					.with(user("team1.user@example.com").roles("USER")))
@@ -96,16 +108,18 @@ class TeststreamApplicationTests {
 	@Test
 	void getFoldersNormalizesWindowsPathSeparatorsForSidebarTree() throws Exception {
 		testCaseRepository.deleteAll();
+		folderRepository.deleteAll();
 		testCaseRepository.saveAll(List.of(
 				TestCaseFixtures.basicCase("TEAM1", "TC-351", "Auth\\Login\\Mfa"),
 				TestCaseFixtures.basicCase("TEAM1", "TC-352", "Auth/Login/Mfa")
 		));
+		folderBackfillService.backfillFoldersFromTestCases();
 
 		mockMvc.perform(get("/api/folders")
 					.with(user("team1.user@example.com").roles("USER")))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$", hasSize(1)))
-				.andExpect(jsonPath("$[0]").value("Auth/Login/Mfa"));
+				.andExpect(jsonPath("$", hasSize(3)))
+				.andExpect(jsonPath("$", containsInAnyOrder("Auth", "Auth/Login", "Auth/Login/Mfa")));
 	}
 
 	@Test

--- a/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
+++ b/src/test/java/com/formswim/teststream/TeststreamApplicationTests.java
@@ -99,10 +99,9 @@ class TeststreamApplicationTests {
 		mockMvc.perform(get("/api/folders")
 					.with(user("team1.user@example.com").roles("USER")))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$", hasSize(3)))
+				.andExpect(jsonPath("$", hasSize(2)))
 				.andExpect(jsonPath("$[0]").value("Billing"))
-				.andExpect(jsonPath("$[1]").value("UI"))
-				.andExpect(jsonPath("$[2]").value("ui"));
+				.andExpect(jsonPath("$[1]").value("UI"));
 	}
 
 	@Test

--- a/src/test/java/com/formswim/teststream/bulk/BulkEditIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/bulk/BulkEditIntegrationTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -29,6 +30,7 @@ import com.formswim.teststream.shared.domain.TestCase;
 import com.formswim.teststream.shared.domain.TestCaseRepository;
 import com.formswim.teststream.shared.domain.TestStep;
 import com.formswim.teststream.support.TestCaseFixtures;
+import com.formswim.teststream.workspace.repository.FolderRepository;
 
 import jakarta.servlet.ServletException;
 
@@ -52,9 +54,13 @@ class BulkEditIntegrationTests {
     @Autowired
     private TestCaseRepository testCaseRepository;
 
+    @Autowired
+    private FolderRepository folderRepository;
+
     @BeforeEach
     void setUp() {
         testCaseRepository.deleteAll();
+        folderRepository.deleteAll();
         userRepository.deleteAll();
 
         userRepository.save(new AppUser("team1.user@example.com", "test-hash", "TEAM1"));
@@ -266,5 +272,28 @@ class BulkEditIntegrationTests {
 
         assertThat(first.getAssignee()).isEqualTo("Assignee");
         assertThat(second.getAssignee()).isEqualTo("Assignee");
+    }
+
+    @Test
+    void bulkEditFolderReplacementCreatesMissingFolderNodes() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "Payments/Core");
+        payload.put("replaceText", "QA/Edited");
+        payload.put("fields", List.of("folder"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1));
+
+        mockMvc.perform(get("/api/folders")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0]").value("QA"))
+            .andExpect(jsonPath("$[1]").value("QA/Edited"));
     }
 }

--- a/src/test/java/com/formswim/teststream/bulk/BulkEditIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/bulk/BulkEditIntegrationTests.java
@@ -1,7 +1,6 @@
 package com.formswim.teststream.bulk;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,8 +29,6 @@ import com.formswim.teststream.shared.domain.TestCaseRepository;
 import com.formswim.teststream.shared.domain.TestStep;
 import com.formswim.teststream.support.TestCaseFixtures;
 import com.formswim.teststream.workspace.repository.FolderRepository;
-
-import jakarta.servlet.ServletException;
 
 @SpringBootTest(properties = {
     "teststream.bulk-edit.enabled=true",
@@ -258,14 +254,15 @@ class BulkEditIntegrationTests {
         payload.put("replaceText", oversizedReplacement);
         payload.put("fields", List.of("assignee"));
 
-        assertThatThrownBy(() -> mockMvc.perform(patch("/api/testcases/bulk-edit")
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(payload)))
-            .andReturn())
-            .isInstanceOf(ServletException.class)
-            .hasCauseInstanceOf(DataIntegrityViolationException.class);
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.requestedCount").value(2))
+            .andExpect(jsonPath("$.invalidCount").value(2))
+            .andExpect(jsonPath("$.failures[0].reason").value("CONFLICT"));
 
         TestCase first = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101").orElseThrow();
         TestCase second = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-102").orElseThrow();

--- a/src/test/java/com/formswim/teststream/bulk/BulkMoveIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/bulk/BulkMoveIntegrationTests.java
@@ -3,6 +3,7 @@ package com.formswim.teststream.bulk;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -26,6 +27,7 @@ import com.formswim.teststream.auth.repository.UserRepository;
 import com.formswim.teststream.shared.domain.TestCase;
 import com.formswim.teststream.shared.domain.TestCaseRepository;
 import com.formswim.teststream.support.TestCaseFixtures;
+import com.formswim.teststream.workspace.repository.FolderRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -44,9 +46,13 @@ class BulkMoveIntegrationTests {
     @Autowired
     private TestCaseRepository testCaseRepository;
 
+    @Autowired
+    private FolderRepository folderRepository;
+
     @BeforeEach
     void setUp() {
         testCaseRepository.deleteAll();
+        folderRepository.deleteAll();
         userRepository.deleteAll();
 
         userRepository.save(new AppUser("team1.user@example.com", "test-hash", "TEAM1"));
@@ -150,5 +156,26 @@ class BulkMoveIntegrationTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(payload)))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void bulkMoveCreatesMissingFolderNodesForTargetPath() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("targetFolder", "QA/NewFolder");
+
+        mockMvc.perform(patch("/api/testcases/bulk-move")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.movedCount").value(1));
+
+        mockMvc.perform(get("/api/folders")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0]").value("QA"))
+            .andExpect(jsonPath("$[1]").value("QA/NewFolder"));
     }
 }

--- a/src/test/java/com/formswim/teststream/ingestion/UploadReviewIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/ingestion/UploadReviewIntegrationTests.java
@@ -40,6 +40,7 @@ import com.formswim.teststream.shared.domain.TestCase;
 import com.formswim.teststream.shared.domain.TestCaseRepository;
 import com.formswim.teststream.shared.domain.TestStep;
 import com.formswim.teststream.support.TestCaseFixtures;
+import com.formswim.teststream.workspace.repository.FolderRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -65,6 +66,9 @@ class UploadReviewIntegrationTests {
     private UploadReviewSessionRepository uploadReviewSessionRepository;
 
     @Autowired
+    private FolderRepository folderRepository;
+
+    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @BeforeEach
@@ -72,6 +76,7 @@ class UploadReviewIntegrationTests {
         uploadReviewSessionRepository.deleteAll();
         uploadHistoryRepository.deleteAll();
         testCaseRepository.deleteAll();
+        folderRepository.deleteAll();
         userRepository.deleteAll();
 
         userRepository.save(new AppUser(
@@ -126,6 +131,41 @@ class UploadReviewIntegrationTests {
         assertThat(secondResult.getMessage()).contains("exact file was already uploaded");
         assertThat(testCaseRepository.countByTeamKey("TEAM1")).isEqualTo(1);
         assertThat(uploadHistoryRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void directUploadGeneratesFolderNodesForImportedCases() throws Exception {
+        MockMultipartFile upload = new MockMultipartFile(
+            "file",
+            "direct-folder-sync.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            workbookBytes(
+                row("TC-110", "Folder sync case 1", "Draft", "UI", "Open payments", "", "Payments visible", "Checkout/Payments"),
+                row("TC-111", "Folder sync case 2", "Pass", "API", "Open refunds", "", "Refunds visible", "Checkout/Refunds")
+            )
+        );
+
+        MvcResult uploadResult = mockMvc.perform(multipart("/api/upload")
+                .file(upload)
+                .with(csrf())
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        EtlResultSummary result = objectMapper.readValue(
+            uploadResult.getResponse().getContentAsByteArray(),
+            EtlResultSummary.class
+        );
+
+        assertThat(result.isReviewRequired()).isFalse();
+        assertThat(result.getImportedCount()).isEqualTo(2);
+
+        mockMvc.perform(get("/api/folders")
+                .with(user("user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("Checkout")))
+            .andExpect(content().string(containsString("Checkout/Payments")))
+            .andExpect(content().string(containsString("Checkout/Refunds")));
     }
 
     @Test
@@ -390,6 +430,17 @@ class UploadReviewIntegrationTests {
                          String stepSummary,
                          String testData,
                          String expectedResult) {
+        return row(workKey, summary, status, components, stepSummary, testData, expectedResult, "Folder/A");
+    }
+
+    private String[] row(String workKey,
+                         String summary,
+                         String status,
+                         String components,
+                         String stepSummary,
+                         String testData,
+                         String expectedResult,
+                         String folder) {
         String[] values = new String[ExcelParserService.CANONICAL_HEADERS.size()];
         values[0] = workKey;
         values[1] = summary;
@@ -408,7 +459,7 @@ class UploadReviewIntegrationTests {
         values[14] = testData;
         values[15] = expectedResult;
         values[16] = "V1";
-        values[17] = "Folder/A";
+        values[17] = folder;
         values[18] = "Regression";
         values[19] = "creator@example.com";
         values[20] = "2026-03-01";

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
@@ -101,6 +101,19 @@ class WorkspaceFolderApiIntegrationTests {
     }
 
             @Test
+            void postFolderRejectsNameLongerThan255Characters() throws Exception {
+            String oversized = "A".repeat(256);
+
+            mockMvc.perform(post("/api/folders")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(Map.of("name", oversized))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Folder name cannot exceed 255 characters."));
+            }
+
+            @Test
             void postFolderReturnsNotFoundWhenParentMissing() throws Exception {
             mockMvc.perform(post("/api/folders")
                 .with(csrf())
@@ -250,6 +263,16 @@ class WorkspaceFolderApiIntegrationTests {
             .isEqualTo("Target/Legacy/Child");
         assertThat(testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-113").orElseThrow().getFolder())
             .isEqualTo("Elsewhere");
+    }
+
+    @Test
+    void backfillSkipsOversizedSegmentsWithoutThrowing() {
+        String oversized = "A".repeat(256);
+        testCaseRepository.save(TestCaseFixtures.basicCase("TEAM1", "TC-901", oversized + "/Child"));
+
+        int created = folderBackfillService.backfillFoldersFromTestCases();
+        assertThat(created).isEqualTo(0);
+        assertThat(folderRepository.findByTeamKeyOrderByIdAsc("TEAM1")).isEmpty();
     }
 
     private Long createFolder(String name, Long parentId) throws Exception {

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
@@ -1,0 +1,241 @@
+package com.formswim.teststream.workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.formswim.teststream.auth.model.AppUser;
+import com.formswim.teststream.auth.repository.UserRepository;
+import com.formswim.teststream.shared.domain.TestCase;
+import com.formswim.teststream.shared.domain.TestCaseRepository;
+import com.formswim.teststream.support.TestCaseFixtures;
+import com.formswim.teststream.workspace.repository.FolderRepository;
+import com.formswim.teststream.workspace.services.FolderBackfillService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class WorkspaceFolderApiIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TestCaseRepository testCaseRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FolderRepository folderRepository;
+
+    @Autowired
+    private FolderBackfillService folderBackfillService;
+
+    @BeforeEach
+    void setUp() {
+        testCaseRepository.deleteAll();
+        folderRepository.deleteAll();
+        userRepository.deleteAll();
+
+        userRepository.save(new AppUser("team1.user@example.com", "test-hash", "TEAM1"));
+        userRepository.save(new AppUser("team2.user@example.com", "test-hash", "TEAM2"));
+    }
+
+    @Test
+    void getFoldersReturnsBackfilledPathsFromFolderTable() throws Exception {
+        testCaseRepository.saveAll(List.of(
+            TestCaseFixtures.basicCase("TEAM1", "TC-101", "Payments/Core"),
+            TestCaseFixtures.basicCase("TEAM1", "TC-102", "Payments/Refunds")
+        ));
+
+        int created = folderBackfillService.backfillFoldersFromTestCases();
+        assertThat(created).isEqualTo(3);
+
+        mockMvc.perform(get("/api/folders")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0]").value("Payments"))
+            .andExpect(jsonPath("$[1]").value("Payments/Core"))
+            .andExpect(jsonPath("$[2]").value("Payments/Refunds"));
+    }
+
+    @Test
+    void postFolderCreatesRootAndChild() throws Exception {
+        Long rootId = createFolder("Project", null);
+
+        mockMvc.perform(post("/api/folders")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(Map.of("name", "Sprint-1", "parentId", rootId))))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.name").value("Sprint-1"))
+            .andExpect(jsonPath("$.parentId").value(rootId))
+            .andExpect(jsonPath("$.path").value("Project/Sprint-1"));
+    }
+
+    @Test
+    void patchFolderRejectsCycles() throws Exception {
+        Long rootId = createFolder("Root", null);
+        Long childId = createFolder("Child", rootId);
+
+        mockMvc.perform(patch("/api/folders/{id}", rootId)
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(Map.of("parentId", childId))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Cannot move a folder into one of its descendants."));
+    }
+
+    @Test
+    void deleteFolderReturnsConflictWhenFolderHasChildren() throws Exception {
+        Long rootId = createFolder("Root", null);
+        createFolder("Child", rootId);
+
+        mockMvc.perform(delete("/api/folders/{id}", rootId)
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message").value("Folder cannot be deleted because it contains subfolders."));
+    }
+
+    @Test
+    void deleteFolderReturnsConflictWhenFolderContainsTestCases() throws Exception {
+        Long rootId = createFolder("Root", null);
+        createFolder("Child", rootId);
+
+        TestCase testCase = TestCaseFixtures.basicCase("TEAM1", "TC-101", "Root/Child");
+        testCaseRepository.save(testCase);
+
+        MvcResult childNodeResult = mockMvc.perform(get("/api/folders/nodes")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        List<Map<String, Object>> nodes = objectMapper.readValue(
+            childNodeResult.getResponse().getContentAsByteArray(),
+            new TypeReference<List<Map<String, Object>>>() {}
+        );
+        Long childId = nodes.stream()
+            .filter(node -> "Root/Child".equals(String.valueOf(node.get("path"))))
+            .map(node -> Long.valueOf(String.valueOf(node.get("id"))))
+            .findFirst()
+            .orElseThrow();
+
+        mockMvc.perform(delete("/api/folders/{id}", childId)
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message").value("Folder cannot be deleted because it contains test cases."));
+    }
+
+    @Test
+    void deleteFolderRemovesEmptyLeaf() throws Exception {
+        Long rootId = createFolder("Root", null);
+        Long childId = createFolder("Child", rootId);
+
+        mockMvc.perform(delete("/api/folders/{id}", childId)
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/folders")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0]").value("Root"))
+            .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    void patchFolderReparentUpdatesTestCaseFolderPathsInSubtree() throws Exception {
+        Long sourceRootId = createFolder("Source", null);
+        createFolder("Legacy", sourceRootId);
+        Long targetRootId = createFolder("Target", null);
+
+        testCaseRepository.saveAll(List.of(
+            TestCaseFixtures.basicCase("TEAM1", "TC-111", "Source/Legacy"),
+            TestCaseFixtures.basicCase("TEAM1", "TC-112", "Source/Legacy/Child"),
+            TestCaseFixtures.basicCase("TEAM1", "TC-113", "Elsewhere")
+        ));
+
+        MvcResult childNodeResult = mockMvc.perform(get("/api/folders/nodes")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        List<Map<String, Object>> nodes = objectMapper.readValue(
+            childNodeResult.getResponse().getContentAsByteArray(),
+            new TypeReference<List<Map<String, Object>>>() {}
+        );
+
+        Long legacyId = nodes.stream()
+            .filter(node -> "Source/Legacy".equals(String.valueOf(node.get("path"))))
+            .map(node -> Long.valueOf(String.valueOf(node.get("id"))))
+            .findFirst()
+            .orElseThrow();
+
+        mockMvc.perform(patch("/api/folders/{id}", legacyId)
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(Map.of("parentId", targetRootId))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.path").value("Target/Legacy"));
+
+        assertThat(testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-111").orElseThrow().getFolder())
+            .isEqualTo("Target/Legacy");
+        assertThat(testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-112").orElseThrow().getFolder())
+            .isEqualTo("Target/Legacy/Child");
+        assertThat(testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-113").orElseThrow().getFolder())
+            .isEqualTo("Elsewhere");
+    }
+
+    private Long createFolder(String name, Long parentId) throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("name", name);
+        if (parentId != null) {
+            payload.put("parentId", parentId);
+        }
+
+        MvcResult result = mockMvc.perform(post("/api/folders")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        Map<String, Object> body = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(),
+            new TypeReference<Map<String, Object>>() {}
+        );
+        return Long.valueOf(String.valueOf(body.get("id")));
+    }
+}

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
@@ -100,53 +100,53 @@ class WorkspaceFolderApiIntegrationTests {
             .andExpect(jsonPath("$.path").value("Project/Sprint-1"));
     }
 
-            @Test
-            void postFolderRejectsNameLongerThan255Characters() throws Exception {
-            String oversized = "A".repeat(256);
+    @Test
+    void postFolderRejectsNameLongerThan255Characters() throws Exception {
+        String oversized = "A".repeat(256);
 
-            mockMvc.perform(post("/api/folders")
+        mockMvc.perform(post("/api/folders")
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(Map.of("name", oversized))))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Folder name cannot exceed 255 characters."));
-            }
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Folder name cannot exceed 255 characters."));
+    }
 
-            @Test
-            void postFolderReturnsNotFoundWhenParentMissing() throws Exception {
-            mockMvc.perform(post("/api/folders")
+    @Test
+    void postFolderReturnsNotFoundWhenParentMissing() throws Exception {
+        mockMvc.perform(post("/api/folders")
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(Map.of("name", "Sprint-1", "parentId", 99999L))))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("Parent folder not found."));
-            }
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Parent folder not found."));
+    }
 
-            @Test
-            void patchFolderReturnsNotFoundWhenFolderMissing() throws Exception {
-            mockMvc.perform(patch("/api/folders/{id}", 99999L)
+    @Test
+    void patchFolderReturnsNotFoundWhenFolderMissing() throws Exception {
+        mockMvc.perform(patch("/api/folders/{id}", 99999L)
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(Map.of("name", "Renamed"))))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("Folder not found."));
-            }
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Folder not found."));
+    }
 
-            @Test
-            void postFolderRejectsDuplicateRootNameIgnoringCase() throws Exception {
-            createFolder("Project", null);
+    @Test
+    void postFolderRejectsDuplicateRootNameIgnoringCase() throws Exception {
+        createFolder("Project", null);
 
-            mockMvc.perform(post("/api/folders")
+        mockMvc.perform(post("/api/folders")
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(Map.of("name", "project"))))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("A folder with this name already exists in the target location."));
-            }
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message").value("A folder with this name already exists in the target location."));
+    }
 
     @Test
     void patchFolderRejectsCycles() throws Exception {

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
@@ -100,6 +100,41 @@ class WorkspaceFolderApiIntegrationTests {
             .andExpect(jsonPath("$.path").value("Project/Sprint-1"));
     }
 
+            @Test
+            void postFolderReturnsNotFoundWhenParentMissing() throws Exception {
+            mockMvc.perform(post("/api/folders")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(Map.of("name", "Sprint-1", "parentId", 99999L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Parent folder not found."));
+            }
+
+            @Test
+            void patchFolderReturnsNotFoundWhenFolderMissing() throws Exception {
+            mockMvc.perform(patch("/api/folders/{id}", 99999L)
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(Map.of("name", "Renamed"))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Folder not found."));
+            }
+
+            @Test
+            void postFolderRejectsDuplicateRootNameIgnoringCase() throws Exception {
+            createFolder("Project", null);
+
+            mockMvc.perform(post("/api/folders")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(Map.of("name", "project"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("A folder with this name already exists in the target location."));
+            }
+
     @Test
     void patchFolderRejectsCycles() throws Exception {
         Long rootId = createFolder("Root", null);

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
@@ -100,53 +100,53 @@ class WorkspaceFolderApiIntegrationTests {
             .andExpect(jsonPath("$.path").value("Project/Sprint-1"));
     }
 
-    @Test
-    void postFolderRejectsNameLongerThan255Characters() throws Exception {
-        String oversized = "A".repeat(256);
+            @Test
+            void postFolderRejectsNameLongerThan255Characters() throws Exception {
+            String oversized = "A".repeat(256);
 
-        mockMvc.perform(post("/api/folders")
+            mockMvc.perform(post("/api/folders")
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(Map.of("name", oversized))))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.message").value("Folder name cannot exceed 255 characters."));
-    }
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Folder name cannot exceed 255 characters."));
+            }
 
-    @Test
-    void postFolderReturnsNotFoundWhenParentMissing() throws Exception {
-        mockMvc.perform(post("/api/folders")
+            @Test
+            void postFolderReturnsNotFoundWhenParentMissing() throws Exception {
+            mockMvc.perform(post("/api/folders")
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(Map.of("name", "Sprint-1", "parentId", 99999L))))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value("Parent folder not found."));
-    }
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Parent folder not found."));
+            }
 
-    @Test
-    void patchFolderReturnsNotFoundWhenFolderMissing() throws Exception {
-        mockMvc.perform(patch("/api/folders/{id}", 99999L)
+            @Test
+            void patchFolderReturnsNotFoundWhenFolderMissing() throws Exception {
+            mockMvc.perform(patch("/api/folders/{id}", 99999L)
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(Map.of("name", "Renamed"))))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value("Folder not found."));
-    }
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Folder not found."));
+            }
 
-    @Test
-    void postFolderRejectsDuplicateRootNameIgnoringCase() throws Exception {
-        createFolder("Project", null);
+            @Test
+            void postFolderRejectsDuplicateRootNameIgnoringCase() throws Exception {
+            createFolder("Project", null);
 
-        mockMvc.perform(post("/api/folders")
+            mockMvc.perform(post("/api/folders")
                 .with(csrf())
                 .with(user("team1.user@example.com").roles("USER"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(Map.of("name", "project"))))
-            .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.message").value("A folder with this name already exists in the target location."));
-    }
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("A folder with this name already exists in the target location."));
+            }
 
     @Test
     void patchFolderRejectsCycles() throws Exception {

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFolderApiIntegrationTests.java
@@ -205,6 +205,36 @@ class WorkspaceFolderApiIntegrationTests {
     }
 
     @Test
+    void deleteFolderReturnsConflictWhenFolderContainsTestCasesWithLeadingSlashPath() throws Exception {
+        Long rootId = createFolder("Root", null);
+        createFolder("Child", rootId);
+
+        TestCase testCase = TestCaseFixtures.basicCase("TEAM1", "TC-102", "/Root/Child");
+        testCaseRepository.save(testCase);
+
+        MvcResult childNodeResult = mockMvc.perform(get("/api/folders/nodes")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        List<Map<String, Object>> nodes = objectMapper.readValue(
+            childNodeResult.getResponse().getContentAsByteArray(),
+            new TypeReference<List<Map<String, Object>>>() {}
+        );
+        Long childId = nodes.stream()
+            .filter(node -> "Root/Child".equals(String.valueOf(node.get("path"))))
+            .map(node -> Long.valueOf(String.valueOf(node.get("id"))))
+            .findFirst()
+            .orElseThrow();
+
+        mockMvc.perform(delete("/api/folders/{id}", childId)
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message").value("Folder cannot be deleted because it contains test cases."));
+    }
+
+    @Test
     void deleteFolderRemovesEmptyLeaf() throws Exception {
         Long rootId = createFolder("Root", null);
         Long childId = createFolder("Child", rootId);


### PR DESCRIPTION
Closes #42 

This pull request introduces a major refactor to treat folders as first-class entities in the application, with a dedicated `folders` table and full CRUD API support. It also includes a startup backfill to migrate legacy folder data, updates the workspace sidebar UI, and adds robust backend and API logic for folder management, including cycle rejection and conflict handling.

**Folder Model and Persistence Layer:**

* Introduced a new `Folder` entity (`Folder.java`) and corresponding `FolderRepository` JPA repository, enabling persistent, hierarchical folders with parent-child relationships and uniqueness constraints on `(team_key, parent_id, name)`. [[1]](diffhunk://#diff-f4bb4ffe2a6001d0c9a8a913fcc47cf8f29605db2a742678c7cf06dd2cf4d7c7R1-R102) [[2]](diffhunk://#diff-adc1312466f9fee97093312033e667b3349009657cd2bddf524f0350194f737eR1-R21)

**Folder API and Controller Enhancements:**

* Extended `WorkspaceMetadataController` with new endpoints for listing, creating, updating (rename/reparent), and deleting folders, using new DTOs (`FolderCreateRequest`, `FolderUpdateRequest`, `FolderResponse`). The endpoints enforce authentication, team membership, and handle error scenarios with appropriate HTTP responses. [[1]](diffhunk://#diff-e70c26363040573e4b5cfe1a2cc9a7c42ed1ae41526f941e9e2cc85d763b3daaR5-R32) [[2]](diffhunk://#diff-e70c26363040573e4b5cfe1a2cc9a7c42ed1ae41526f941e9e2cc85d763b3daaR45-R59) [[3]](diffhunk://#diff-e70c26363040573e4b5cfe1a2cc9a7c42ed1ae41526f941e9e2cc85d763b3daaL60-R176) [[4]](diffhunk://#diff-1eddedb0bd37f1852936b0ab6e7fd1a031f86c915bdf146754508b5e9340646aR1-R23) [[5]](diffhunk://#diff-0f0d3e408204f1363803d1544ac67d8811379c8ca8177654268679b1608bf130R1-R39) [[6]](diffhunk://#diff-e3dc1266149b8dd50dde374a97e8020a44f2d9557357bfed425dfc7dcc291769R1-R4)

**Startup Data Migration and Backfill:**

* Modified `SchemaAlterRunner` to invoke a `FolderBackfillService` on startup, which hydrates the new folder table from legacy slash-delimited folder paths in existing test cases, ensuring a smooth migration. [[1]](diffhunk://#diff-a1260cae1ed8ee427e7f5441bf6034920cf6321216d5d7809a5a1f1760219a8dR13-R14) [[2]](diffhunk://#diff-a1260cae1ed8ee427e7f5441bf6034920cf6321216d5d7809a5a1f1760219a8dR27-R32) [[3]](diffhunk://#diff-a1260cae1ed8ee427e7f5441bf6034920cf6321216d5d7809a5a1f1760219a8dR50-R56)

**Query and Repository Updates:**

* Added new and updated JPA queries in `TestCaseRepository` to support folder-related operations, such as listing distinct team keys with folders and counting test cases within a folder hierarchy. [[1]](diffhunk://#diff-4d11686a320f19c8e5c031c0b6586f6485caa7ac8e1ba70c8a9a7147aaf5e149R146-R155) [[2]](diffhunk://#diff-4d11686a320f19c8e5c031c0b6586f6485caa7ac8e1ba70c8a9a7147aaf5e149R200-R211)

**Documentation and State Tracking:**

* Updated `.context/STATE.md` to reflect the new folder system, API capabilities, and UI enhancements in the workspace sidebar. [[1]](diffhunk://#diff-ad3935d31546c01470376ad0d8ae9fb1c95a8ea4eeae251399d920ca79824511L3-R3) [[2]](diffhunk://#diff-ad3935d31546c01470376ad0d8ae9fb1c95a8ea4eeae251399d920ca79824511R38-R45)

These changes lay the groundwork for robust, hierarchical folder management in both the backend and frontend, with migration support and a clean API surface.