### PR TITLE
45 single test edit adapt width

### DIFF
--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated: 2026-04-01
+Last updated: 2026-04-03
 
 ## Summary
 

--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -31,6 +31,24 @@ TestStream is a working Spring Boot and Thymeleaf application with core authenti
 - stronger test coverage across auth, workspace, ingestion, export, and bulk features
 - GitHub Actions CI running tests against PostgreSQL
 
+### Iteration 3 — Single Field Editing (branch 45-single-test-edit-adapt-width, delivered 2026-04-03)
+
+- single-field inline editing on the test case details page using the existing bulk edit API (`PATCH /api/testcases/bulk-edit`)
+- team-scoped and auth-enforced; consistent with bulk edit security model
+- double-click to edit for content-heavy fields (summary, description, precondition, story linkages, step summary, test data, expected result)
+- click to edit for metadata fields (status, priority, folder, components, test case type, labels, sprint, fix versions, version, estimated time)
+- `updatedOn` auto-stamped in `TestCaseBulkEditService` on every successful case or step mutation, formatted `dd/MMM/yyyy HH:mm`
+- keyboard shortcuts: Escape to cancel, Ctrl+Enter to save in textareas
+- unsaved changes warning via `beforeunload`
+- inline yellow flash on field display after successful save
+- color-coded notice banner (yellow dot for success, red dot for error, dim dot for no-changes)
+- no-changes short-circuit with neutral banner feedback
+- auto-growing textareas (grows on input, capped at `max-h-96`, scrollable beyond)
+- pencil icon discoverability on hover for all double-click fields
+- trailing whitespace trimmed from textarea on open to avoid empty-space bloat from imported data
+- adaptive page width (max-width cap removed)
+- 4 integration tests covering single-field edit, cross-team rejection, auth guard, and step field edit; `updatedOn` format assertion added
+
 ## Iteration 3 Focus
 
 Iteration 3 is in progress.
@@ -41,6 +59,10 @@ Primary active goals:
 - reduce controller and service duplication
 - implement undo/redo safely
 - harden Docker and Render deployment readiness
+
+Completed in Iteration 3 so far:
+
+- single-field editing on the test case details page (see above)
 
 ## Codebase Snapshot
 
@@ -78,6 +100,7 @@ Known frontend hotspots:
 
 - `upload-review.html` still embeds significant review logic in the template
 - shared layout fragments are not established yet across the rest of the app
+- `test-case-details.html` and `test-case-details.js` are now feature-complete for single-field editing but are growing large; future work may want to split the JS into sub-modules
 
 ### Tests
 
@@ -99,6 +122,8 @@ This is a strength of the current project and should remain part of the definiti
 - Shared domain and repository code is growing faster than the module boundaries around it.
 - Frontend organization is behind the pace of feature growth.
 - Render-specific deployment configuration is not checked into the repo yet.
+- Empty fields on the test case details page cannot be edited (the find/replace API requires existing text); users must set initial values via bulk edit in the workspace.
+- The folder edit field has no click target when no folder is currently assigned to the test case.
 
 ## Known Debt And Risks
 

--- a/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
+++ b/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -25,6 +27,9 @@ import java.util.Set;
  * if any persistence error occurs during processing.</p>
  */
 public class TestCaseBulkEditService {
+
+    private static final DateTimeFormatter UPDATED_ON_FORMAT =
+        DateTimeFormatter.ofPattern("dd/MMM/yyyy HH:mm", Locale.ENGLISH);
 
     private static final String FAILURE_INVALID = "INVALID_WORK_KEY";
     private static final String FAILURE_FORBIDDEN = "FORBIDDEN";
@@ -294,6 +299,7 @@ public class TestCaseBulkEditService {
                 updatedCaseCount++;
             }
 
+            boolean anyStepChanged = false;
             for (TestStep step : testCase.getSteps()) {
                 boolean stepChanged = false;
 
@@ -314,7 +320,12 @@ public class TestCaseBulkEditService {
 
                 if (stepChanged) {
                     updatedStepCount++;
+                    anyStepChanged = true;
                 }
+            }
+
+            if (caseChanged || anyStepChanged) {
+                testCase.setUpdatedOn(LocalDateTime.now().format(UPDATED_ON_FORMAT));
             }
         }
 

--- a/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
+++ b/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;

--- a/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
+++ b/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
@@ -11,8 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -29,9 +27,6 @@ import java.util.Set;
  * if any persistence error occurs during processing.</p>
  */
 public class TestCaseBulkEditService {
-
-    private static final DateTimeFormatter UPDATED_ON_FORMAT =
-        DateTimeFormatter.ofPattern("dd/MMM/yyyy HH:mm", Locale.ENGLISH);
 
     private static final String FAILURE_INVALID = "INVALID_WORK_KEY";
     private static final String FAILURE_FORBIDDEN = "FORBIDDEN";
@@ -331,7 +326,7 @@ public class TestCaseBulkEditService {
             }
 
             if (caseChanged || anyStepChanged) {
-                testCase.setUpdatedOn(LocalDateTime.now().format(UPDATED_ON_FORMAT));
+                testCase.setUpdatedOn(updatedOnValue);
             }
         }
 

--- a/src/main/resources/static/js/workspace/test-case-details.js
+++ b/src/main/resources/static/js/workspace/test-case-details.js
@@ -209,15 +209,44 @@ function getApiFieldKey(fieldKey) {
 function showNotice(type, message) {
     const notice = document.getElementById('detailsNotice');
     const msg = document.getElementById('detailsNoticeMsg');
+    const dot = document.getElementById('detailsNoticeDot');
     if (!notice || !msg) {
         return;
     }
+    const isSuccess = type === 'success';
+    const isError = type === 'error';
     msg.textContent = message;
-    notice.classList.toggle('border-[#E7FF02]/50', type === 'success');
-    notice.classList.toggle('border-red-500/40', type !== 'success');
+    msg.className = isError ? 'text-sm text-red-300' : isSuccess ? 'text-sm text-white/90' : 'text-sm text-white/50';
+    if (dot) {
+        dot.className = isSuccess
+            ? 'shrink-0 h-1.5 w-1.5 rounded-full bg-[#E7FF02]'
+            : isError
+                ? 'shrink-0 h-1.5 w-1.5 rounded-full bg-red-400'
+                : 'shrink-0 h-1.5 w-1.5 rounded-full bg-white/30';
+    }
     notice.classList.remove('hidden');
     clearTimeout(noticeTimeout);
-    noticeTimeout = setTimeout(() => notice.classList.add('hidden'), 6000);
+    const timeout = isError ? 8000 : isSuccess ? 6000 : 2500;
+    noticeTimeout = setTimeout(() => notice.classList.add('hidden'), timeout);
+}
+
+function autoGrow(textarea) {
+    textarea.style.height = 'auto';
+    textarea.style.height = textarea.scrollHeight + 'px';
+}
+
+function flashFieldSaved(fieldKey) {
+    const displayEl = document.querySelector('[data-field-display="' + fieldKey + '"]');
+    if (!displayEl) {
+        return;
+    }
+    displayEl.style.transition = '';
+    displayEl.style.backgroundColor = 'rgba(231, 255, 2, 0.08)';
+    setTimeout(() => {
+        displayEl.style.transition = 'background-color 0.8s ease';
+        displayEl.style.backgroundColor = '';
+        setTimeout(() => { displayEl.style.transition = ''; }, 800);
+    }, 700);
 }
 
 async function saveFieldEdit(workKey, fieldKey, oldValue, newValue) {
@@ -304,7 +333,8 @@ function activateEditMode(fieldKey) {
     }
     const currentValue = displayEl.dataset.rawValue || '';
     if (textarea) {
-        textarea.value = currentValue;
+        textarea.value = currentValue.trimEnd();
+        textarea.style.height = '';
     }
     if (input) {
         input.value = currentValue;
@@ -383,6 +413,7 @@ function initFieldEditing() {
 
             if (newValue === oldValue) {
                 deactivateEditMode(fieldKey);
+                showNotice('neutral', 'No changes made.');
                 return;
             }
 
@@ -410,6 +441,7 @@ function initFieldEditing() {
                     applyDisplayUpdate(fieldKey, newValue);
                     deactivateEditMode(fieldKey);
                     updateUpdatedOn();
+                    flashFieldSaved(fieldKey);
                     showNotice('success', 'Field updated.');
                 } else {
                     if (errorEl) {
@@ -429,6 +461,38 @@ function initFieldEditing() {
                 saveBtn.disabled = false;
             }
         });
+    });
+
+    window.addEventListener('beforeunload', (e) => {
+        if (document.querySelector('[data-field-edit]:not(.hidden)')) {
+            e.preventDefault();
+            e.returnValue = '';
+        }
+    });
+
+    document.querySelectorAll('[data-field-textarea]').forEach((textarea) => {
+        textarea.addEventListener('input', () => autoGrow(textarea));
+        const fieldKey = textarea.dataset.fieldTextarea;
+        textarea.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                const saveBtn = document.querySelector('[data-field-save="' + fieldKey + '"]');
+                if (saveBtn && !saveBtn.disabled) {
+                    saveBtn.click();
+                }
+            }
+        });
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key !== 'Escape') {
+            return;
+        }
+        const openEdit = document.querySelector('[data-field-edit]:not(.hidden)');
+        if (!openEdit) {
+            return;
+        }
+        deactivateEditMode(openEdit.dataset.fieldEdit);
     });
 
     const noticeClose = document.getElementById('detailsNoticeClose');

--- a/src/main/resources/static/js/workspace/test-case-details.js
+++ b/src/main/resources/static/js/workspace/test-case-details.js
@@ -244,6 +244,20 @@ async function saveFieldEdit(workKey, fieldKey, oldValue, newValue) {
     return response.json();
 }
 
+function updateUpdatedOn() {
+    const el = document.getElementById('detailsUpdatedOn');
+    if (!el) {
+        return;
+    }
+    const now = new Date();
+    const day = String(now.getDate()).padStart(2, '0');
+    const month = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][now.getMonth()];
+    const year = now.getFullYear();
+    const hh = String(now.getHours()).padStart(2, '0');
+    const mm = String(now.getMinutes()).padStart(2, '0');
+    el.textContent = `${day}/${month}/${year} ${hh}:${mm}`;
+}
+
 function updateFolderSegments(newFolderPath) {
     const container = document.getElementById('folderSegmentsContainer');
     if (!container) {
@@ -395,6 +409,7 @@ function initFieldEditing() {
                 if (didChange) {
                     applyDisplayUpdate(fieldKey, newValue);
                     deactivateEditMode(fieldKey);
+                    updateUpdatedOn();
                     showNotice('success', 'Field updated.');
                 } else {
                     if (errorEl) {
@@ -429,3 +444,19 @@ function initFieldEditing() {
 }
 
 initFieldEditing();
+
+function initDoubleClickEdit() {
+    const workKey = getWorkKey();
+    if (!workKey) {
+        return;
+    }
+    document.querySelectorAll('[data-dblclick-edit="true"]').forEach((displayEl) => {
+        const fieldKey = displayEl.dataset.fieldDisplay;
+        if (!fieldKey) {
+            return;
+        }
+        displayEl.addEventListener('dblclick', () => activateEditMode(fieldKey));
+    });
+}
+
+initDoubleClickEdit();

--- a/src/main/resources/static/js/workspace/test-case-details.js
+++ b/src/main/resources/static/js/workspace/test-case-details.js
@@ -184,3 +184,248 @@ function initBackToWorkspaceLink() {
 
 initBackToWorkspaceLink();
 formatMarkdownBlocks();
+
+// ---- Single-field edit support ----
+
+let noticeTimeout = null;
+
+function getCsrf() {
+    return {
+        token: document.querySelector('meta[name="_csrf"]')?.content || '',
+        headerName: document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN'
+    };
+}
+
+function getWorkKey() {
+    return document.querySelector('[data-work-key]')?.dataset?.workKey || '';
+}
+
+function getApiFieldKey(fieldKey) {
+    // Composite step field keys like "step-1-stepSummary" map to just "stepSummary" for the API.
+    const stepMatch = fieldKey.match(/^step-\d+-(.+)$/);
+    return stepMatch ? stepMatch[1] : fieldKey;
+}
+
+function showNotice(type, message) {
+    const notice = document.getElementById('detailsNotice');
+    const msg = document.getElementById('detailsNoticeMsg');
+    if (!notice || !msg) {
+        return;
+    }
+    msg.textContent = message;
+    notice.classList.toggle('border-[#E7FF02]/50', type === 'success');
+    notice.classList.toggle('border-red-500/40', type !== 'success');
+    notice.classList.remove('hidden');
+    clearTimeout(noticeTimeout);
+    noticeTimeout = setTimeout(() => notice.classList.add('hidden'), 6000);
+}
+
+async function saveFieldEdit(workKey, fieldKey, oldValue, newValue) {
+    const csrf = getCsrf();
+    const apiField = getApiFieldKey(fieldKey);
+    const response = await fetch('/api/testcases/bulk-edit', {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+            [csrf.headerName]: csrf.token
+        },
+        body: JSON.stringify({
+            workKeys: [workKey],
+            findText: oldValue,
+            replaceText: newValue,
+            fields: [apiField]
+        })
+    });
+    if (!response.ok) {
+        const err = new Error('Edit failed with status ' + response.status);
+        err.status = response.status;
+        throw err;
+    }
+    return response.json();
+}
+
+function updateFolderSegments(newFolderPath) {
+    const container = document.getElementById('folderSegmentsContainer');
+    if (!container) {
+        return;
+    }
+    const segments = String(newFolderPath || '').split('/').map((s) => s.trim()).filter(Boolean);
+    if (segments.length === 0) {
+        container.innerHTML = '';
+        return;
+    }
+    container.innerHTML = segments.map((segment, index) => {
+        const sep = index < segments.length - 1
+            ? '<span class="text-white/40">/</span>'
+            : '';
+        return '<span class="px-2 py-1 border border-white/15 bg-black/20">' + escapeHtml(segment) + '</span>' + sep;
+    }).join('');
+}
+
+function applyDisplayUpdate(fieldKey, newValue) {
+    const displayEl = document.querySelector('[data-field-display="' + fieldKey + '"]');
+    if (!displayEl) {
+        return;
+    }
+    displayEl.dataset.rawValue = newValue;
+    if (displayEl.dataset.md === 'true') {
+        const emptyLabel = displayEl.dataset.emptyLabel || 'Not provided';
+        displayEl.innerHTML = renderMarkdown(newValue, emptyLabel);
+    } else {
+        displayEl.textContent = newValue;
+    }
+    if (fieldKey === 'folder') {
+        updateFolderSegments(newValue);
+    }
+}
+
+function activateEditMode(fieldKey) {
+    const displayEl = document.querySelector('[data-field-display="' + fieldKey + '"]');
+    const editContainer = document.querySelector('[data-field-edit="' + fieldKey + '"]');
+    const editBtn = document.querySelector('[data-edit-field="' + fieldKey + '"]');
+    const textarea = document.querySelector('[data-field-textarea="' + fieldKey + '"]');
+    const input = document.querySelector('[data-field-input="' + fieldKey + '"]');
+    if (!displayEl || !editContainer) {
+        return;
+    }
+    const currentValue = displayEl.dataset.rawValue || '';
+    if (textarea) {
+        textarea.value = currentValue;
+    }
+    if (input) {
+        input.value = currentValue;
+    }
+    displayEl.classList.add('hidden');
+    if (editBtn) {
+        editBtn.classList.add('hidden');
+    }
+    editContainer.classList.remove('hidden');
+    const focusTarget = textarea || input;
+    if (focusTarget) {
+        focusTarget.focus();
+    }
+}
+
+function deactivateEditMode(fieldKey) {
+    const displayEl = document.querySelector('[data-field-display="' + fieldKey + '"]');
+    const editContainer = document.querySelector('[data-field-edit="' + fieldKey + '"]');
+    const editBtn = document.querySelector('[data-edit-field="' + fieldKey + '"]');
+    if (editContainer) {
+        editContainer.classList.add('hidden');
+    }
+    if (displayEl) {
+        displayEl.classList.remove('hidden');
+    }
+    if (editBtn) {
+        editBtn.classList.remove('hidden');
+    }
+}
+
+function getEditErrorMessage(error) {
+    const status = error?.status;
+    if (status === 401) {
+        return 'You must be logged in to edit.';
+    }
+    if (status === 403) {
+        return 'You do not have permission to edit this test case.';
+    }
+    if (status === 400) {
+        return 'The current value may have changed. Refresh and try again.';
+    }
+    return 'Edit failed. Please try again.';
+}
+
+function initFieldEditing() {
+    const workKey = getWorkKey();
+    if (!workKey) {
+        return;
+    }
+
+    document.querySelectorAll('[data-edit-field]').forEach((editBtn) => {
+        const fieldKey = editBtn.dataset.editField;
+        editBtn.addEventListener('click', () => activateEditMode(fieldKey));
+    });
+
+    document.querySelectorAll('[data-field-cancel]').forEach((cancelBtn) => {
+        const fieldKey = cancelBtn.dataset.fieldCancel;
+        cancelBtn.addEventListener('click', () => deactivateEditMode(fieldKey));
+    });
+
+    document.querySelectorAll('[data-field-save]').forEach((saveBtn) => {
+        const fieldKey = saveBtn.dataset.fieldSave;
+        const errorEl = document.querySelector('[data-field-error="' + fieldKey + '"]');
+
+        saveBtn.addEventListener('click', async () => {
+            if (saveBtn.disabled) {
+                return;
+            }
+
+            const displayEl = document.querySelector('[data-field-display="' + fieldKey + '"]');
+            const textarea = document.querySelector('[data-field-textarea="' + fieldKey + '"]');
+            const input = document.querySelector('[data-field-input="' + fieldKey + '"]');
+
+            const oldValue = displayEl?.dataset?.rawValue || '';
+            const newValue = (textarea || input)?.value || '';
+
+            if (newValue === oldValue) {
+                deactivateEditMode(fieldKey);
+                return;
+            }
+
+            if (!oldValue.trim()) {
+                if (errorEl) {
+                    errorEl.textContent = 'Empty fields cannot be edited here. Use bulk edit to add content.';
+                    errorEl.classList.remove('hidden');
+                }
+                return;
+            }
+
+            if (errorEl) {
+                errorEl.classList.add('hidden');
+            }
+
+            const originalLabel = saveBtn.textContent;
+            saveBtn.textContent = 'Saving...';
+            saveBtn.disabled = true;
+
+            try {
+                const result = await saveFieldEdit(workKey, fieldKey, oldValue, newValue);
+                const didChange = Number(result?.totalReplacements || 0) > 0;
+
+                if (didChange) {
+                    applyDisplayUpdate(fieldKey, newValue);
+                    deactivateEditMode(fieldKey);
+                    showNotice('success', 'Field updated.');
+                } else {
+                    if (errorEl) {
+                        errorEl.textContent = 'No match found. The value may have changed — refresh and try again.';
+                        errorEl.classList.remove('hidden');
+                    }
+                }
+            } catch (error) {
+                const message = getEditErrorMessage(error);
+                if (errorEl) {
+                    errorEl.textContent = message;
+                    errorEl.classList.remove('hidden');
+                }
+                showNotice('error', message);
+            } finally {
+                saveBtn.textContent = originalLabel;
+                saveBtn.disabled = false;
+            }
+        });
+    });
+
+    const noticeClose = document.getElementById('detailsNoticeClose');
+    if (noticeClose) {
+        noticeClose.addEventListener('click', () => {
+            const notice = document.getElementById('detailsNotice');
+            if (notice) {
+                notice.classList.add('hidden');
+                clearTimeout(noticeTimeout);
+            }
+        });
+    }
+}
+
+initFieldEditing();

--- a/src/main/resources/static/js/workspace/test-case-details.js
+++ b/src/main/resources/static/js/workspace/test-case-details.js
@@ -344,6 +344,9 @@ function activateEditMode(fieldKey) {
         editBtn.classList.add('hidden');
     }
     editContainer.classList.remove('hidden');
+    if (textarea) {
+        autoGrow(textarea);
+    }
     const focusTarget = textarea || input;
     if (focusTarget) {
         focusTarget.focus();

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -48,8 +48,11 @@
                     <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 lg:gap-6">
 
                         <!-- Summary -->
-                        <div class="min-w-0 flex-1">
+                        <div class="min-w-0 flex-1 group relative">
                             <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Summary</p>
+                            <span class="absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                            </span>
                             <h2 class="mt-2 text-xl sm:text-2xl text-white/90 font-semibold leading-tight cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                 data-field-display="summary"
                                 data-dblclick-edit="true"
@@ -139,7 +142,7 @@
                                 <span class="text-white/40" th:if="${!stat.last}">/</span>
                             </th:block>
                         </div>
-                        <p class="mt-3 text-xs text-white/60 break-all"
+                        <p th:classappend="${detailsFolderSegments != null and !#lists.isEmpty(detailsFolderSegments)} ? 'sr-only' : 'mt-3 text-xs text-white/60 break-all'"
                            data-field-display="folder"
                            th:attr="data-raw-value=${detailsFolder ?: ''}"
                            th:text="${detailsFolder ?: '-'}">Device/HeadCoach Skill/HeadCoach Skill Pitch</p>
@@ -165,8 +168,13 @@
                     <div class="xl:col-span-8 space-y-6">
 
                         <!-- Description -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsDescription)}">
-                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Description</p>
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative" th:if="${!#strings.isEmpty(detailsDescription)}">
+                            <div class="flex items-center justify-between">
+                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Description</p>
+                                <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                </span>
+                            </div>
                             <div class="mt-3 text-sm leading-7 text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                  data-md="true"
                                  data-field-display="description"
@@ -407,15 +415,12 @@
                                 <div th:if="${!#strings.isEmpty(detailsLabels)}">
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Labels</dt>
-                                        <div class="flex items-center gap-2 min-w-0">
-                                            <dd class="text-white/80 text-right break-all"
-                                                data-field-display="labels"
-                                                th:attr="data-raw-value=${detailsLabels}"
-                                                th:text="${detailsLabels}">training, assignment, mobile</dd>
-                                            <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
-                                                    data-edit-field="labels">Edit</button>
-                                        </div>
+                                        <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
+                                            data-field-display="labels"
+                                            data-edit-field="labels"
+                                            title="Click to edit"
+                                            th:attr="data-raw-value=${detailsLabels}"
+                                            th:text="${detailsLabels}">training, assignment, mobile</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="labels">
                                         <input type="text"
@@ -443,15 +448,12 @@
                                 <div th:if="${!#strings.isEmpty(detailsSprint)}">
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Sprint</dt>
-                                        <div class="flex items-center gap-2 min-w-0">
-                                            <dd class="text-white/80 text-right break-all"
-                                                data-field-display="sprint"
-                                                th:attr="data-raw-value=${detailsSprint}"
-                                                th:text="${detailsSprint}">Sprint 14</dd>
-                                            <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
-                                                    data-edit-field="sprint">Edit</button>
-                                        </div>
+                                        <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
+                                            data-field-display="sprint"
+                                            data-edit-field="sprint"
+                                            title="Click to edit"
+                                            th:attr="data-raw-value=${detailsSprint}"
+                                            th:text="${detailsSprint}">Sprint 14</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="sprint">
                                         <input type="text"
@@ -470,15 +472,12 @@
                                 <div th:if="${!#strings.isEmpty(detailsFixVersions)}">
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Fix versions</dt>
-                                        <div class="flex items-center gap-2 min-w-0">
-                                            <dd class="text-white/80 text-right break-all"
-                                                data-field-display="fixVersions"
-                                                th:attr="data-raw-value=${detailsFixVersions}"
-                                                th:text="${detailsFixVersions}">v0.14.0</dd>
-                                            <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
-                                                    data-edit-field="fixVersions">Edit</button>
-                                        </div>
+                                        <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
+                                            data-field-display="fixVersions"
+                                            data-edit-field="fixVersions"
+                                            title="Click to edit"
+                                            th:attr="data-raw-value=${detailsFixVersions}"
+                                            th:text="${detailsFixVersions}">v0.14.0</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="fixVersions">
                                         <input type="text"
@@ -497,15 +496,12 @@
                                 <div th:if="${!#strings.isEmpty(detailsVersion)}">
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Version</dt>
-                                        <div class="flex items-center gap-2 min-w-0">
-                                            <dd class="text-white/80 text-right break-all"
-                                                data-field-display="version"
-                                                th:attr="data-raw-value=${detailsVersion}"
-                                                th:text="${detailsVersion}">2</dd>
-                                            <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
-                                                    data-edit-field="version">Edit</button>
-                                        </div>
+                                        <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
+                                            data-field-display="version"
+                                            data-edit-field="version"
+                                            title="Click to edit"
+                                            th:attr="data-raw-value=${detailsVersion}"
+                                            th:text="${detailsVersion}">2</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="version">
                                         <input type="text"
@@ -524,15 +520,12 @@
                                 <div th:if="${!#strings.isEmpty(detailsEstimatedTime)}">
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Estimated time</dt>
-                                        <div class="flex items-center gap-2 min-w-0">
-                                            <dd class="text-white/80 text-right break-all"
-                                                data-field-display="estimatedTime"
-                                                th:attr="data-raw-value=${detailsEstimatedTime}"
-                                                th:text="${detailsEstimatedTime}">5m</dd>
-                                            <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
-                                                    data-edit-field="estimatedTime">Edit</button>
-                                        </div>
+                                        <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
+                                            data-field-display="estimatedTime"
+                                            data-edit-field="estimatedTime"
+                                            title="Click to edit"
+                                            th:attr="data-raw-value=${detailsEstimatedTime}"
+                                            th:text="${detailsEstimatedTime}">5m</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="estimatedTime">
                                         <input type="text"

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -32,7 +32,6 @@
     </div>
 
     <div class="min-h-screen relative overflow-hidden" th:attr="data-work-key=${detailsCaseId}">
-        <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_85%_0%,rgba(255,255,255,0.08)_0%,rgba(255,255,255,0)_38%)]"></div>
 
         <header class="sticky top-0 z-20 border-b border-white/10 bg-[#1d1d1d]/95 backdrop-blur">
             <div class="w-full px-6 sm:px-8 py-4 flex items-center justify-between gap-3">
@@ -63,7 +62,7 @@
                             <span class="absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
                             </span>
-                            <h2 class="mt-2 text-xl sm:text-2xl text-white/90 font-semibold leading-tight cursor-text hover:bg-white/[0.03] rounded transition-colors"
+                            <h2 class="mt-2 text-xl sm:text-2xl text-white/90 font-semibold leading-tight cursor-text border-b border-dotted border-white/20 hover:border-white/40 hover:bg-white/[0.06] transition-colors"
                                 data-field-display="summary"
                                 data-dblclick-edit="true"
                                 title="Double-click to edit"
@@ -173,9 +172,9 @@
 
                 </section>
 
-                <!-- Main content grid -->
-                <section class="mt-6 grid grid-cols-1 xl:grid-cols-12 gap-6">
-                    <div class="xl:col-span-8 space-y-6">
+                <!-- Main content -->
+                <section class="mt-6 space-y-6">
+                    <div class="space-y-6">
 
                         <!-- Description -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative" th:if="${!#strings.isEmpty(detailsDescription)}">
@@ -185,7 +184,7 @@
                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
                                 </span>
                             </div>
-                            <div class="mt-3 text-sm leading-7 text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
+                            <div class="mt-3 text-sm leading-7 text-white/80 break-words cursor-text border-b border-dotted border-white/20 hover:border-white/40 hover:bg-white/[0.06] transition-colors"
                                  data-md="true"
                                  data-field-display="description"
                                  data-dblclick-edit="true"
@@ -212,7 +211,7 @@
                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
                                 </span>
                             </div>
-                            <div class="mt-3 text-sm leading-7 text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
+                            <div class="mt-3 text-sm leading-7 text-white/80 break-words cursor-text border-b border-dotted border-white/20 hover:border-white/40 hover:bg-white/[0.06] transition-colors"
                                  data-md="true"
                                  data-field-display="precondition"
                                  data-dblclick-edit="true"
@@ -231,136 +230,6 @@
                             </div>
                         </article>
 
-                        <!-- Execution timeline -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6">
-                            <div class="flex items-center justify-between gap-3">
-                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Execution timeline</p>
-                                <span class="text-xs text-white/60" th:text="${(detailsSteps != null ? #lists.size(detailsSteps) : 0) + ' steps'}">0 steps</span>
-                            </div>
-
-                            <div class="mt-3 flex gap-2 overflow-x-auto pb-1" th:if="${detailsSteps != null and #lists.size(detailsSteps) > 1}">
-                                <a th:each="step : ${detailsSteps}"
-                                   th:href="${'#step-' + step.stepNumber}"
-                                   class="shrink-0 px-2 py-1 border border-white/15 text-xs text-white/75 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors"
-                                   th:text="${'Step ' + step.stepNumber}">Step 1</a>
-                            </div>
-
-                            <div class="mt-5" th:if="${detailsSteps != null and !#lists.isEmpty(detailsSteps)}">
-                                <ol class="border-l border-white/15 pl-5 space-y-6">
-                                    <li th:each="step : ${detailsSteps}" th:id="${'step-' + step.stepNumber}" class="relative">
-                                        <span class="absolute -left-[1.875rem] top-1.5 h-3 w-3 rounded-full border border-[#E7FF02] bg-[#202020]"></span>
-                                        <div class="border border-white/10 bg-white/[0.03] p-4 sm:p-5 group relative">
-
-                                            <!-- Step label -->
-                                            <div class="flex items-center justify-between">
-                                                <p class="text-xs uppercase tracking-wider text-white/55" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
-                                                    Step <span th:text="${step.stepNumber}">1</span>
-                                                </p>
-                                                <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
-                                                </span>
-                                            </div>
-
-                                            <!-- Step summary display -->
-                                            <div class="mt-2 text-sm text-white/85 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
-                                                 data-md="true"
-                                                 data-dblclick-edit="true"
-                                                 data-empty-label="No step summary"
-                                                 title="Double-click to edit"
-                                                 th:attr="data-field-display=${'step-' + step.stepNumber + '-stepSummary'}, data-raw-value=${step.stepSummary ?: ''}"
-                                                 th:text="${step.stepSummary}">Open session plan and select the target swimmer.</div>
-
-                                            <!-- Step summary edit form -->
-                                            <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-stepSummary'}">
-                                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
-                                                          rows="3"
-                                                          th:attr="data-field-textarea=${'step-' + step.stepNumber + '-stepSummary'}"
-                                                          th:text="${step.stepSummary}"></textarea>
-                                                <div class="mt-2 flex items-center gap-2 flex-wrap">
-                                                    <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
-                                                            th:attr="data-field-save=${'step-' + step.stepNumber + '-stepSummary'}">Save</button>
-                                                    <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
-                                                            th:attr="data-field-cancel=${'step-' + step.stepNumber + '-stepSummary'}">Cancel</button>
-                                                    <span class="hidden text-xs text-red-400"
-                                                          th:attr="data-field-error=${'step-' + step.stepNumber + '-stepSummary'}"></span>
-                                                </div>
-                                            </div>
-
-                                            <!-- Test data and expected result -->
-                                            <div class="mt-4 grid grid-cols-1 gap-3" th:classappend="${!#strings.isEmpty(step.testData)} ? ' sm:grid-cols-2' : ''">
-
-                                                <!-- Test data -->
-                                                <div class="border border-white/10 bg-black/20 p-3 group/sub relative" th:if="${!#strings.isEmpty(step.testData)}">
-                                                    <div class="flex items-center justify-between">
-                                                        <p class="text-xs text-white/50">Test data</p>
-                                                        <span class="opacity-0 group-hover/sub:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
-                                                        </span>
-                                                    </div>
-                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
-                                                         data-md="true"
-                                                         data-dblclick-edit="true"
-                                                         title="Double-click to edit"
-                                                         th:attr="data-field-display=${'step-' + step.stepNumber + '-testData'}, data-raw-value=${step.testData ?: ''}"
-                                                         th:text="${step.testData}">Swimmer: Maya T. | Plan: Endurance - Week 4</div>
-                                                    <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-testData'}">
-                                                        <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
-                                                                  rows="3"
-                                                                  th:attr="data-field-textarea=${'step-' + step.stepNumber + '-testData'}"
-                                                                  th:text="${step.testData}"></textarea>
-                                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
-                                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
-                                                                    th:attr="data-field-save=${'step-' + step.stepNumber + '-testData'}">Save</button>
-                                                            <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
-                                                                    th:attr="data-field-cancel=${'step-' + step.stepNumber + '-testData'}">Cancel</button>
-                                                            <span class="hidden text-xs text-red-400"
-                                                                  th:attr="data-field-error=${'step-' + step.stepNumber + '-testData'}"></span>
-                                                        </div>
-                                                    </div>
-                                                </div>
-
-                                                <!-- Expected result -->
-                                                <div class="border border-white/10 bg-black/20 p-3 group/sub relative">
-                                                    <div class="flex items-center justify-between">
-                                                        <p class="text-xs text-white/50">Expected result</p>
-                                                        <span class="opacity-0 group-hover/sub:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
-                                                        </span>
-                                                    </div>
-                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
-                                                         data-md="true"
-                                                         data-dblclick-edit="true"
-                                                         data-empty-label="No expected result"
-                                                         title="Double-click to edit"
-                                                         th:attr="data-field-display=${'step-' + step.stepNumber + '-expectedResult'}, data-raw-value=${step.expectedResult ?: ''}"
-                                                         th:text="${step.expectedResult}">Swimmer profile opens with the selected session plan visible.</div>
-                                                    <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-expectedResult'}">
-                                                        <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
-                                                                  rows="3"
-                                                                  th:attr="data-field-textarea=${'step-' + step.stepNumber + '-expectedResult'}"
-                                                                  th:text="${step.expectedResult}"></textarea>
-                                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
-                                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
-                                                                    th:attr="data-field-save=${'step-' + step.stepNumber + '-expectedResult'}">Save</button>
-                                                            <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
-                                                                    th:attr="data-field-cancel=${'step-' + step.stepNumber + '-expectedResult'}">Cancel</button>
-                                                            <span class="hidden text-xs text-red-400"
-                                                                  th:attr="data-field-error=${'step-' + step.stepNumber + '-expectedResult'}"></span>
-                                                        </div>
-                                                    </div>
-                                                </div>
-
-                                            </div>
-                                        </div>
-                                    </li>
-                                </ol>
-                            </div>
-
-                            <div class="mt-5 border border-white/10 bg-white/[0.03] p-4" th:if="${detailsSteps == null or #lists.isEmpty(detailsSteps)}">
-                                <p class="text-sm text-white/70">No steps available for this test case.</p>
-                            </div>
-                        </article>
-
                         <!-- Story linkages -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative" th:if="${!#strings.isEmpty(detailsStoryLinkages)}">
                             <div class="flex items-center justify-between">
@@ -369,7 +238,7 @@
                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
                                 </span>
                             </div>
-                            <div class="mt-3 text-sm text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
+                            <div class="mt-3 text-sm text-white/80 break-words cursor-text border-b border-dotted border-white/20 hover:border-white/40 hover:bg-white/[0.06] transition-colors"
                                  data-md="true"
                                  data-field-display="storyLinkages"
                                  data-dblclick-edit="true"
@@ -389,8 +258,8 @@
 
                     </div>
 
-                    <!-- Aside: Classification, Release context, Timeline -->
-                    <aside class="xl:col-span-4 space-y-6">
+                    <!-- Classification, Release context, Timeline — horizontal row -->
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
 
                         <!-- Classification -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6"
@@ -593,7 +462,137 @@
                             </dl>
                         </article>
 
-                    </aside>
+                    </div>
+                </section>
+
+                <!-- Execution timeline (full width) -->
+                <section class="mt-6 border border-white/10 bg-[#202020] p-5 sm:p-6">
+                    <div class="flex items-center justify-between gap-3">
+                        <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Execution timeline</p>
+                        <span class="text-xs text-white/60" th:text="${(detailsSteps != null ? #lists.size(detailsSteps) : 0) + ' steps'}">0 steps</span>
+                    </div>
+
+                    <div class="mt-3 flex gap-2 overflow-x-auto pb-1" th:if="${detailsSteps != null and #lists.size(detailsSteps) > 1}">
+                        <a th:each="step : ${detailsSteps}"
+                           th:href="${'#step-' + step.stepNumber}"
+                           class="shrink-0 px-2 py-1 border border-white/15 text-xs text-white/75 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors"
+                           th:text="${'Step ' + step.stepNumber}">Step 1</a>
+                    </div>
+
+                    <div class="mt-5" th:if="${detailsSteps != null and !#lists.isEmpty(detailsSteps)}">
+                        <ol class="border-l border-white/15 pl-5 space-y-6">
+                            <li th:each="step : ${detailsSteps}" th:id="${'step-' + step.stepNumber}" class="relative">
+                                <span class="absolute -left-[1.875rem] top-1.5 h-3 w-3 rounded-full border border-[#E7FF02] bg-[#202020]"></span>
+                                <div class="border border-white/10 bg-white/[0.03] p-4 sm:p-5 group relative">
+
+                                    <!-- Step label -->
+                                    <div class="flex items-center justify-between">
+                                        <p class="text-xs uppercase tracking-wider text-white/55" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
+                                            Step <span th:text="${step.stepNumber}">1</span>
+                                        </p>
+                                        <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                        </span>
+                                    </div>
+
+                                    <!-- Step summary display -->
+                                    <div class="mt-2 text-sm text-white/85 leading-7 break-words cursor-text border-b border-dotted border-white/20 hover:border-white/40 hover:bg-white/[0.06] transition-colors"
+                                         data-md="true"
+                                         data-dblclick-edit="true"
+                                         data-empty-label="No step summary"
+                                         title="Double-click to edit"
+                                         th:attr="data-field-display=${'step-' + step.stepNumber + '-stepSummary'}, data-raw-value=${step.stepSummary ?: ''}"
+                                         th:text="${step.stepSummary}">Open session plan and select the target swimmer.</div>
+
+                                    <!-- Step summary edit form -->
+                                    <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-stepSummary'}">
+                                        <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
+                                                  rows="3"
+                                                  th:attr="data-field-textarea=${'step-' + step.stepNumber + '-stepSummary'}"
+                                                  th:text="${step.stepSummary}"></textarea>
+                                        <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
+                                                    th:attr="data-field-save=${'step-' + step.stepNumber + '-stepSummary'}">Save</button>
+                                            <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
+                                                    th:attr="data-field-cancel=${'step-' + step.stepNumber + '-stepSummary'}">Cancel</button>
+                                            <span class="hidden text-xs text-red-400"
+                                                  th:attr="data-field-error=${'step-' + step.stepNumber + '-stepSummary'}"></span>
+                                        </div>
+                                    </div>
+
+                                    <!-- Test data and expected result -->
+                                    <div class="mt-4 grid grid-cols-1 gap-3" th:classappend="${!#strings.isEmpty(step.testData)} ? ' sm:grid-cols-2' : ''">
+
+                                        <!-- Test data -->
+                                        <div class="border border-white/10 bg-black/20 p-3 group/sub relative" th:if="${!#strings.isEmpty(step.testData)}">
+                                            <div class="flex items-center justify-between">
+                                                <p class="text-xs text-white/50">Test data</p>
+                                                <span class="opacity-0 group-hover/sub:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                                </span>
+                                            </div>
+                                            <div class="mt-1 text-sm text-white/80 leading-7 break-words cursor-text border-b border-dotted border-white/20 hover:border-white/40 hover:bg-white/[0.06] transition-colors"
+                                                 data-md="true"
+                                                 data-dblclick-edit="true"
+                                                 title="Double-click to edit"
+                                                 th:attr="data-field-display=${'step-' + step.stepNumber + '-testData'}, data-raw-value=${step.testData ?: ''}"
+                                                 th:text="${step.testData}">Swimmer: Maya T. | Plan: Endurance - Week 4</div>
+                                            <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-testData'}">
+                                                <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
+                                                          rows="3"
+                                                          th:attr="data-field-textarea=${'step-' + step.stepNumber + '-testData'}"
+                                                          th:text="${step.testData}"></textarea>
+                                                <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                                    <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
+                                                            th:attr="data-field-save=${'step-' + step.stepNumber + '-testData'}">Save</button>
+                                                    <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
+                                                            th:attr="data-field-cancel=${'step-' + step.stepNumber + '-testData'}">Cancel</button>
+                                                    <span class="hidden text-xs text-red-400"
+                                                          th:attr="data-field-error=${'step-' + step.stepNumber + '-testData'}"></span>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- Expected result -->
+                                        <div class="border border-white/10 bg-black/20 p-3 group/sub relative">
+                                            <div class="flex items-center justify-between">
+                                                <p class="text-xs text-white/50">Expected result</p>
+                                                <span class="opacity-0 group-hover/sub:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                                </span>
+                                            </div>
+                                            <div class="mt-1 text-sm text-white/80 leading-7 break-words cursor-text border-b border-dotted border-white/20 hover:border-white/40 hover:bg-white/[0.06] transition-colors"
+                                                 data-md="true"
+                                                 data-dblclick-edit="true"
+                                                 data-empty-label="No expected result"
+                                                 title="Double-click to edit"
+                                                 th:attr="data-field-display=${'step-' + step.stepNumber + '-expectedResult'}, data-raw-value=${step.expectedResult ?: ''}"
+                                                 th:text="${step.expectedResult}">Swimmer profile opens with the selected session plan visible.</div>
+                                            <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-expectedResult'}">
+                                                <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
+                                                          rows="3"
+                                                          th:attr="data-field-textarea=${'step-' + step.stepNumber + '-expectedResult'}"
+                                                          th:text="${step.expectedResult}"></textarea>
+                                                <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                                    <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
+                                                            th:attr="data-field-save=${'step-' + step.stepNumber + '-expectedResult'}">Save</button>
+                                                    <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
+                                                            th:attr="data-field-cancel=${'step-' + step.stepNumber + '-expectedResult'}">Cancel</button>
+                                                    <span class="hidden text-xs text-red-400"
+                                                          th:attr="data-field-error=${'step-' + step.stepNumber + '-expectedResult'}"></span>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </div>
+                            </li>
+                        </ol>
+                    </div>
+
+                    <div class="mt-5 border border-white/10 bg-white/[0.03] p-4" th:if="${detailsSteps == null or #lists.isEmpty(detailsSteps)}">
+                        <p class="text-sm text-white/70">No steps available for this test case.</p>
+                    </div>
                 </section>
 
             </div>

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -22,8 +22,6 @@
     </div>
 
     <div class="min-h-screen relative overflow-hidden" th:attr="data-work-key=${detailsCaseId}">
-        <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_15%_20%,rgba(231,255,2,0.09)_0%,rgba(231,255,2,0)_32%),radial-gradient(circle_at_85%_0%,rgba(255,255,255,0.08)_0%,rgba(255,255,255,0)_38%)]"></div>
-
         <header class="sticky top-0 z-20 border-b border-white/10 bg-[#1d1d1d]/95 backdrop-blur">
             <div class="w-full px-6 sm:px-8 py-4 flex items-center justify-between gap-3">
                 <div class="min-w-0">

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -7,10 +7,21 @@
     <title>Test Case Details</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;700;900&display=swap" rel="stylesheet">
+    <meta name="_csrf" th:content="${_csrf.token}">
+    <meta name="_csrf_header" th:content="${_csrf.headerName}">
 </head>
 
 <body class="bg-[#181818] text-white">
-    <div class="min-h-screen relative overflow-hidden">
+
+    <!-- Edit notice banner (shown/hidden by JS) -->
+    <div id="detailsNotice" class="fixed top-0 inset-x-0 z-50 hidden border-b border-white/15 bg-[#1d1d1d]/98 backdrop-blur">
+        <div class="px-6 sm:px-8 py-3 flex items-center justify-between gap-4">
+            <span id="detailsNoticeMsg" class="text-sm text-white/90"></span>
+            <button type="button" id="detailsNoticeClose" class="shrink-0 text-white/50 hover:text-white text-xl leading-none">×</button>
+        </div>
+    </div>
+
+    <div class="min-h-screen relative overflow-hidden" th:attr="data-work-key=${detailsCaseId}">
         <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_15%_20%,rgba(231,255,2,0.09)_0%,rgba(231,255,2,0)_32%),radial-gradient(circle_at_85%_0%,rgba(255,255,255,0.08)_0%,rgba(255,255,255,0)_38%)]"></div>
 
         <header class="sticky top-0 z-20 border-b border-white/10 bg-[#1d1d1d]/95 backdrop-blur">
@@ -29,45 +40,185 @@
         </header>
 
         <main class="relative w-full px-6 sm:px-8 py-8 sm:py-10">
-            <div class="max-w-[76rem] mx-auto">
+            <div class="mx-auto">
+
+                <!-- Case header card -->
                 <section class="border border-white/10 bg-[#202020] p-5 sm:p-6 lg:p-7">
+
                     <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 lg:gap-6">
-                        <div class="min-w-0">
-                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Summary</p>
-                            <h2 class="mt-2 text-xl sm:text-2xl text-white/90 font-semibold leading-tight" th:text="${detailsSummary ?: 'No summary available'}">Validate drill assignment from session plan</h2>
+
+                        <!-- Summary -->
+                        <div class="min-w-0 flex-1">
+                            <div class="flex items-center gap-3">
+                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Summary</p>
+                                <button type="button"
+                                        class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                        data-edit-field="summary"
+                                        th:if="${!#strings.isEmpty(detailsSummary)}">Edit</button>
+                            </div>
+                            <h2 class="mt-2 text-xl sm:text-2xl text-white/90 font-semibold leading-tight"
+                                data-field-display="summary"
+                                th:attr="data-raw-value=${detailsSummary ?: ''}"
+                                th:text="${detailsSummary ?: 'No summary available'}">Validate drill assignment from session plan</h2>
+                            <div class="hidden mt-3" data-field-edit="summary">
+                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[4rem]"
+                                          rows="3" data-field-textarea="summary" th:text="${detailsSummary ?: ''}"></textarea>
+                                <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                    <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="summary">Save</button>
+                                    <button type="button" class="px-4 py-2 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors" data-field-cancel="summary">Cancel</button>
+                                    <span class="hidden text-xs text-red-400" data-field-error="summary"></span>
+                                </div>
+                            </div>
                         </div>
-                        <div class="shrink-0 flex flex-wrap items-center gap-2">
-                            <span class="px-3 py-1 border border-white/15 text-xs text-white/70">Status: <span th:text="${detailsStatus ?: '-'}">Draft</span></span>
-                            <span class="px-3 py-1 border border-white/15 text-xs text-white/70">Priority: <span th:text="${detailsPriority ?: '-'}">Medium</span></span>
-                            <span class="px-3 py-1 border border-white/15 text-xs text-white/70">Steps: <span th:text="${detailsSteps != null ? #lists.size(detailsSteps) : 0}">0</span></span>
-                            <span class="px-3 py-1 border border-[#E7FF02]/55 text-xs text-black" style="background-color: #E7FF02;">Read only</span>
+
+                        <!-- Status / Priority badges -->
+                        <div class="shrink-0">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70">
+                                    Status: <span data-field-display="status"
+                                                  th:attr="data-raw-value=${detailsStatus ?: ''}"
+                                                  th:text="${detailsStatus ?: '-'}">Draft</span>
+                                </span>
+                                <button type="button"
+                                        class="text-xs text-white/40 hover:text-[#E7FF02] transition-colors"
+                                        data-edit-field="status"
+                                        th:if="${!#strings.isEmpty(detailsStatus)}">edit</button>
+
+                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70">
+                                    Priority: <span data-field-display="priority"
+                                                    th:attr="data-raw-value=${detailsPriority ?: ''}"
+                                                    th:text="${detailsPriority ?: '-'}">Medium</span>
+                                </span>
+                                <button type="button"
+                                        class="text-xs text-white/40 hover:text-[#E7FF02] transition-colors"
+                                        data-edit-field="priority"
+                                        th:if="${!#strings.isEmpty(detailsPriority)}">edit</button>
+
+                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70">Steps: <span th:text="${detailsSteps != null ? #lists.size(detailsSteps) : 0}">0</span></span>
+                            </div>
+
+                            <!-- Status edit form -->
+                            <div class="hidden mt-3" data-field-edit="status">
+                                <input type="text"
+                                       class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                       data-field-input="status"
+                                       th:value="${detailsStatus ?: ''}">
+                                <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                    <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="status">Save</button>
+                                    <button type="button" class="px-4 py-2 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors" data-field-cancel="status">Cancel</button>
+                                    <span class="hidden text-xs text-red-400" data-field-error="status"></span>
+                                </div>
+                            </div>
+
+                            <!-- Priority edit form -->
+                            <div class="hidden mt-3" data-field-edit="priority">
+                                <input type="text"
+                                       class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                       data-field-input="priority"
+                                       th:value="${detailsPriority ?: ''}">
+                                <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                    <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="priority">Save</button>
+                                    <button type="button" class="px-4 py-2 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors" data-field-cancel="priority">Cancel</button>
+                                    <span class="hidden text-xs text-red-400" data-field-error="priority"></span>
+                                </div>
+                            </div>
                         </div>
+
                     </div>
 
+                    <!-- Folder context -->
                     <div class="mt-5 border border-white/10 bg-white/[0.03] p-4 sm:p-5">
-                        <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Folder context</p>
-                        <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-white/80" th:if="${detailsFolderSegments != null and !#lists.isEmpty(detailsFolderSegments)}">
+                        <div class="flex items-center justify-between gap-3">
+                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Folder context</p>
+                            <button type="button"
+                                    class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                    data-edit-field="folder"
+                                    th:if="${!#strings.isEmpty(detailsFolder)}">Edit</button>
+                        </div>
+                        <div id="folderSegmentsContainer"
+                             class="mt-3 flex flex-wrap items-center gap-2 text-xs text-white/80"
+                             th:if="${detailsFolderSegments != null and !#lists.isEmpty(detailsFolderSegments)}">
                             <th:block th:each="segment, stat : ${detailsFolderSegments}">
                                 <span class="px-2 py-1 border border-white/15 bg-black/20" th:text="${segment}">Device</span>
                                 <span class="text-white/40" th:if="${!stat.last}">/</span>
                             </th:block>
                         </div>
-                        <p class="mt-3 text-xs text-white/60 break-all" th:text="${detailsFolder ?: '-'}">Device/HeadCoach Skill/HeadCoach Skill Pitch</p>
+                        <p class="mt-3 text-xs text-white/60 break-all"
+                           data-field-display="folder"
+                           th:attr="data-raw-value=${detailsFolder ?: ''}"
+                           th:text="${detailsFolder ?: '-'}">Device/HeadCoach Skill/HeadCoach Skill Pitch</p>
+
+                        <!-- Folder edit form -->
+                        <div class="hidden mt-3" data-field-edit="folder">
+                            <input type="text"
+                                   class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                   data-field-input="folder"
+                                   th:value="${detailsFolder ?: ''}">
+                            <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="folder">Save</button>
+                                <button type="button" class="px-4 py-2 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors" data-field-cancel="folder">Cancel</button>
+                                <span class="hidden text-xs text-red-400" data-field-error="folder"></span>
+                            </div>
+                        </div>
                     </div>
+
                 </section>
 
+                <!-- Main content grid -->
                 <section class="mt-6 grid grid-cols-1 xl:grid-cols-12 gap-6">
                     <div class="xl:col-span-8 space-y-6">
+
+                        <!-- Description -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsDescription)}">
-                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Description</p>
-                            <div class="mt-3 text-sm leading-7 text-white/80 break-words" data-md="true" th:text="${detailsDescription}">Coach assigns a planned drill to a swimmer and verifies it appears in the daily training view with the correct configuration.</div>
+                            <div class="flex items-center justify-between gap-3">
+                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Description</p>
+                                <button type="button"
+                                        class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                        data-edit-field="description">Edit</button>
+                            </div>
+                            <div class="mt-3 text-sm leading-7 text-white/80 break-words"
+                                 data-md="true"
+                                 data-field-display="description"
+                                 data-empty-label="Not provided"
+                                 th:attr="data-raw-value=${detailsDescription}"
+                                 th:text="${detailsDescription}">Coach assigns a planned drill to a swimmer and verifies it appears in the daily training view with the correct configuration.</div>
+                            <div class="hidden mt-3" data-field-edit="description">
+                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[6rem]"
+                                          rows="6" data-field-textarea="description" th:text="${detailsDescription}"></textarea>
+                                <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                    <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="description">Save</button>
+                                    <button type="button" class="px-4 py-2 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors" data-field-cancel="description">Cancel</button>
+                                    <span class="hidden text-xs text-red-400" data-field-error="description"></span>
+                                </div>
+                            </div>
                         </article>
 
+                        <!-- Precondition -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsPrecondition)}">
-                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Precondition</p>
-                            <div class="mt-3 text-sm leading-7 text-white/80 break-words" data-md="true" th:text="${detailsPrecondition}">User is authenticated, swimmer profile exists, and the session plan has at least one unpublished drill.</div>
+                            <div class="flex items-center justify-between gap-3">
+                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Precondition</p>
+                                <button type="button"
+                                        class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                        data-edit-field="precondition">Edit</button>
+                            </div>
+                            <div class="mt-3 text-sm leading-7 text-white/80 break-words"
+                                 data-md="true"
+                                 data-field-display="precondition"
+                                 data-empty-label="Not provided"
+                                 th:attr="data-raw-value=${detailsPrecondition}"
+                                 th:text="${detailsPrecondition}">User is authenticated, swimmer profile exists, and the session plan has at least one unpublished drill.</div>
+                            <div class="hidden mt-3" data-field-edit="precondition">
+                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[4rem]"
+                                          rows="4" data-field-textarea="precondition" th:text="${detailsPrecondition}"></textarea>
+                                <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                    <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="precondition">Save</button>
+                                    <button type="button" class="px-4 py-2 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors" data-field-cancel="precondition">Cancel</button>
+                                    <span class="hidden text-xs text-red-400" data-field-error="precondition"></span>
+                                </div>
+                            </div>
                         </article>
 
+                        <!-- Execution timeline -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6">
                             <div class="flex items-center justify-between gap-3">
                                 <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Execution timeline</p>
@@ -86,20 +237,102 @@
                                     <li th:each="step : ${detailsSteps}" th:id="${'step-' + step.stepNumber}" class="relative">
                                         <span class="absolute -left-[1.875rem] top-1.5 h-3 w-3 rounded-full border border-[#E7FF02] bg-[#202020]"></span>
                                         <div class="border border-white/10 bg-white/[0.03] p-4 sm:p-5">
-                                            <p class="text-xs uppercase tracking-wider text-white/55" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
-                                                Step <span th:text="${step.stepNumber}">1</span>
-                                            </p>
-                                            <div class="mt-2 text-sm text-white/85 leading-7 break-words" data-md="true" data-md-kind="summary" data-empty-label="No step summary" th:text="${step.stepSummary}">Open session plan and select the target swimmer.</div>
 
+                                            <!-- Step label and step summary edit trigger -->
+                                            <div class="flex items-center justify-between gap-3">
+                                                <p class="text-xs uppercase tracking-wider text-white/55" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
+                                                    Step <span th:text="${step.stepNumber}">1</span>
+                                                </p>
+                                                <button type="button"
+                                                        class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                                        th:attr="data-edit-field=${'step-' + step.stepNumber + '-stepSummary'}"
+                                                        th:if="${!#strings.isEmpty(step.stepSummary)}">Edit action</button>
+                                            </div>
+
+                                            <!-- Step summary display -->
+                                            <div class="mt-2 text-sm text-white/85 leading-7 break-words"
+                                                 data-md="true"
+                                                 data-empty-label="No step summary"
+                                                 th:attr="data-field-display=${'step-' + step.stepNumber + '-stepSummary'}, data-raw-value=${step.stepSummary ?: ''}"
+                                                 th:text="${step.stepSummary}">Open session plan and select the target swimmer.</div>
+
+                                            <!-- Step summary edit form -->
+                                            <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-stepSummary'}">
+                                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[3rem]"
+                                                          rows="3"
+                                                          th:attr="data-field-textarea=${'step-' + step.stepNumber + '-stepSummary'}"
+                                                          th:text="${step.stepSummary}"></textarea>
+                                                <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                                    <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
+                                                            th:attr="data-field-save=${'step-' + step.stepNumber + '-stepSummary'}">Save</button>
+                                                    <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
+                                                            th:attr="data-field-cancel=${'step-' + step.stepNumber + '-stepSummary'}">Cancel</button>
+                                                    <span class="hidden text-xs text-red-400"
+                                                          th:attr="data-field-error=${'step-' + step.stepNumber + '-stepSummary'}"></span>
+                                                </div>
+                                            </div>
+
+                                            <!-- Test data and expected result -->
                                             <div class="mt-4 grid grid-cols-1 gap-3" th:classappend="${!#strings.isEmpty(step.testData)} ? ' sm:grid-cols-2' : ''">
+
+                                                <!-- Test data -->
                                                 <div class="border border-white/10 bg-black/20 p-3" th:if="${!#strings.isEmpty(step.testData)}">
-                                                    <p class="text-xs text-white/50">Test data</p>
-                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words" data-md="true" data-md-kind="test-data" th:text="${step.testData}">Swimmer: Maya T. | Plan: Endurance - Week 4</div>
+                                                    <div class="flex items-center justify-between gap-2">
+                                                        <p class="text-xs text-white/50">Test data</p>
+                                                        <button type="button"
+                                                                class="text-xs text-white/40 hover:text-[#E7FF02] transition-colors"
+                                                                th:attr="data-edit-field=${'step-' + step.stepNumber + '-testData'}">edit</button>
+                                                    </div>
+                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words"
+                                                         data-md="true"
+                                                         th:attr="data-field-display=${'step-' + step.stepNumber + '-testData'}, data-raw-value=${step.testData ?: ''}"
+                                                         th:text="${step.testData}">Swimmer: Maya T. | Plan: Endurance - Week 4</div>
+                                                    <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-testData'}">
+                                                        <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-y min-h-[3rem]"
+                                                                  rows="3"
+                                                                  th:attr="data-field-textarea=${'step-' + step.stepNumber + '-testData'}"
+                                                                  th:text="${step.testData}"></textarea>
+                                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
+                                                                    th:attr="data-field-save=${'step-' + step.stepNumber + '-testData'}">Save</button>
+                                                            <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
+                                                                    th:attr="data-field-cancel=${'step-' + step.stepNumber + '-testData'}">Cancel</button>
+                                                            <span class="hidden text-xs text-red-400"
+                                                                  th:attr="data-field-error=${'step-' + step.stepNumber + '-testData'}"></span>
+                                                        </div>
+                                                    </div>
                                                 </div>
+
+                                                <!-- Expected result -->
                                                 <div class="border border-white/10 bg-black/20 p-3">
-                                                    <p class="text-xs text-white/50">Expected result</p>
-                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words" data-md="true" data-md-kind="expected" data-empty-label="No expected result" th:text="${step.expectedResult}">Swimmer profile opens with the selected session plan visible.</div>
+                                                    <div class="flex items-center justify-between gap-2">
+                                                        <p class="text-xs text-white/50">Expected result</p>
+                                                        <button type="button"
+                                                                class="text-xs text-white/40 hover:text-[#E7FF02] transition-colors"
+                                                                th:attr="data-edit-field=${'step-' + step.stepNumber + '-expectedResult'}"
+                                                                th:if="${!#strings.isEmpty(step.expectedResult)}">edit</button>
+                                                    </div>
+                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words"
+                                                         data-md="true"
+                                                         data-empty-label="No expected result"
+                                                         th:attr="data-field-display=${'step-' + step.stepNumber + '-expectedResult'}, data-raw-value=${step.expectedResult ?: ''}"
+                                                         th:text="${step.expectedResult}">Swimmer profile opens with the selected session plan visible.</div>
+                                                    <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-expectedResult'}">
+                                                        <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-y min-h-[3rem]"
+                                                                  rows="3"
+                                                                  th:attr="data-field-textarea=${'step-' + step.stepNumber + '-expectedResult'}"
+                                                                  th:text="${step.expectedResult}"></textarea>
+                                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors"
+                                                                    th:attr="data-field-save=${'step-' + step.stepNumber + '-expectedResult'}">Save</button>
+                                                            <button type="button" class="px-3 py-1.5 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors"
+                                                                    th:attr="data-field-cancel=${'step-' + step.stepNumber + '-expectedResult'}">Cancel</button>
+                                                            <span class="hidden text-xs text-red-400"
+                                                                  th:attr="data-field-error=${'step-' + step.stepNumber + '-expectedResult'}"></span>
+                                                        </div>
+                                                    </div>
                                                 </div>
+
                                             </div>
                                         </div>
                                     </li>
@@ -111,53 +344,243 @@
                             </div>
                         </article>
 
+                        <!-- Story linkages -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsStoryLinkages)}">
-                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Story linkage</p>
-                            <div class="mt-3 text-sm text-white/80 break-words" data-md="true" th:text="${detailsStoryLinkages}">https://tracker.example.com/story/TC-2481</div>
+                            <div class="flex items-center justify-between gap-3">
+                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Story linkage</p>
+                                <button type="button"
+                                        class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                        data-edit-field="storyLinkages">Edit</button>
+                            </div>
+                            <div class="mt-3 text-sm text-white/80 break-words"
+                                 data-md="true"
+                                 data-field-display="storyLinkages"
+                                 th:attr="data-raw-value=${detailsStoryLinkages}"
+                                 th:text="${detailsStoryLinkages}">https://tracker.example.com/story/TC-2481</div>
+                            <div class="hidden mt-3" data-field-edit="storyLinkages">
+                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[3rem]"
+                                          rows="3" data-field-textarea="storyLinkages" th:text="${detailsStoryLinkages}"></textarea>
+                                <div class="mt-2 flex items-center gap-2 flex-wrap">
+                                    <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="storyLinkages">Save</button>
+                                    <button type="button" class="px-4 py-2 border border-white/20 text-white/70 text-xs hover:border-white/40 transition-colors" data-field-cancel="storyLinkages">Cancel</button>
+                                    <span class="hidden text-xs text-red-400" data-field-error="storyLinkages"></span>
+                                </div>
+                            </div>
                         </article>
+
                     </div>
 
+                    <!-- Aside: Classification, Release context, Timeline -->
                     <aside class="xl:col-span-4 space-y-6">
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsComponents) or !#strings.isEmpty(detailsTestCaseType) or !#strings.isEmpty(detailsLabels)}">
+
+                        <!-- Classification -->
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6"
+                                 th:if="${!#strings.isEmpty(detailsComponents) or !#strings.isEmpty(detailsTestCaseType) or !#strings.isEmpty(detailsLabels)}">
                             <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Classification</p>
-                            <dl class="mt-4 space-y-3 text-sm">
-                                <div class="flex items-start justify-between gap-4" th:if="${!#strings.isEmpty(detailsComponents)}">
-                                    <dt class="text-white/50">Components</dt>
-                                    <dd class="text-white/80 text-right break-all" th:text="${detailsComponents}">HeadCoach, Device</dd>
+                            <dl class="mt-4 space-y-4 text-sm">
+
+                                <!-- Components -->
+                                <div th:if="${!#strings.isEmpty(detailsComponents)}">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-white/50 shrink-0">Components</dt>
+                                        <div class="flex items-center gap-2 min-w-0">
+                                            <dd class="text-white/80 text-right break-all"
+                                                data-field-display="components"
+                                                th:attr="data-raw-value=${detailsComponents}"
+                                                th:text="${detailsComponents}">HeadCoach, Device</dd>
+                                            <button type="button"
+                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    data-edit-field="components">edit</button>
+                                        </div>
+                                    </div>
+                                    <div class="hidden mt-2" data-field-edit="components">
+                                        <input type="text"
+                                               class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                               data-field-input="components"
+                                               th:value="${detailsComponents}">
+                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="components">Save</button>
+                                            <button type="button" class="px-3 py-1.5 border border-white/15 text-white/60 text-xs hover:border-white/30 transition-colors" data-field-cancel="components">Cancel</button>
+                                            <span class="hidden text-xs text-red-400" data-field-error="components"></span>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="flex items-start justify-between gap-4" th:if="${!#strings.isEmpty(detailsTestCaseType)}">
-                                    <dt class="text-white/50">Test case type</dt>
-                                    <dd class="text-white/80 text-right break-all" th:text="${detailsTestCaseType}">Functional</dd>
+
+                                <!-- Test case type -->
+                                <div th:if="${!#strings.isEmpty(detailsTestCaseType)}">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-white/50 shrink-0">Test case type</dt>
+                                        <div class="flex items-center gap-2 min-w-0">
+                                            <dd class="text-white/80 text-right break-all"
+                                                data-field-display="testCaseType"
+                                                th:attr="data-raw-value=${detailsTestCaseType}"
+                                                th:text="${detailsTestCaseType}">Functional</dd>
+                                            <button type="button"
+                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    data-edit-field="testCaseType">edit</button>
+                                        </div>
+                                    </div>
+                                    <div class="hidden mt-2" data-field-edit="testCaseType">
+                                        <input type="text"
+                                               class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                               data-field-input="testCaseType"
+                                               th:value="${detailsTestCaseType}">
+                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="testCaseType">Save</button>
+                                            <button type="button" class="px-3 py-1.5 border border-white/15 text-white/60 text-xs hover:border-white/30 transition-colors" data-field-cancel="testCaseType">Cancel</button>
+                                            <span class="hidden text-xs text-red-400" data-field-error="testCaseType"></span>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="flex items-start justify-between gap-4" th:if="${!#strings.isEmpty(detailsLabels)}">
-                                    <dt class="text-white/50">Labels</dt>
-                                    <dd class="text-white/80 text-right break-all" th:text="${detailsLabels}">training, assignment, mobile</dd>
+
+                                <!-- Labels -->
+                                <div th:if="${!#strings.isEmpty(detailsLabels)}">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-white/50 shrink-0">Labels</dt>
+                                        <div class="flex items-center gap-2 min-w-0">
+                                            <dd class="text-white/80 text-right break-all"
+                                                data-field-display="labels"
+                                                th:attr="data-raw-value=${detailsLabels}"
+                                                th:text="${detailsLabels}">training, assignment, mobile</dd>
+                                            <button type="button"
+                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    data-edit-field="labels">edit</button>
+                                        </div>
+                                    </div>
+                                    <div class="hidden mt-2" data-field-edit="labels">
+                                        <input type="text"
+                                               class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                               data-field-input="labels"
+                                               th:value="${detailsLabels}">
+                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="labels">Save</button>
+                                            <button type="button" class="px-3 py-1.5 border border-white/15 text-white/60 text-xs hover:border-white/30 transition-colors" data-field-cancel="labels">Cancel</button>
+                                            <span class="hidden text-xs text-red-400" data-field-error="labels"></span>
+                                        </div>
+                                    </div>
                                 </div>
+
                             </dl>
                         </article>
 
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsSprint) or !#strings.isEmpty(detailsFixVersions) or !#strings.isEmpty(detailsVersion) or !#strings.isEmpty(detailsEstimatedTime)}">
+                        <!-- Release context -->
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6"
+                                 th:if="${!#strings.isEmpty(detailsSprint) or !#strings.isEmpty(detailsFixVersions) or !#strings.isEmpty(detailsVersion) or !#strings.isEmpty(detailsEstimatedTime)}">
                             <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Release context</p>
-                            <dl class="mt-4 space-y-3 text-sm">
-                                <div class="flex items-start justify-between gap-4" th:if="${!#strings.isEmpty(detailsSprint)}">
-                                    <dt class="text-white/50">Sprint</dt>
-                                    <dd class="text-white/80 text-right break-all" th:text="${detailsSprint}">Sprint 14</dd>
+                            <dl class="mt-4 space-y-4 text-sm">
+
+                                <!-- Sprint -->
+                                <div th:if="${!#strings.isEmpty(detailsSprint)}">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-white/50 shrink-0">Sprint</dt>
+                                        <div class="flex items-center gap-2 min-w-0">
+                                            <dd class="text-white/80 text-right break-all"
+                                                data-field-display="sprint"
+                                                th:attr="data-raw-value=${detailsSprint}"
+                                                th:text="${detailsSprint}">Sprint 14</dd>
+                                            <button type="button"
+                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    data-edit-field="sprint">edit</button>
+                                        </div>
+                                    </div>
+                                    <div class="hidden mt-2" data-field-edit="sprint">
+                                        <input type="text"
+                                               class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                               data-field-input="sprint"
+                                               th:value="${detailsSprint}">
+                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="sprint">Save</button>
+                                            <button type="button" class="px-3 py-1.5 border border-white/15 text-white/60 text-xs hover:border-white/30 transition-colors" data-field-cancel="sprint">Cancel</button>
+                                            <span class="hidden text-xs text-red-400" data-field-error="sprint"></span>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="flex items-start justify-between gap-4" th:if="${!#strings.isEmpty(detailsFixVersions)}">
-                                    <dt class="text-white/50">Fix versions</dt>
-                                    <dd class="text-white/80 text-right break-all" th:text="${detailsFixVersions}">v0.14.0</dd>
+
+                                <!-- Fix versions -->
+                                <div th:if="${!#strings.isEmpty(detailsFixVersions)}">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-white/50 shrink-0">Fix versions</dt>
+                                        <div class="flex items-center gap-2 min-w-0">
+                                            <dd class="text-white/80 text-right break-all"
+                                                data-field-display="fixVersions"
+                                                th:attr="data-raw-value=${detailsFixVersions}"
+                                                th:text="${detailsFixVersions}">v0.14.0</dd>
+                                            <button type="button"
+                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    data-edit-field="fixVersions">edit</button>
+                                        </div>
+                                    </div>
+                                    <div class="hidden mt-2" data-field-edit="fixVersions">
+                                        <input type="text"
+                                               class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                               data-field-input="fixVersions"
+                                               th:value="${detailsFixVersions}">
+                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="fixVersions">Save</button>
+                                            <button type="button" class="px-3 py-1.5 border border-white/15 text-white/60 text-xs hover:border-white/30 transition-colors" data-field-cancel="fixVersions">Cancel</button>
+                                            <span class="hidden text-xs text-red-400" data-field-error="fixVersions"></span>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="flex items-start justify-between gap-4" th:if="${!#strings.isEmpty(detailsVersion)}">
-                                    <dt class="text-white/50">Version</dt>
-                                    <dd class="text-white/80 text-right break-all" th:text="${detailsVersion}">2</dd>
+
+                                <!-- Version -->
+                                <div th:if="${!#strings.isEmpty(detailsVersion)}">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-white/50 shrink-0">Version</dt>
+                                        <div class="flex items-center gap-2 min-w-0">
+                                            <dd class="text-white/80 text-right break-all"
+                                                data-field-display="version"
+                                                th:attr="data-raw-value=${detailsVersion}"
+                                                th:text="${detailsVersion}">2</dd>
+                                            <button type="button"
+                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    data-edit-field="version">edit</button>
+                                        </div>
+                                    </div>
+                                    <div class="hidden mt-2" data-field-edit="version">
+                                        <input type="text"
+                                               class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                               data-field-input="version"
+                                               th:value="${detailsVersion}">
+                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="version">Save</button>
+                                            <button type="button" class="px-3 py-1.5 border border-white/15 text-white/60 text-xs hover:border-white/30 transition-colors" data-field-cancel="version">Cancel</button>
+                                            <span class="hidden text-xs text-red-400" data-field-error="version"></span>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="flex items-start justify-between gap-4" th:if="${!#strings.isEmpty(detailsEstimatedTime)}">
-                                    <dt class="text-white/50">Estimated time</dt>
-                                    <dd class="text-white/80 text-right break-all" th:text="${detailsEstimatedTime}">5m</dd>
+
+                                <!-- Estimated time -->
+                                <div th:if="${!#strings.isEmpty(detailsEstimatedTime)}">
+                                    <div class="flex items-center justify-between gap-4">
+                                        <dt class="text-white/50 shrink-0">Estimated time</dt>
+                                        <div class="flex items-center gap-2 min-w-0">
+                                            <dd class="text-white/80 text-right break-all"
+                                                data-field-display="estimatedTime"
+                                                th:attr="data-raw-value=${detailsEstimatedTime}"
+                                                th:text="${detailsEstimatedTime}">5m</dd>
+                                            <button type="button"
+                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    data-edit-field="estimatedTime">edit</button>
+                                        </div>
+                                    </div>
+                                    <div class="hidden mt-2" data-field-edit="estimatedTime">
+                                        <input type="text"
+                                               class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm px-3 py-2"
+                                               data-field-input="estimatedTime"
+                                               th:value="${detailsEstimatedTime}">
+                                        <div class="mt-1 flex items-center gap-2 flex-wrap">
+                                            <button type="button" class="px-3 py-1.5 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="estimatedTime">Save</button>
+                                            <button type="button" class="px-3 py-1.5 border border-white/15 text-white/60 text-xs hover:border-white/30 transition-colors" data-field-cancel="estimatedTime">Cancel</button>
+                                            <span class="hidden text-xs text-red-400" data-field-error="estimatedTime"></span>
+                                        </div>
+                                    </div>
                                 </div>
+
                             </dl>
                         </article>
 
+                        <!-- Timeline (read-only — system-managed fields) -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6">
                             <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Timeline</p>
                             <dl class="mt-4 space-y-3 text-sm">
@@ -171,8 +594,10 @@
                                 </div>
                             </dl>
                         </article>
+
                     </aside>
                 </section>
+
             </div>
         </main>
     </div>

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -78,7 +78,7 @@
                                                   th:text="${detailsStatus ?: '-'}">Draft</span>
                                 </span>
                                 <button type="button"
-                                        class="text-xs text-white/40 hover:text-[#E7FF02] transition-colors"
+                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                         data-edit-field="status"
                                         th:if="${!#strings.isEmpty(detailsStatus)}">edit</button>
 
@@ -88,7 +88,7 @@
                                                     th:text="${detailsPriority ?: '-'}">Medium</span>
                                 </span>
                                 <button type="button"
-                                        class="text-xs text-white/40 hover:text-[#E7FF02] transition-colors"
+                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                         data-edit-field="priority"
                                         th:if="${!#strings.isEmpty(detailsPriority)}">edit</button>
 
@@ -242,7 +242,7 @@
                                                     Step <span th:text="${step.stepNumber}">1</span>
                                                 </p>
                                                 <button type="button"
-                                                        class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                         th:attr="data-edit-field=${'step-' + step.stepNumber + '-stepSummary'}"
                                                         th:if="${!#strings.isEmpty(step.stepSummary)}">Edit action</button>
                                             </div>
@@ -278,7 +278,7 @@
                                                     <div class="flex items-center justify-between gap-2">
                                                         <p class="text-xs text-white/50">Test data</p>
                                                         <button type="button"
-                                                                class="text-xs text-white/40 hover:text-[#E7FF02] transition-colors"
+                                                                class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                                 th:attr="data-edit-field=${'step-' + step.stepNumber + '-testData'}">edit</button>
                                                     </div>
                                                     <div class="mt-1 text-sm text-white/80 leading-7 break-words"
@@ -306,7 +306,7 @@
                                                     <div class="flex items-center justify-between gap-2">
                                                         <p class="text-xs text-white/50">Expected result</p>
                                                         <button type="button"
-                                                                class="text-xs text-white/40 hover:text-[#E7FF02] transition-colors"
+                                                                class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                                 th:attr="data-edit-field=${'step-' + step.stepNumber + '-expectedResult'}"
                                                                 th:if="${!#strings.isEmpty(step.expectedResult)}">edit</button>
                                                     </div>
@@ -387,7 +387,7 @@
                                                 th:attr="data-raw-value=${detailsComponents}"
                                                 th:text="${detailsComponents}">HeadCoach, Device</dd>
                                             <button type="button"
-                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                     data-edit-field="components">edit</button>
                                         </div>
                                     </div>
@@ -414,7 +414,7 @@
                                                 th:attr="data-raw-value=${detailsTestCaseType}"
                                                 th:text="${detailsTestCaseType}">Functional</dd>
                                             <button type="button"
-                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                     data-edit-field="testCaseType">edit</button>
                                         </div>
                                     </div>
@@ -441,7 +441,7 @@
                                                 th:attr="data-raw-value=${detailsLabels}"
                                                 th:text="${detailsLabels}">training, assignment, mobile</dd>
                                             <button type="button"
-                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                     data-edit-field="labels">edit</button>
                                         </div>
                                     </div>
@@ -477,7 +477,7 @@
                                                 th:attr="data-raw-value=${detailsSprint}"
                                                 th:text="${detailsSprint}">Sprint 14</dd>
                                             <button type="button"
-                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                     data-edit-field="sprint">edit</button>
                                         </div>
                                     </div>
@@ -504,7 +504,7 @@
                                                 th:attr="data-raw-value=${detailsFixVersions}"
                                                 th:text="${detailsFixVersions}">v0.14.0</dd>
                                             <button type="button"
-                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                     data-edit-field="fixVersions">edit</button>
                                         </div>
                                     </div>
@@ -531,7 +531,7 @@
                                                 th:attr="data-raw-value=${detailsVersion}"
                                                 th:text="${detailsVersion}">2</dd>
                                             <button type="button"
-                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                     data-edit-field="version">edit</button>
                                         </div>
                                     </div>
@@ -558,7 +558,7 @@
                                                 th:attr="data-raw-value=${detailsEstimatedTime}"
                                                 th:text="${detailsEstimatedTime}">5m</dd>
                                             <button type="button"
-                                                    class="shrink-0 text-xs text-white/40 hover:text-[#E7FF02] transition-colors whitespace-nowrap"
+                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                                     data-edit-field="estimatedTime">edit</button>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -22,6 +22,8 @@
     </div>
 
     <div class="min-h-screen relative overflow-hidden" th:attr="data-work-key=${detailsCaseId}">
+        <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_85%_0%,rgba(255,255,255,0.08)_0%,rgba(255,255,255,0)_38%)]"></div>
+
         <header class="sticky top-0 z-20 border-b border-white/10 bg-[#1d1d1d]/95 backdrop-blur">
             <div class="w-full px-6 sm:px-8 py-4 flex items-center justify-between gap-3">
                 <div class="min-w-0">
@@ -47,15 +49,11 @@
 
                         <!-- Summary -->
                         <div class="min-w-0 flex-1">
-                            <div class="flex items-center gap-3">
-                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Summary</p>
-                                <button type="button"
-                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                        data-edit-field="summary"
-                                        th:if="${!#strings.isEmpty(detailsSummary)}">Edit</button>
-                            </div>
-                            <h2 class="mt-2 text-xl sm:text-2xl text-white/90 font-semibold leading-tight"
+                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Summary</p>
+                            <h2 class="mt-2 text-xl sm:text-2xl text-white/90 font-semibold leading-tight cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                 data-field-display="summary"
+                                data-dblclick-edit="true"
+                                title="Double-click to edit"
                                 th:attr="data-raw-value=${detailsSummary ?: ''}"
                                 th:text="${detailsSummary ?: 'No summary available'}">Validate drill assignment from session plan</h2>
                             <div class="hidden mt-3" data-field-edit="summary">
@@ -72,25 +70,29 @@
                         <!-- Status / Priority badges -->
                         <div class="shrink-0">
                             <div class="flex flex-wrap items-center gap-2">
-                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70">
+                                <button type="button"
+                                        class="px-3 py-1 border border-white/15 text-xs text-white/70 hover:border-white/40 transition-colors cursor-pointer"
+                                        data-edit-field="status"
+                                        th:if="${!#strings.isEmpty(detailsStatus)}"
+                                        title="Click to edit">
                                     Status: <span data-field-display="status"
                                                   th:attr="data-raw-value=${detailsStatus ?: ''}"
                                                   th:text="${detailsStatus ?: '-'}">Draft</span>
-                                </span>
-                                <button type="button"
-                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                        data-edit-field="status"
-                                        th:if="${!#strings.isEmpty(detailsStatus)}">edit</button>
+                                </button>
+                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70"
+                                      th:unless="${!#strings.isEmpty(detailsStatus)}">Status: -</span>
 
-                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70">
+                                <button type="button"
+                                        class="px-3 py-1 border border-white/15 text-xs text-white/70 hover:border-white/40 transition-colors cursor-pointer"
+                                        data-edit-field="priority"
+                                        th:if="${!#strings.isEmpty(detailsPriority)}"
+                                        title="Click to edit">
                                     Priority: <span data-field-display="priority"
                                                     th:attr="data-raw-value=${detailsPriority ?: ''}"
                                                     th:text="${detailsPriority ?: '-'}">Medium</span>
-                                </span>
-                                <button type="button"
-                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                        data-edit-field="priority"
-                                        th:if="${!#strings.isEmpty(detailsPriority)}">edit</button>
+                                </button>
+                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70"
+                                      th:unless="${!#strings.isEmpty(detailsPriority)}">Priority: -</span>
 
                                 <span class="px-3 py-1 border border-white/15 text-xs text-white/70">Steps: <span th:text="${detailsSteps != null ? #lists.size(detailsSteps) : 0}">0</span></span>
                             </div>
@@ -126,15 +128,11 @@
 
                     <!-- Folder context -->
                     <div class="mt-5 border border-white/10 bg-white/[0.03] p-4 sm:p-5">
-                        <div class="flex items-center justify-between gap-3">
-                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Folder context</p>
-                            <button type="button"
-                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                    data-edit-field="folder"
-                                    th:if="${!#strings.isEmpty(detailsFolder)}">Edit</button>
-                        </div>
+                        <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Folder context</p>
                         <div id="folderSegmentsContainer"
-                             class="mt-3 flex flex-wrap items-center gap-2 text-xs text-white/80"
+                             class="mt-3 flex flex-wrap items-center gap-2 text-xs text-white/80 cursor-pointer hover:opacity-80 transition-opacity"
+                             data-edit-field="folder"
+                             title="Click to edit"
                              th:if="${detailsFolderSegments != null and !#lists.isEmpty(detailsFolderSegments)}">
                             <th:block th:each="segment, stat : ${detailsFolderSegments}">
                                 <span class="px-2 py-1 border border-white/15 bg-black/20" th:text="${segment}">Device</span>
@@ -168,16 +166,13 @@
 
                         <!-- Description -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsDescription)}">
-                            <div class="flex items-center justify-between gap-3">
-                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Description</p>
-                                <button type="button"
-                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                        data-edit-field="description">Edit</button>
-                            </div>
-                            <div class="mt-3 text-sm leading-7 text-white/80 break-words"
+                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Description</p>
+                            <div class="mt-3 text-sm leading-7 text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                  data-md="true"
                                  data-field-display="description"
+                                 data-dblclick-edit="true"
                                  data-empty-label="Not provided"
+                                 title="Double-click to edit"
                                  th:attr="data-raw-value=${detailsDescription}"
                                  th:text="${detailsDescription}">Coach assigns a planned drill to a swimmer and verifies it appears in the daily training view with the correct configuration.</div>
                             <div class="hidden mt-3" data-field-edit="description">
@@ -193,16 +188,13 @@
 
                         <!-- Precondition -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsPrecondition)}">
-                            <div class="flex items-center justify-between gap-3">
-                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Precondition</p>
-                                <button type="button"
-                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                        data-edit-field="precondition">Edit</button>
-                            </div>
-                            <div class="mt-3 text-sm leading-7 text-white/80 break-words"
+                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Precondition</p>
+                            <div class="mt-3 text-sm leading-7 text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                  data-md="true"
                                  data-field-display="precondition"
+                                 data-dblclick-edit="true"
                                  data-empty-label="Not provided"
+                                 title="Double-click to edit"
                                  th:attr="data-raw-value=${detailsPrecondition}"
                                  th:text="${detailsPrecondition}">User is authenticated, swimmer profile exists, and the session plan has at least one unpublished drill.</div>
                             <div class="hidden mt-3" data-field-edit="precondition">
@@ -236,21 +228,17 @@
                                         <span class="absolute -left-[1.875rem] top-1.5 h-3 w-3 rounded-full border border-[#E7FF02] bg-[#202020]"></span>
                                         <div class="border border-white/10 bg-white/[0.03] p-4 sm:p-5">
 
-                                            <!-- Step label and step summary edit trigger -->
-                                            <div class="flex items-center justify-between gap-3">
-                                                <p class="text-xs uppercase tracking-wider text-white/55" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
-                                                    Step <span th:text="${step.stepNumber}">1</span>
-                                                </p>
-                                                <button type="button"
-                                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                        th:attr="data-edit-field=${'step-' + step.stepNumber + '-stepSummary'}"
-                                                        th:if="${!#strings.isEmpty(step.stepSummary)}">Edit action</button>
-                                            </div>
+                                            <!-- Step label -->
+                                            <p class="text-xs uppercase tracking-wider text-white/55" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
+                                                Step <span th:text="${step.stepNumber}">1</span>
+                                            </p>
 
                                             <!-- Step summary display -->
-                                            <div class="mt-2 text-sm text-white/85 leading-7 break-words"
+                                            <div class="mt-2 text-sm text-white/85 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                                  data-md="true"
+                                                 data-dblclick-edit="true"
                                                  data-empty-label="No step summary"
+                                                 title="Double-click to edit"
                                                  th:attr="data-field-display=${'step-' + step.stepNumber + '-stepSummary'}, data-raw-value=${step.stepSummary ?: ''}"
                                                  th:text="${step.stepSummary}">Open session plan and select the target swimmer.</div>
 
@@ -275,14 +263,11 @@
 
                                                 <!-- Test data -->
                                                 <div class="border border-white/10 bg-black/20 p-3" th:if="${!#strings.isEmpty(step.testData)}">
-                                                    <div class="flex items-center justify-between gap-2">
-                                                        <p class="text-xs text-white/50">Test data</p>
-                                                        <button type="button"
-                                                                class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                                th:attr="data-edit-field=${'step-' + step.stepNumber + '-testData'}">edit</button>
-                                                    </div>
-                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words"
+                                                    <p class="text-xs text-white/50">Test data</p>
+                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                                          data-md="true"
+                                                         data-dblclick-edit="true"
+                                                         title="Double-click to edit"
                                                          th:attr="data-field-display=${'step-' + step.stepNumber + '-testData'}, data-raw-value=${step.testData ?: ''}"
                                                          th:text="${step.testData}">Swimmer: Maya T. | Plan: Endurance - Week 4</div>
                                                     <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-testData'}">
@@ -303,16 +288,12 @@
 
                                                 <!-- Expected result -->
                                                 <div class="border border-white/10 bg-black/20 p-3">
-                                                    <div class="flex items-center justify-between gap-2">
-                                                        <p class="text-xs text-white/50">Expected result</p>
-                                                        <button type="button"
-                                                                class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                                th:attr="data-edit-field=${'step-' + step.stepNumber + '-expectedResult'}"
-                                                                th:if="${!#strings.isEmpty(step.expectedResult)}">edit</button>
-                                                    </div>
-                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words"
+                                                    <p class="text-xs text-white/50">Expected result</p>
+                                                    <div class="mt-1 text-sm text-white/80 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                                          data-md="true"
+                                                         data-dblclick-edit="true"
                                                          data-empty-label="No expected result"
+                                                         title="Double-click to edit"
                                                          th:attr="data-field-display=${'step-' + step.stepNumber + '-expectedResult'}, data-raw-value=${step.expectedResult ?: ''}"
                                                          th:text="${step.expectedResult}">Swimmer profile opens with the selected session plan visible.</div>
                                                     <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-expectedResult'}">
@@ -344,15 +325,12 @@
 
                         <!-- Story linkages -->
                         <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsStoryLinkages)}">
-                            <div class="flex items-center justify-between gap-3">
-                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Story linkage</p>
-                                <button type="button"
-                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                        data-edit-field="storyLinkages">Edit</button>
-                            </div>
-                            <div class="mt-3 text-sm text-white/80 break-words"
+                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Story linkage</p>
+                            <div class="mt-3 text-sm text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                  data-md="true"
                                  data-field-display="storyLinkages"
+                                 data-dblclick-edit="true"
+                                 title="Double-click to edit"
                                  th:attr="data-raw-value=${detailsStoryLinkages}"
                                  th:text="${detailsStoryLinkages}">https://tracker.example.com/story/TC-2481</div>
                             <div class="hidden mt-3" data-field-edit="storyLinkages">
@@ -381,15 +359,12 @@
                                 <div th:if="${!#strings.isEmpty(detailsComponents)}">
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Components</dt>
-                                        <div class="flex items-center gap-2 min-w-0">
-                                            <dd class="text-white/80 text-right break-all"
-                                                data-field-display="components"
-                                                th:attr="data-raw-value=${detailsComponents}"
-                                                th:text="${detailsComponents}">HeadCoach, Device</dd>
-                                            <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                    data-edit-field="components">edit</button>
-                                        </div>
+                                        <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
+                                            data-field-display="components"
+                                            data-edit-field="components"
+                                            title="Click to edit"
+                                            th:attr="data-raw-value=${detailsComponents}"
+                                            th:text="${detailsComponents}">HeadCoach, Device</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="components">
                                         <input type="text"
@@ -414,8 +389,8 @@
                                                 th:attr="data-raw-value=${detailsTestCaseType}"
                                                 th:text="${detailsTestCaseType}">Functional</dd>
                                             <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                    data-edit-field="testCaseType">edit</button>
+                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
+                                                    data-edit-field="testCaseType">Edit</button>
                                         </div>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="testCaseType">
@@ -441,8 +416,8 @@
                                                 th:attr="data-raw-value=${detailsLabels}"
                                                 th:text="${detailsLabels}">training, assignment, mobile</dd>
                                             <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                    data-edit-field="labels">edit</button>
+                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
+                                                    data-edit-field="labels">Edit</button>
                                         </div>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="labels">
@@ -477,8 +452,8 @@
                                                 th:attr="data-raw-value=${detailsSprint}"
                                                 th:text="${detailsSprint}">Sprint 14</dd>
                                             <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                    data-edit-field="sprint">edit</button>
+                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
+                                                    data-edit-field="sprint">Edit</button>
                                         </div>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="sprint">
@@ -504,8 +479,8 @@
                                                 th:attr="data-raw-value=${detailsFixVersions}"
                                                 th:text="${detailsFixVersions}">v0.14.0</dd>
                                             <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                    data-edit-field="fixVersions">edit</button>
+                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
+                                                    data-edit-field="fixVersions">Edit</button>
                                         </div>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="fixVersions">
@@ -531,8 +506,8 @@
                                                 th:attr="data-raw-value=${detailsVersion}"
                                                 th:text="${detailsVersion}">2</dd>
                                             <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                    data-edit-field="version">edit</button>
+                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
+                                                    data-edit-field="version">Edit</button>
                                         </div>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="version">
@@ -558,8 +533,8 @@
                                                 th:attr="data-raw-value=${detailsEstimatedTime}"
                                                 th:text="${detailsEstimatedTime}">5m</dd>
                                             <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
-                                                    data-edit-field="estimatedTime">edit</button>
+                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
+                                                    data-edit-field="estimatedTime">Edit</button>
                                         </div>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="estimatedTime">
@@ -588,7 +563,7 @@
                                 </div>
                                 <div class="flex items-start justify-between gap-4">
                                     <dt class="text-white/50">Updated on</dt>
-                                    <dd class="text-white/80 text-right" th:text="${detailsUpdatedOn ?: '-'}">2026-03-22 09:10</dd>
+                                    <dd class="text-white/80 text-right" id="detailsUpdatedOn" th:text="${detailsUpdatedOn ?: '-'}">2026-03-22 09:10</dd>
                                 </div>
                             </dl>
                         </article>

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -9,6 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;700;900&display=swap" rel="stylesheet">
     <meta name="_csrf" th:content="${_csrf.token}">
     <meta name="_csrf_header" th:content="${_csrf.headerName}">
+    <style>
+        textarea { scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.15) transparent; }
+        textarea::-webkit-scrollbar { width: 5px; }
+        textarea::-webkit-scrollbar-track { background: transparent; }
+        textarea::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 3px; }
+        textarea::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.28); }
+    </style>
 </head>
 
 <body class="bg-[#181818] text-white">
@@ -16,7 +23,10 @@
     <!-- Edit notice banner (shown/hidden by JS) -->
     <div id="detailsNotice" class="fixed top-0 inset-x-0 z-50 hidden border-b border-white/15 bg-[#1d1d1d]/98 backdrop-blur">
         <div class="px-6 sm:px-8 py-3 flex items-center justify-between gap-4">
-            <span id="detailsNoticeMsg" class="text-sm text-white/90"></span>
+            <div class="flex items-center gap-2.5 min-w-0">
+                <span id="detailsNoticeDot" class="shrink-0 h-1.5 w-1.5 rounded-full"></span>
+                <span id="detailsNoticeMsg" class="text-sm text-white/90"></span>
+            </div>
             <button type="button" id="detailsNoticeClose" class="shrink-0 text-white/50 hover:text-white text-xl leading-none">×</button>
         </div>
     </div>
@@ -60,7 +70,7 @@
                                 th:attr="data-raw-value=${detailsSummary ?: ''}"
                                 th:text="${detailsSummary ?: 'No summary available'}">Validate drill assignment from session plan</h2>
                             <div class="hidden mt-3" data-field-edit="summary">
-                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[4rem]"
+                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[4rem]"
                                           rows="3" data-field-textarea="summary" th:text="${detailsSummary ?: ''}"></textarea>
                                 <div class="mt-2 flex items-center gap-2 flex-wrap">
                                     <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="summary">Save</button>
@@ -184,7 +194,7 @@
                                  th:attr="data-raw-value=${detailsDescription}"
                                  th:text="${detailsDescription}">Coach assigns a planned drill to a swimmer and verifies it appears in the daily training view with the correct configuration.</div>
                             <div class="hidden mt-3" data-field-edit="description">
-                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[6rem]"
+                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[6rem]"
                                           rows="6" data-field-textarea="description" th:text="${detailsDescription}"></textarea>
                                 <div class="mt-2 flex items-center gap-2 flex-wrap">
                                     <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="description">Save</button>
@@ -195,8 +205,13 @@
                         </article>
 
                         <!-- Precondition -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsPrecondition)}">
-                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Precondition</p>
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative" th:if="${!#strings.isEmpty(detailsPrecondition)}">
+                            <div class="flex items-center justify-between">
+                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Precondition</p>
+                                <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                </span>
+                            </div>
                             <div class="mt-3 text-sm leading-7 text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                  data-md="true"
                                  data-field-display="precondition"
@@ -206,7 +221,7 @@
                                  th:attr="data-raw-value=${detailsPrecondition}"
                                  th:text="${detailsPrecondition}">User is authenticated, swimmer profile exists, and the session plan has at least one unpublished drill.</div>
                             <div class="hidden mt-3" data-field-edit="precondition">
-                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[4rem]"
+                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[4rem]"
                                           rows="4" data-field-textarea="precondition" th:text="${detailsPrecondition}"></textarea>
                                 <div class="mt-2 flex items-center gap-2 flex-wrap">
                                     <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="precondition">Save</button>
@@ -234,12 +249,17 @@
                                 <ol class="border-l border-white/15 pl-5 space-y-6">
                                     <li th:each="step : ${detailsSteps}" th:id="${'step-' + step.stepNumber}" class="relative">
                                         <span class="absolute -left-[1.875rem] top-1.5 h-3 w-3 rounded-full border border-[#E7FF02] bg-[#202020]"></span>
-                                        <div class="border border-white/10 bg-white/[0.03] p-4 sm:p-5">
+                                        <div class="border border-white/10 bg-white/[0.03] p-4 sm:p-5 group relative">
 
                                             <!-- Step label -->
-                                            <p class="text-xs uppercase tracking-wider text-white/55" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
-                                                Step <span th:text="${step.stepNumber}">1</span>
-                                            </p>
+                                            <div class="flex items-center justify-between">
+                                                <p class="text-xs uppercase tracking-wider text-white/55" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
+                                                    Step <span th:text="${step.stepNumber}">1</span>
+                                                </p>
+                                                <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                                </span>
+                                            </div>
 
                                             <!-- Step summary display -->
                                             <div class="mt-2 text-sm text-white/85 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
@@ -252,7 +272,7 @@
 
                                             <!-- Step summary edit form -->
                                             <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-stepSummary'}">
-                                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[3rem]"
+                                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
                                                           rows="3"
                                                           th:attr="data-field-textarea=${'step-' + step.stepNumber + '-stepSummary'}"
                                                           th:text="${step.stepSummary}"></textarea>
@@ -270,8 +290,13 @@
                                             <div class="mt-4 grid grid-cols-1 gap-3" th:classappend="${!#strings.isEmpty(step.testData)} ? ' sm:grid-cols-2' : ''">
 
                                                 <!-- Test data -->
-                                                <div class="border border-white/10 bg-black/20 p-3" th:if="${!#strings.isEmpty(step.testData)}">
-                                                    <p class="text-xs text-white/50">Test data</p>
+                                                <div class="border border-white/10 bg-black/20 p-3 group/sub relative" th:if="${!#strings.isEmpty(step.testData)}">
+                                                    <div class="flex items-center justify-between">
+                                                        <p class="text-xs text-white/50">Test data</p>
+                                                        <span class="opacity-0 group-hover/sub:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                                        </span>
+                                                    </div>
                                                     <div class="mt-1 text-sm text-white/80 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                                          data-md="true"
                                                          data-dblclick-edit="true"
@@ -279,7 +304,7 @@
                                                          th:attr="data-field-display=${'step-' + step.stepNumber + '-testData'}, data-raw-value=${step.testData ?: ''}"
                                                          th:text="${step.testData}">Swimmer: Maya T. | Plan: Endurance - Week 4</div>
                                                     <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-testData'}">
-                                                        <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-y min-h-[3rem]"
+                                                        <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
                                                                   rows="3"
                                                                   th:attr="data-field-textarea=${'step-' + step.stepNumber + '-testData'}"
                                                                   th:text="${step.testData}"></textarea>
@@ -295,8 +320,13 @@
                                                 </div>
 
                                                 <!-- Expected result -->
-                                                <div class="border border-white/10 bg-black/20 p-3">
-                                                    <p class="text-xs text-white/50">Expected result</p>
+                                                <div class="border border-white/10 bg-black/20 p-3 group/sub relative">
+                                                    <div class="flex items-center justify-between">
+                                                        <p class="text-xs text-white/50">Expected result</p>
+                                                        <span class="opacity-0 group-hover/sub:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                                        </span>
+                                                    </div>
                                                     <div class="mt-1 text-sm text-white/80 leading-7 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                                          data-md="true"
                                                          data-dblclick-edit="true"
@@ -305,7 +335,7 @@
                                                          th:attr="data-field-display=${'step-' + step.stepNumber + '-expectedResult'}, data-raw-value=${step.expectedResult ?: ''}"
                                                          th:text="${step.expectedResult}">Swimmer profile opens with the selected session plan visible.</div>
                                                     <div class="hidden mt-2" th:attr="data-field-edit=${'step-' + step.stepNumber + '-expectedResult'}">
-                                                        <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-y min-h-[3rem]"
+                                                        <textarea class="w-full bg-black/30 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-2 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
                                                                   rows="3"
                                                                   th:attr="data-field-textarea=${'step-' + step.stepNumber + '-expectedResult'}"
                                                                   th:text="${step.expectedResult}"></textarea>
@@ -332,8 +362,13 @@
                         </article>
 
                         <!-- Story linkages -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6" th:if="${!#strings.isEmpty(detailsStoryLinkages)}">
-                            <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Story linkage</p>
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative" th:if="${!#strings.isEmpty(detailsStoryLinkages)}">
+                            <div class="flex items-center justify-between">
+                                <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Story linkage</p>
+                                <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/></svg>
+                                </span>
+                            </div>
                             <div class="mt-3 text-sm text-white/80 break-words cursor-text hover:bg-white/[0.03] rounded transition-colors"
                                  data-md="true"
                                  data-field-display="storyLinkages"
@@ -342,7 +377,7 @@
                                  th:attr="data-raw-value=${detailsStoryLinkages}"
                                  th:text="${detailsStoryLinkages}">https://tracker.example.com/story/TC-2481</div>
                             <div class="hidden mt-3" data-field-edit="storyLinkages">
-                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-y min-h-[3rem]"
+                                <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
                                           rows="3" data-field-textarea="storyLinkages" th:text="${detailsStoryLinkages}"></textarea>
                                 <div class="mt-2 flex items-center gap-2 flex-wrap">
                                     <button type="button" class="px-4 py-2 bg-[#E7FF02] text-black text-xs font-semibold hover:bg-[#f3ff7a] transition-colors" data-field-save="storyLinkages">Save</button>

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -50,7 +50,7 @@
                             <div class="flex items-center gap-3">
                                 <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Summary</p>
                                 <button type="button"
-                                        class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                         data-edit-field="summary"
                                         th:if="${!#strings.isEmpty(detailsSummary)}">Edit</button>
                             </div>
@@ -129,7 +129,7 @@
                         <div class="flex items-center justify-between gap-3">
                             <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Folder context</p>
                             <button type="button"
-                                    class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                    class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                     data-edit-field="folder"
                                     th:if="${!#strings.isEmpty(detailsFolder)}">Edit</button>
                         </div>
@@ -171,7 +171,7 @@
                             <div class="flex items-center justify-between gap-3">
                                 <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Description</p>
                                 <button type="button"
-                                        class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                         data-edit-field="description">Edit</button>
                             </div>
                             <div class="mt-3 text-sm leading-7 text-white/80 break-words"
@@ -196,7 +196,7 @@
                             <div class="flex items-center justify-between gap-3">
                                 <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Precondition</p>
                                 <button type="button"
-                                        class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                         data-edit-field="precondition">Edit</button>
                             </div>
                             <div class="mt-3 text-sm leading-7 text-white/80 break-words"
@@ -347,7 +347,7 @@
                             <div class="flex items-center justify-between gap-3">
                                 <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Story linkage</p>
                                 <button type="button"
-                                        class="shrink-0 text-xs text-white/45 hover:text-[#E7FF02] border border-white/15 hover:border-[#E7FF02] px-2 py-0.5 transition-colors"
+                                        class="shrink-0 px-2 py-0.5 border border-[#E7FF02]/50 text-white/70 text-xs hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors whitespace-nowrap"
                                         data-edit-field="storyLinkages">Edit</button>
                             </div>
                             <div class="mt-3 text-sm text-white/80 break-words"

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -383,15 +383,12 @@
                                 <div th:if="${!#strings.isEmpty(detailsTestCaseType)}">
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Test case type</dt>
-                                        <div class="flex items-center gap-2 min-w-0">
-                                            <dd class="text-white/80 text-right break-all"
-                                                data-field-display="testCaseType"
-                                                th:attr="data-raw-value=${detailsTestCaseType}"
-                                                th:text="${detailsTestCaseType}">Functional</dd>
-                                            <button type="button"
-                                                    class="shrink-0 px-2 py-0.5 border border-white/20 text-white/60 text-xs hover:border-white/50 hover:text-white transition-colors whitespace-nowrap"
-                                                    data-edit-field="testCaseType">Edit</button>
-                                        </div>
+                                        <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
+                                            data-field-display="testCaseType"
+                                            data-edit-field="testCaseType"
+                                            title="Click to edit"
+                                            th:attr="data-raw-value=${detailsTestCaseType}"
+                                            th:text="${detailsTestCaseType}">Functional</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="testCaseType">
                                         <input type="text"

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
@@ -185,6 +185,69 @@ class WorkspaceTestCaseDetailsIntegrationTests {
     }
 
     @Test
+    void singleCaseEditOverwritesFolderValue() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "Checkout/Payments");
+        payload.put("replaceText", "Checkout/Payments/Refunds");
+        payload.put("fields", List.of("folder"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1))
+            .andExpect(jsonPath("$.totalReplacements").value(1));
+
+        TestCase updated = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101").orElseThrow();
+        assertThat(updated.getFolder()).isEqualTo("Checkout/Payments/Refunds");
+        assertThat(updated.getUpdatedOn()).matches("\\d{2}/[A-Z][a-z]{2}/\\d{4} \\d{2}:\\d{2}");
+    }
+
+    @Test
+    void singleCaseEditFolderToRootLevelValue() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "Checkout/Payments");
+        payload.put("replaceText", "Checkout");
+        payload.put("fields", List.of("folder"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1));
+
+        TestCase updated = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101").orElseThrow();
+        assertThat(updated.getFolder()).isEqualTo("Checkout");
+    }
+
+    @Test
+    void singleCaseEditFolderCrossTeamIsRejected() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-201"));
+        payload.put("findText", "OtherTeam/Auth");
+        payload.put("replaceText", "Stolen/Folder");
+        payload.put("fields", List.of("folder"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.forbiddenCount").value(1))
+            .andExpect(jsonPath("$.updatedCaseCount").value(0));
+
+        TestCase unchanged = testCaseRepository.findByTeamKeyAndWorkKey("TEAM2", "TC-201").orElseThrow();
+        assertThat(unchanged.getFolder()).isEqualTo("OtherTeam/Auth");
+    }
+
+    @Test
     void singleCaseEditOverwritesStepFieldValue() throws Exception {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("workKeys", List.of("TC-101"));

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
@@ -143,7 +143,7 @@ class WorkspaceTestCaseDetailsIntegrationTests {
         assertThat(updated.getPrecondition()).isEqualTo("User has valid cart");
         assertThat(updated.getUpdatedOn()).isNotNull();
         assertThat(updated.getUpdatedOn()).isNotEqualTo("2026-03-02");
-        assertThat(updated.getUpdatedOn()).matches("\\d{2}/[A-Z][a-z]{2}/\\d{4} \\d{2}:\\d{2}");
+        assertThat(updated.getUpdatedOn()).matches("\\d{4}-\\d{2}-\\d{2}");
     }
 
     @Test
@@ -203,7 +203,7 @@ class WorkspaceTestCaseDetailsIntegrationTests {
 
         TestCase updated = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101").orElseThrow();
         assertThat(updated.getFolder()).isEqualTo("Checkout/Payments/Refunds");
-        assertThat(updated.getUpdatedOn()).matches("\\d{2}/[A-Z][a-z]{2}/\\d{4} \\d{2}:\\d{2}");
+        assertThat(updated.getUpdatedOn()).matches("\\d{4}-\\d{2}-\\d{2}");
     }
 
     @Test

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
@@ -1,24 +1,32 @@
 package com.formswim.teststream.workspace;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.formswim.teststream.auth.model.AppUser;
 import com.formswim.teststream.auth.repository.UserRepository;
 import com.formswim.teststream.shared.domain.TestCase;
@@ -33,6 +41,9 @@ class WorkspaceTestCaseDetailsIntegrationTests {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private TestCaseRepository testCaseRepository;
@@ -107,5 +118,88 @@ class WorkspaceTestCaseDetailsIntegrationTests {
                 .with(user("team1.user@example.com").roles("USER")))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/workspace?importError=Test+case+not+found"));
+    }
+
+    @Test
+    void singleCaseEditOverwritesFullFieldValue() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "Checkout flow summary");
+        payload.put("replaceText", "Updated checkout flow summary");
+        payload.put("fields", List.of("summary"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1))
+            .andExpect(jsonPath("$.totalReplacements").value(1));
+
+        TestCase updated = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-101").orElseThrow();
+        assertThat(updated.getSummary()).isEqualTo("Updated checkout flow summary");
+        assertThat(updated.getDescription()).isEqualTo("Detailed checkout description");
+        assertThat(updated.getPrecondition()).isEqualTo("User has valid cart");
+    }
+
+    @Test
+    void singleCaseEditCrossTeamCaseIsReportedAsForbidden() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-201"));
+        payload.put("findText", "Summary TC-201");
+        payload.put("replaceText", "Attempted overwrite");
+        payload.put("fields", List.of("summary"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.forbiddenCount").value(1))
+            .andExpect(jsonPath("$.updatedCaseCount").value(0))
+            .andExpect(jsonPath("$.totalReplacements").value(0));
+
+        TestCase unchanged = testCaseRepository.findByTeamKeyAndWorkKey("TEAM2", "TC-201").orElseThrow();
+        assertThat(unchanged.getSummary()).isEqualTo("Summary TC-201");
+    }
+
+    @Test
+    void singleCaseEditRequiresAuthentication() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "Checkout flow summary");
+        payload.put("replaceText", "New value");
+        payload.put("fields", List.of("summary"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("unknown.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void singleCaseEditOverwritesStepFieldValue() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-101"));
+        payload.put("findText", "Open checkout page");
+        payload.put("replaceText", "Navigate to checkout");
+        payload.put("fields", List.of("stepSummary"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedStepCount").value(1))
+            .andExpect(jsonPath("$.totalReplacements").value(1));
+
+        TestCase updated = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn("TEAM1", List.of("TC-101")).get(0);
+        assertThat(updated.getSteps().get(0).getStepSummary()).isEqualTo("Navigate to checkout");
+        assertThat(updated.getSummary()).isEqualTo("Checkout flow summary");
     }
 }

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
@@ -141,6 +141,9 @@ class WorkspaceTestCaseDetailsIntegrationTests {
         assertThat(updated.getSummary()).isEqualTo("Updated checkout flow summary");
         assertThat(updated.getDescription()).isEqualTo("Detailed checkout description");
         assertThat(updated.getPrecondition()).isEqualTo("User has valid cart");
+        assertThat(updated.getUpdatedOn()).isNotNull();
+        assertThat(updated.getUpdatedOn()).isNotEqualTo("2026-03-02");
+        assertThat(updated.getUpdatedOn()).matches("\\d{2}/[A-Z][a-z]{2}/\\d{4} \\d{2}:\\d{2}");
     }
 
     @Test


### PR DESCRIPTION
- [x] Fix `updatedOn` auto-stamp in `TestCaseBulkEditService` to use `updatedOnValue` (`LocalDate.now().toString()`, e.g. `"2026-04-05"`) instead of `LocalDateTime.now().format(UPDATED_ON_FORMAT)` which produced `"dd/MMM/yyyy HH:mm"` format
- [x] Remove unused `UPDATED_ON_FORMAT` constant, `LocalDateTime`, and `DateTimeFormatter` imports
- [x] All 19 `BulkEditIntegrationTests` pass