### PR TITLE
Allow empty detail fields via bulk edit

### DIFF
--- a/src/main/java/com/formswim/teststream/bulk/controllers/BulkMutationController.java
+++ b/src/main/java/com/formswim/teststream/bulk/controllers/BulkMutationController.java
@@ -1,6 +1,7 @@
 package com.formswim.teststream.bulk.controllers;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -116,10 +117,19 @@ public class BulkMutationController {
         String normalizedStatusValue = normalizeTrimmed(request.getStatusValue());
         request.setFindText(normalizedFindText);
         request.setStatusValue(normalizedStatusValue);
+        request.setFieldValues(request.getFieldValues().entrySet().stream()
+            .filter(entry -> entry.getKey() != null)
+            .collect(Collectors.toMap(
+                entry -> entry.getKey().trim(),
+                entry -> entry.getValue() == null ? "" : entry.getValue(),
+                (left, right) -> right,
+                java.util.LinkedHashMap::new
+            )));
 
         boolean hasTextOperation = !normalizedFindText.isBlank();
         boolean hasStatusOperation = !normalizedStatusValue.isBlank();
-        if (!hasTextOperation && !hasStatusOperation) {
+        boolean hasDirectSetOperation = !request.getFieldValues().isEmpty();
+        if (!hasTextOperation && !hasStatusOperation && !hasDirectSetOperation) {
             return ResponseEntity.badRequest().build();
         }
 

--- a/src/main/java/com/formswim/teststream/bulk/dto/BulkEditRequest.java
+++ b/src/main/java/com/formswim/teststream/bulk/dto/BulkEditRequest.java
@@ -3,7 +3,9 @@ package com.formswim.teststream.bulk.dto;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Request payload for PATCH /api/testcases/bulk-edit.
@@ -26,6 +28,8 @@ public class BulkEditRequest {
     private Boolean caseSensitive;
 
     private String statusValue;
+
+    private Map<String, String> fieldValues = new LinkedHashMap<>();
 
     /**
      * Returns requested work keys as a non-null list.
@@ -103,5 +107,19 @@ public class BulkEditRequest {
 
     public void setStatusValue(String statusValue) {
         this.statusValue = statusValue;
+    }
+
+    /**
+     * Optional direct-assignment values keyed by canonical field names.
+     */
+    public Map<String, String> getFieldValues() {
+        if (fieldValues == null) {
+            fieldValues = new LinkedHashMap<>();
+        }
+        return fieldValues;
+    }
+
+    public void setFieldValues(Map<String, String> fieldValues) {
+        this.fieldValues = fieldValues == null ? new LinkedHashMap<>() : new LinkedHashMap<>(fieldValues);
     }
 }

--- a/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
+++ b/src/main/java/com/formswim/teststream/bulk/service/TestCaseBulkEditService.java
@@ -12,11 +12,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 @Service
@@ -57,6 +59,22 @@ public class TestCaseBulkEditService {
         "stepSummary",
         "testData",
         "expectedResult"
+    );
+
+    private static final Set<String> DIRECT_ASSIGNABLE_FIELDS = Set.of(
+        "summary",
+        "description",
+        "precondition",
+        "priority",
+        "components",
+        "sprint",
+        "fixVersions",
+        "version",
+        "folder",
+        "testCaseType",
+        "labels",
+        "estimatedTime",
+        "storyLinkages"
     );
 
     private static final Map<String, String> FIELD_ALIASES = Map.ofEntries(
@@ -150,6 +168,7 @@ public class TestCaseBulkEditService {
         String requestedStatusValue = normalizeStatusValue(request.getStatusValue());
         boolean hasTextOperation = findText != null && !findText.isEmpty();
         Set<String> requestedFields = hasTextOperation ? resolveRequestedFields(request.getFields()) : Set.of();
+        Map<String, String> directFieldAssignments = resolveDirectFieldAssignments(request.getFieldValues());
 
         List<String> normalizedWorkKeys = new ArrayList<>(normalizedUniqueWorkKeys);
         Set<String> ownedWorkKeys = new HashSet<>(testCaseRepository.findOwnedWorkKeysIn(teamKey, normalizedWorkKeys));
@@ -186,26 +205,33 @@ public class TestCaseBulkEditService {
 
         for (TestCase testCase : cases) {
             boolean caseChanged = false;
-            boolean stepChanged = false;
 
+            String originalSummary = testCase.getSummary();
             ReplaceOutcome summaryOutcome = updateIfRequested(requestedFields.contains("summary"), testCase.getSummary(), findText, replaceText, caseSensitive);
-            testCase.setSummary(summaryOutcome.updatedValue());
-            caseChanged = caseChanged || summaryOutcome.changed();
+            String summaryValue = applyDirectAssignment("summary", summaryOutcome.updatedValue(), directFieldAssignments);
+            testCase.setSummary(summaryValue);
+            caseChanged = caseChanged || summaryOutcome.changed() || !equalsValue(originalSummary, summaryValue);
             totalReplacements += summaryOutcome.replacementCount();
 
+            String originalDescription = testCase.getDescription();
             ReplaceOutcome descriptionOutcome = updateIfRequested(requestedFields.contains("description"), testCase.getDescription(), findText, replaceText, caseSensitive);
-            testCase.setDescription(descriptionOutcome.updatedValue());
-            caseChanged = caseChanged || descriptionOutcome.changed();
+            String descriptionValue = applyDirectAssignment("description", descriptionOutcome.updatedValue(), directFieldAssignments);
+            testCase.setDescription(descriptionValue);
+            caseChanged = caseChanged || descriptionOutcome.changed() || !equalsValue(originalDescription, descriptionValue);
             totalReplacements += descriptionOutcome.replacementCount();
 
+            String originalPrecondition = testCase.getPrecondition();
             ReplaceOutcome preconditionOutcome = updateIfRequested(requestedFields.contains("precondition"), testCase.getPrecondition(), findText, replaceText, caseSensitive);
-            testCase.setPrecondition(preconditionOutcome.updatedValue());
-            caseChanged = caseChanged || preconditionOutcome.changed();
+            String preconditionValue = applyDirectAssignment("precondition", preconditionOutcome.updatedValue(), directFieldAssignments);
+            testCase.setPrecondition(preconditionValue);
+            caseChanged = caseChanged || preconditionOutcome.changed() || !equalsValue(originalPrecondition, preconditionValue);
             totalReplacements += preconditionOutcome.replacementCount();
 
+            String originalPriority = testCase.getPriority();
             ReplaceOutcome priorityOutcome = updateIfRequested(requestedFields.contains("priority"), testCase.getPriority(), findText, replaceText, caseSensitive);
-            testCase.setPriority(priorityOutcome.updatedValue());
-            caseChanged = caseChanged || priorityOutcome.changed();
+            String priorityValue = applyDirectAssignment("priority", priorityOutcome.updatedValue(), directFieldAssignments);
+            testCase.setPriority(priorityValue);
+            caseChanged = caseChanged || priorityOutcome.changed() || !equalsValue(originalPriority, priorityValue);
             totalReplacements += priorityOutcome.replacementCount();
 
             ReplaceOutcome assigneeOutcome = updateIfRequested(requestedFields.contains("assignee"), testCase.getAssignee(), findText, replaceText, caseSensitive);
@@ -218,47 +244,64 @@ public class TestCaseBulkEditService {
             caseChanged = caseChanged || reporterOutcome.changed();
             totalReplacements += reporterOutcome.replacementCount();
 
+            String originalEstimatedTime = testCase.getEstimatedTime();
             ReplaceOutcome estimatedTimeOutcome = updateIfRequested(requestedFields.contains("estimatedTime"), testCase.getEstimatedTime(), findText, replaceText, caseSensitive);
-            testCase.setEstimatedTime(estimatedTimeOutcome.updatedValue());
-            caseChanged = caseChanged || estimatedTimeOutcome.changed();
+            String estimatedTimeValue = applyDirectAssignment("estimatedTime", estimatedTimeOutcome.updatedValue(), directFieldAssignments);
+            testCase.setEstimatedTime(estimatedTimeValue);
+            caseChanged = caseChanged || estimatedTimeOutcome.changed() || !equalsValue(originalEstimatedTime, estimatedTimeValue);
             totalReplacements += estimatedTimeOutcome.replacementCount();
 
+            String originalLabels = testCase.getLabels();
             ReplaceOutcome labelsOutcome = updateIfRequested(requestedFields.contains("labels"), testCase.getLabels(), findText, replaceText, caseSensitive);
-            testCase.setLabels(labelsOutcome.updatedValue());
-            caseChanged = caseChanged || labelsOutcome.changed();
+            String labelsValue = applyDirectAssignment("labels", labelsOutcome.updatedValue(), directFieldAssignments);
+            testCase.setLabels(labelsValue);
+            caseChanged = caseChanged || labelsOutcome.changed() || !equalsValue(originalLabels, labelsValue);
             totalReplacements += labelsOutcome.replacementCount();
 
+            String originalComponents = testCase.getComponents();
             ReplaceOutcome componentsOutcome = updateIfRequested(requestedFields.contains("components"), testCase.getComponents(), findText, replaceText, caseSensitive);
-            testCase.setComponents(componentsOutcome.updatedValue());
-            caseChanged = caseChanged || componentsOutcome.changed();
+            String componentsValue = applyDirectAssignment("components", componentsOutcome.updatedValue(), directFieldAssignments);
+            testCase.setComponents(componentsValue);
+            caseChanged = caseChanged || componentsOutcome.changed() || !equalsValue(originalComponents, componentsValue);
             totalReplacements += componentsOutcome.replacementCount();
 
+            String originalSprint = testCase.getSprint();
             ReplaceOutcome sprintOutcome = updateIfRequested(requestedFields.contains("sprint"), testCase.getSprint(), findText, replaceText, caseSensitive);
-            testCase.setSprint(sprintOutcome.updatedValue());
-            caseChanged = caseChanged || sprintOutcome.changed();
+            String sprintValue = applyDirectAssignment("sprint", sprintOutcome.updatedValue(), directFieldAssignments);
+            testCase.setSprint(sprintValue);
+            caseChanged = caseChanged || sprintOutcome.changed() || !equalsValue(originalSprint, sprintValue);
             totalReplacements += sprintOutcome.replacementCount();
 
+            String originalFixVersions = testCase.getFixVersions();
             ReplaceOutcome fixVersionsOutcome = updateIfRequested(requestedFields.contains("fixVersions"), testCase.getFixVersions(), findText, replaceText, caseSensitive);
-            testCase.setFixVersions(fixVersionsOutcome.updatedValue());
-            caseChanged = caseChanged || fixVersionsOutcome.changed();
+            String fixVersionsValue = applyDirectAssignment("fixVersions", fixVersionsOutcome.updatedValue(), directFieldAssignments);
+            testCase.setFixVersions(fixVersionsValue);
+            caseChanged = caseChanged || fixVersionsOutcome.changed() || !equalsValue(originalFixVersions, fixVersionsValue);
             totalReplacements += fixVersionsOutcome.replacementCount();
 
+            String originalVersion = testCase.getVersion();
             ReplaceOutcome versionOutcome = updateIfRequested(requestedFields.contains("version"), testCase.getVersion(), findText, replaceText, caseSensitive);
-            testCase.setVersion(versionOutcome.updatedValue());
-            caseChanged = caseChanged || versionOutcome.changed();
+            String versionValue = applyDirectAssignment("version", versionOutcome.updatedValue(), directFieldAssignments);
+            testCase.setVersion(versionValue);
+            caseChanged = caseChanged || versionOutcome.changed() || !equalsValue(originalVersion, versionValue);
             totalReplacements += versionOutcome.replacementCount();
 
             ReplaceOutcome folderOutcome = updateIfRequested(requestedFields.contains("folder"), testCase.getFolder(), findText, replaceText, caseSensitive);
-            testCase.setFolder(folderOutcome.updatedValue());
-            caseChanged = caseChanged || folderOutcome.changed();
+            String originalFolder = testCase.getFolder();
+            String folderValue = applyDirectAssignment("folder", folderOutcome.updatedValue(), directFieldAssignments);
+            testCase.setFolder(folderValue);
+            boolean folderChanged = !equalsValue(originalFolder, folderValue);
+            caseChanged = caseChanged || folderOutcome.changed() || folderChanged;
             totalReplacements += folderOutcome.replacementCount();
-            if (folderOutcome.changed() && folderOutcome.updatedValue() != null && !folderOutcome.updatedValue().isBlank()) {
-                syncedFolders.add(folderOutcome.updatedValue());
+            if (folderChanged && folderValue != null && !folderValue.isBlank()) {
+                syncedFolders.add(folderValue);
             }
 
+            String originalTestCaseType = testCase.getTestCaseType();
             ReplaceOutcome testCaseTypeOutcome = updateIfRequested(requestedFields.contains("testCaseType"), testCase.getTestCaseType(), findText, replaceText, caseSensitive);
-            testCase.setTestCaseType(testCaseTypeOutcome.updatedValue());
-            caseChanged = caseChanged || testCaseTypeOutcome.changed();
+            String testCaseTypeValue = applyDirectAssignment("testCaseType", testCaseTypeOutcome.updatedValue(), directFieldAssignments);
+            testCase.setTestCaseType(testCaseTypeValue);
+            caseChanged = caseChanged || testCaseTypeOutcome.changed() || !equalsValue(originalTestCaseType, testCaseTypeValue);
             totalReplacements += testCaseTypeOutcome.replacementCount();
 
             ReplaceOutcome createdByOutcome = updateIfRequested(requestedFields.contains("createdBy"), testCase.getCreatedBy(), findText, replaceText, caseSensitive);
@@ -276,9 +319,11 @@ public class TestCaseBulkEditService {
             caseChanged = caseChanged || updatedByOutcome.changed();
             totalReplacements += updatedByOutcome.replacementCount();
 
+            String originalStoryLinkages = testCase.getStoryLinkages();
             ReplaceOutcome storyLinkagesOutcome = updateIfRequested(requestedFields.contains("storyLinkages"), testCase.getStoryLinkages(), findText, replaceText, caseSensitive);
-            testCase.setStoryLinkages(storyLinkagesOutcome.updatedValue());
-            caseChanged = caseChanged || storyLinkagesOutcome.changed();
+            String storyLinkagesValue = applyDirectAssignment("storyLinkages", storyLinkagesOutcome.updatedValue(), directFieldAssignments);
+            testCase.setStoryLinkages(storyLinkagesValue);
+            caseChanged = caseChanged || storyLinkagesOutcome.changed() || !equalsValue(originalStoryLinkages, storyLinkagesValue);
             totalReplacements += storyLinkagesOutcome.replacementCount();
 
             ReplaceOutcome isSharableStepOutcome = updateIfRequested(requestedFields.contains("isSharableStep"), testCase.getIsSharableStep(), findText, replaceText, caseSensitive);
@@ -458,6 +503,49 @@ public class TestCaseBulkEditService {
         }
 
         return trimmed;
+    }
+
+    private Map<String, String> resolveDirectFieldAssignments(Map<String, String> rawFieldValues) {
+        if (rawFieldValues == null || rawFieldValues.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> resolved = new java.util.LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : rawFieldValues.entrySet()) {
+            String rawField = entry.getKey();
+            if (rawField == null) {
+                continue;
+            }
+
+            String normalized = rawField.trim();
+            if (normalized.isEmpty()) {
+                continue;
+            }
+
+            String canonicalField = toCanonicalField(normalized);
+            if (canonicalField == null || !DIRECT_ASSIGNABLE_FIELDS.contains(canonicalField)) {
+                throw new IllegalArgumentException("Unsupported direct field: " + normalized);
+            }
+
+            resolved.put(canonicalField, entry.getValue());
+        }
+
+        if (resolved.isEmpty()) {
+            throw new IllegalArgumentException("At least one valid direct field is required");
+        }
+
+        return resolved;
+    }
+
+    private String applyDirectAssignment(String fieldKey, String currentValue, Map<String, String> directFieldAssignments) {
+        if (!directFieldAssignments.containsKey(fieldKey)) {
+            return currentValue;
+        }
+        return directFieldAssignments.get(fieldKey);
+    }
+
+    private boolean equalsValue(String left, String right) {
+        return Objects.equals(left, right);
     }
 
     /**

--- a/src/main/resources/static/js/workspace/test-case-details.js
+++ b/src/main/resources/static/js/workspace/test-case-details.js
@@ -206,6 +206,10 @@ function getApiFieldKey(fieldKey) {
     return stepMatch ? stepMatch[1] : fieldKey;
 }
 
+function isStepField(fieldKey) {
+    return /^step-\d+-/.test(fieldKey);
+}
+
 function showNotice(type, message) {
     const notice = document.getElementById('detailsNotice');
     const msg = document.getElementById('detailsNoticeMsg');
@@ -252,18 +256,27 @@ function flashFieldSaved(fieldKey) {
 async function saveFieldEdit(workKey, fieldKey, oldValue, newValue) {
     const csrf = getCsrf();
     const apiField = getApiFieldKey(fieldKey);
+    const payload = {
+        workKeys: [workKey]
+    };
+
+    if (fieldKey === 'status') {
+        payload.statusValue = newValue;
+    } else if (oldValue.trim() || isStepField(fieldKey)) {
+        payload.findText = oldValue;
+        payload.replaceText = newValue;
+        payload.fields = [apiField];
+    } else {
+        payload.fieldValues = { [apiField]: newValue };
+    }
+
     const response = await fetch('/api/testcases/bulk-edit', {
         method: 'PATCH',
         headers: {
             'Content-Type': 'application/json',
             [csrf.headerName]: csrf.token
         },
-        body: JSON.stringify({
-            workKeys: [workKey],
-            findText: oldValue,
-            replaceText: newValue,
-            fields: [apiField]
-        })
+        body: JSON.stringify(payload)
     });
     if (!response.ok) {
         const err = new Error('Edit failed with status ' + response.status);
@@ -289,13 +302,22 @@ function updateUpdatedOn() {
 
 function updateFolderSegments(newFolderPath) {
     const container = document.getElementById('folderSegmentsContainer');
+    const displayEl = document.querySelector('[data-field-display="folder"]');
     if (!container) {
         return;
     }
     const segments = String(newFolderPath || '').split('/').map((s) => s.trim()).filter(Boolean);
     if (segments.length === 0) {
         container.innerHTML = '';
+        container.classList.add('hidden');
+        if (displayEl) {
+            displayEl.classList.remove('sr-only');
+        }
         return;
+    }
+    container.classList.remove('hidden');
+    if (displayEl) {
+        displayEl.classList.add('sr-only');
     }
     container.innerHTML = segments.map((segment, index) => {
         const sep = index < segments.length - 1
@@ -315,7 +337,7 @@ function applyDisplayUpdate(fieldKey, newValue) {
         const emptyLabel = displayEl.dataset.emptyLabel || 'Not provided';
         displayEl.innerHTML = renderMarkdown(newValue, emptyLabel);
     } else {
-        displayEl.textContent = newValue;
+        displayEl.textContent = newValue || displayEl.dataset.emptyLabel || '-';
     }
     if (fieldKey === 'folder') {
         updateFolderSegments(newValue);
@@ -377,7 +399,7 @@ function getEditErrorMessage(error) {
         return 'You do not have permission to edit this test case.';
     }
     if (status === 400) {
-        return 'The current value may have changed. Refresh and try again.';
+        return 'This edit was not accepted. Check the value and try again.';
     }
     return 'Edit failed. Please try again.';
 }
@@ -420,14 +442,6 @@ function initFieldEditing() {
                 return;
             }
 
-            if (!oldValue.trim()) {
-                if (errorEl) {
-                    errorEl.textContent = 'Empty fields cannot be edited here. Use bulk edit to add content.';
-                    errorEl.classList.remove('hidden');
-                }
-                return;
-            }
-
             if (errorEl) {
                 errorEl.classList.add('hidden');
             }
@@ -438,7 +452,7 @@ function initFieldEditing() {
 
             try {
                 const result = await saveFieldEdit(workKey, fieldKey, oldValue, newValue);
-                const didChange = Number(result?.totalReplacements || 0) > 0;
+                const didChange = Number(result?.updatedCaseCount || 0) > 0 || Number(result?.updatedStepCount || 0) > 0;
 
                 if (didChange) {
                     applyDisplayUpdate(fieldKey, newValue);
@@ -448,7 +462,7 @@ function initFieldEditing() {
                     showNotice('success', 'Field updated.');
                 } else {
                     if (errorEl) {
-                        errorEl.textContent = 'No match found. The value may have changed — refresh and try again.';
+                        errorEl.textContent = 'No changes were applied.';
                         errorEl.classList.remove('hidden');
                     }
                 }

--- a/src/main/resources/static/js/workspace/test-case-details.js
+++ b/src/main/resources/static/js/workspace/test-case-details.js
@@ -256,14 +256,24 @@ function flashFieldSaved(fieldKey) {
 async function saveFieldEdit(workKey, fieldKey, oldValue, newValue) {
     const csrf = getCsrf();
     const apiField = getApiFieldKey(fieldKey);
+    const currentValue = String(oldValue || '');
     const payload = {
         workKeys: [workKey]
     };
 
     if (fieldKey === 'status') {
         payload.statusValue = newValue;
-    } else if (oldValue.trim() || isStepField(fieldKey)) {
-        payload.findText = oldValue;
+    } else if (isStepField(fieldKey)) {
+        if (!currentValue.trim()) {
+            const err = new Error('Empty step fields cannot be edited');
+            err.status = 400;
+            throw err;
+        }
+        payload.findText = currentValue;
+        payload.replaceText = newValue;
+        payload.fields = [apiField];
+    } else if (currentValue.trim()) {
+        payload.findText = currentValue;
         payload.replaceText = newValue;
         payload.fields = [apiField];
     } else {

--- a/src/main/resources/templates/test-case-details.html
+++ b/src/main/resources/templates/test-case-details.html
@@ -85,26 +85,20 @@
                                 <button type="button"
                                         class="px-3 py-1 border border-white/15 text-xs text-white/70 hover:border-white/40 transition-colors cursor-pointer"
                                         data-edit-field="status"
-                                        th:if="${!#strings.isEmpty(detailsStatus)}"
                                         title="Click to edit">
                                     Status: <span data-field-display="status"
                                                   th:attr="data-raw-value=${detailsStatus ?: ''}"
                                                   th:text="${detailsStatus ?: '-'}">Draft</span>
                                 </button>
-                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70"
-                                      th:unless="${!#strings.isEmpty(detailsStatus)}">Status: -</span>
 
                                 <button type="button"
                                         class="px-3 py-1 border border-white/15 text-xs text-white/70 hover:border-white/40 transition-colors cursor-pointer"
                                         data-edit-field="priority"
-                                        th:if="${!#strings.isEmpty(detailsPriority)}"
                                         title="Click to edit">
                                     Priority: <span data-field-display="priority"
                                                     th:attr="data-raw-value=${detailsPriority ?: ''}"
                                                     th:text="${detailsPriority ?: '-'}">Medium</span>
                                 </button>
-                                <span class="px-3 py-1 border border-white/15 text-xs text-white/70"
-                                      th:unless="${!#strings.isEmpty(detailsPriority)}">Priority: -</span>
 
                                 <span class="px-3 py-1 border border-white/15 text-xs text-white/70">Steps: <span th:text="${detailsSteps != null ? #lists.size(detailsSteps) : 0}">0</span></span>
                             </div>
@@ -145,14 +139,16 @@
                              class="mt-3 flex flex-wrap items-center gap-2 text-xs text-white/80 cursor-pointer hover:opacity-80 transition-opacity"
                              data-edit-field="folder"
                              title="Click to edit"
-                             th:if="${detailsFolderSegments != null and !#lists.isEmpty(detailsFolderSegments)}">
+                             th:classappend="${detailsFolderSegments == null or #lists.isEmpty(detailsFolderSegments)} ? ' hidden' : ''">
                             <th:block th:each="segment, stat : ${detailsFolderSegments}">
                                 <span class="px-2 py-1 border border-white/15 bg-black/20" th:text="${segment}">Device</span>
                                 <span class="text-white/40" th:if="${!stat.last}">/</span>
                             </th:block>
                         </div>
-                        <p th:classappend="${detailsFolderSegments != null and !#lists.isEmpty(detailsFolderSegments)} ? 'sr-only' : 'mt-3 text-xs text-white/60 break-all'"
+                        <p class="mt-3 text-xs text-white/60 break-all cursor-pointer hover:text-white/80 transition-colors"
+                           th:classappend="${detailsFolderSegments != null and !#lists.isEmpty(detailsFolderSegments)} ? ' sr-only' : ''"
                            data-field-display="folder"
+                           data-edit-field="folder"
                            th:attr="data-raw-value=${detailsFolder ?: ''}"
                            th:text="${detailsFolder ?: '-'}">Device/HeadCoach Skill/HeadCoach Skill Pitch</p>
 
@@ -177,7 +173,7 @@
                     <div class="space-y-6">
 
                         <!-- Description -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative" th:if="${!#strings.isEmpty(detailsDescription)}">
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative">
                             <div class="flex items-center justify-between">
                                 <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Description</p>
                                 <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
@@ -190,8 +186,8 @@
                                  data-dblclick-edit="true"
                                  data-empty-label="Not provided"
                                  title="Double-click to edit"
-                                 th:attr="data-raw-value=${detailsDescription}"
-                                 th:text="${detailsDescription}">Coach assigns a planned drill to a swimmer and verifies it appears in the daily training view with the correct configuration.</div>
+                                 th:attr="data-raw-value=${detailsDescription ?: ''}"
+                                 th:text="${detailsDescription ?: ''}">Coach assigns a planned drill to a swimmer and verifies it appears in the daily training view with the correct configuration.</div>
                             <div class="hidden mt-3" data-field-edit="description">
                                 <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[6rem]"
                                           rows="6" data-field-textarea="description" th:text="${detailsDescription}"></textarea>
@@ -204,7 +200,7 @@
                         </article>
 
                         <!-- Precondition -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative" th:if="${!#strings.isEmpty(detailsPrecondition)}">
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative">
                             <div class="flex items-center justify-between">
                                 <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Precondition</p>
                                 <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
@@ -217,8 +213,8 @@
                                  data-dblclick-edit="true"
                                  data-empty-label="Not provided"
                                  title="Double-click to edit"
-                                 th:attr="data-raw-value=${detailsPrecondition}"
-                                 th:text="${detailsPrecondition}">User is authenticated, swimmer profile exists, and the session plan has at least one unpublished drill.</div>
+                                 th:attr="data-raw-value=${detailsPrecondition ?: ''}"
+                                 th:text="${detailsPrecondition ?: ''}">User is authenticated, swimmer profile exists, and the session plan has at least one unpublished drill.</div>
                             <div class="hidden mt-3" data-field-edit="precondition">
                                 <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[4rem]"
                                           rows="4" data-field-textarea="precondition" th:text="${detailsPrecondition}"></textarea>
@@ -231,7 +227,7 @@
                         </article>
 
                         <!-- Story linkages -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative" th:if="${!#strings.isEmpty(detailsStoryLinkages)}">
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6 group relative">
                             <div class="flex items-center justify-between">
                                 <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Story linkage</p>
                                 <span class="opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none text-white/35 select-none" aria-hidden="true">
@@ -242,9 +238,10 @@
                                  data-md="true"
                                  data-field-display="storyLinkages"
                                  data-dblclick-edit="true"
+                                 data-empty-label="Not provided"
                                  title="Double-click to edit"
-                                 th:attr="data-raw-value=${detailsStoryLinkages}"
-                                 th:text="${detailsStoryLinkages}">https://tracker.example.com/story/TC-2481</div>
+                                 th:attr="data-raw-value=${detailsStoryLinkages ?: ''}"
+                                 th:text="${detailsStoryLinkages ?: ''}">https://tracker.example.com/story/TC-2481</div>
                             <div class="hidden mt-3" data-field-edit="storyLinkages">
                                 <textarea class="w-full bg-black/20 border border-white/20 focus:border-[#E7FF02] focus:outline-none text-white/90 text-sm p-3 leading-6 resize-none overflow-y-auto max-h-96 min-h-[3rem]"
                                           rows="3" data-field-textarea="storyLinkages" th:text="${detailsStoryLinkages}"></textarea>
@@ -262,21 +259,20 @@
                     <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
 
                         <!-- Classification -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6"
-                                 th:if="${!#strings.isEmpty(detailsComponents) or !#strings.isEmpty(detailsTestCaseType) or !#strings.isEmpty(detailsLabels)}">
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6">
                             <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Classification</p>
                             <dl class="mt-4 space-y-4 text-sm">
 
                                 <!-- Components -->
-                                <div th:if="${!#strings.isEmpty(detailsComponents)}">
+                                <div>
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Components</dt>
                                         <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
                                             data-field-display="components"
                                             data-edit-field="components"
                                             title="Click to edit"
-                                            th:attr="data-raw-value=${detailsComponents}"
-                                            th:text="${detailsComponents}">HeadCoach, Device</dd>
+                                            th:attr="data-raw-value=${detailsComponents ?: ''}"
+                                            th:text="${detailsComponents ?: '-'}">HeadCoach, Device</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="components">
                                         <input type="text"
@@ -292,15 +288,15 @@
                                 </div>
 
                                 <!-- Test case type -->
-                                <div th:if="${!#strings.isEmpty(detailsTestCaseType)}">
+                                <div>
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Test case type</dt>
                                         <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
                                             data-field-display="testCaseType"
                                             data-edit-field="testCaseType"
                                             title="Click to edit"
-                                            th:attr="data-raw-value=${detailsTestCaseType}"
-                                            th:text="${detailsTestCaseType}">Functional</dd>
+                                            th:attr="data-raw-value=${detailsTestCaseType ?: ''}"
+                                            th:text="${detailsTestCaseType ?: '-'}">Functional</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="testCaseType">
                                         <input type="text"
@@ -316,15 +312,15 @@
                                 </div>
 
                                 <!-- Labels -->
-                                <div th:if="${!#strings.isEmpty(detailsLabels)}">
+                                <div>
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Labels</dt>
                                         <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
                                             data-field-display="labels"
                                             data-edit-field="labels"
                                             title="Click to edit"
-                                            th:attr="data-raw-value=${detailsLabels}"
-                                            th:text="${detailsLabels}">training, assignment, mobile</dd>
+                                            th:attr="data-raw-value=${detailsLabels ?: ''}"
+                                            th:text="${detailsLabels ?: '-'}">training, assignment, mobile</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="labels">
                                         <input type="text"
@@ -343,21 +339,20 @@
                         </article>
 
                         <!-- Release context -->
-                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6"
-                                 th:if="${!#strings.isEmpty(detailsSprint) or !#strings.isEmpty(detailsFixVersions) or !#strings.isEmpty(detailsVersion) or !#strings.isEmpty(detailsEstimatedTime)}">
+                        <article class="border border-white/10 bg-[#202020] p-5 sm:p-6">
                             <p class="text-xs uppercase tracking-wider text-white/50" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Release context</p>
                             <dl class="mt-4 space-y-4 text-sm">
 
                                 <!-- Sprint -->
-                                <div th:if="${!#strings.isEmpty(detailsSprint)}">
+                                <div>
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Sprint</dt>
                                         <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
                                             data-field-display="sprint"
                                             data-edit-field="sprint"
                                             title="Click to edit"
-                                            th:attr="data-raw-value=${detailsSprint}"
-                                            th:text="${detailsSprint}">Sprint 14</dd>
+                                            th:attr="data-raw-value=${detailsSprint ?: ''}"
+                                            th:text="${detailsSprint ?: '-'}">Sprint 14</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="sprint">
                                         <input type="text"
@@ -373,15 +368,15 @@
                                 </div>
 
                                 <!-- Fix versions -->
-                                <div th:if="${!#strings.isEmpty(detailsFixVersions)}">
+                                <div>
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Fix versions</dt>
                                         <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
                                             data-field-display="fixVersions"
                                             data-edit-field="fixVersions"
                                             title="Click to edit"
-                                            th:attr="data-raw-value=${detailsFixVersions}"
-                                            th:text="${detailsFixVersions}">v0.14.0</dd>
+                                            th:attr="data-raw-value=${detailsFixVersions ?: ''}"
+                                            th:text="${detailsFixVersions ?: '-'}">v0.14.0</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="fixVersions">
                                         <input type="text"
@@ -397,15 +392,15 @@
                                 </div>
 
                                 <!-- Version -->
-                                <div th:if="${!#strings.isEmpty(detailsVersion)}">
+                                <div>
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Version</dt>
                                         <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
                                             data-field-display="version"
                                             data-edit-field="version"
                                             title="Click to edit"
-                                            th:attr="data-raw-value=${detailsVersion}"
-                                            th:text="${detailsVersion}">2</dd>
+                                            th:attr="data-raw-value=${detailsVersion ?: ''}"
+                                            th:text="${detailsVersion ?: '-'}">2</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="version">
                                         <input type="text"
@@ -421,15 +416,15 @@
                                 </div>
 
                                 <!-- Estimated time -->
-                                <div th:if="${!#strings.isEmpty(detailsEstimatedTime)}">
+                                <div>
                                     <div class="flex items-center justify-between gap-4">
                                         <dt class="text-white/50 shrink-0">Estimated time</dt>
                                         <dd class="text-white/80 text-right break-all cursor-pointer hover:text-white transition-colors"
                                             data-field-display="estimatedTime"
                                             data-edit-field="estimatedTime"
                                             title="Click to edit"
-                                            th:attr="data-raw-value=${detailsEstimatedTime}"
-                                            th:text="${detailsEstimatedTime}">5m</dd>
+                                            th:attr="data-raw-value=${detailsEstimatedTime ?: ''}"
+                                            th:text="${detailsEstimatedTime ?: '-'}">5m</dd>
                                     </div>
                                     <div class="hidden mt-2" data-field-edit="estimatedTime">
                                         <input type="text"

--- a/src/test/java/com/formswim/teststream/bulk/BulkEditIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/bulk/BulkEditIntegrationTests.java
@@ -1,6 +1,7 @@
 package com.formswim.teststream.bulk;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItems;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -74,11 +75,16 @@ class BulkEditIntegrationTests {
         team1CaseB.setSummary("Click in second case");
         team1CaseB.addStep(new TestStep(1, "Click next", "", ""));
 
+        TestCase team1BlankCase = TestCaseFixtures.basicCase("TEAM1", "TC-103", "");
+        team1BlankCase.setPriority("");
+        team1BlankCase.setFolder("");
+        team1BlankCase.setUpdatedOn("2026-03-18");
+
         TestCase team2Case = TestCaseFixtures.basicCase("TEAM2", "TC-201", "Auth/Login");
         team2Case.setSummary("Click from another team");
         team2Case.addStep(new TestStep(1, "Click hidden", "", ""));
 
-        testCaseRepository.saveAll(List.of(team1CaseA, team1CaseB, team2Case));
+        testCaseRepository.saveAll(List.of(team1CaseA, team1CaseB, team1BlankCase, team2Case));
     }
 
     @Test
@@ -141,6 +147,68 @@ class BulkEditIntegrationTests {
         assertThat(edited.getStatus()).isEqualTo("Pass");
         assertThat(edited.getUpdatedOn()).isEqualTo(LocalDate.now().toString());
         assertThat(edited.getSummary()).isEqualTo("Please Click the button. Click once.");
+    }
+
+    @Test
+    void bulkEditSupportsDirectAssignmentForInitiallyBlankPriority() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-103"));
+        payload.put("fieldValues", Map.of("priority", "Critical"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1))
+            .andExpect(jsonPath("$.totalReplacements").value(0));
+
+        TestCase edited = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-103").orElseThrow();
+        assertThat(edited.getPriority()).isEqualTo("Critical");
+        assertThat(edited.getUpdatedOn()).isEqualTo(LocalDate.now().toString());
+    }
+
+    @Test
+    void bulkEditDirectAssignmentForBlankFolderCreatesMissingFolderNodes() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-103"));
+        payload.put("fieldValues", Map.of("folder", "QA/Edited"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1));
+
+        TestCase edited = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-103").orElseThrow();
+        assertThat(edited.getFolder()).isEqualTo("QA/Edited");
+
+        mockMvc.perform(get("/api/folders")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasItems("QA", "QA/Edited")));
+    }
+
+    @Test
+    void bulkEditRejectsUnsupportedDirectAssignmentFieldAndDoesNotMutate() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-103"));
+        payload.put("fieldValues", Map.of("stepSummary", "Nope"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isBadRequest());
+
+        TestCase untouched = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-103").orElseThrow();
+        assertThat(untouched.getPriority()).isEmpty();
+        assertThat(untouched.getFolder()).isEmpty();
+        assertThat(untouched.getUpdatedOn()).isEqualTo("2026-03-18");
     }
 
     @Test

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceTestCaseDetailsIntegrationTests.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -72,10 +73,24 @@ class WorkspaceTestCaseDetailsIntegrationTests {
         );
         team1Case.addStep(new TestStep(1, "Open checkout page", "Input cart", "Checkout page opens"));
 
+        TestCase blankTeam1Case = TestCaseFixtures.basicCase("TEAM1", "TC-102", "");
+        blankTeam1Case.setDescription("");
+        blankTeam1Case.setPrecondition("");
+        blankTeam1Case.setStoryLinkages("");
+        blankTeam1Case.setStatus("");
+        blankTeam1Case.setPriority("");
+        blankTeam1Case.setComponents("");
+        blankTeam1Case.setTestCaseType("");
+        blankTeam1Case.setLabels("");
+        blankTeam1Case.setSprint("");
+        blankTeam1Case.setFixVersions("");
+        blankTeam1Case.setVersion("");
+        blankTeam1Case.setEstimatedTime("");
+
         TestCase team2Case = TestCaseFixtures.basicCase("TEAM2", "TC-201", "OtherTeam/Auth");
         team2Case.addStep(new TestStep(1, "Open other team page", "", ""));
 
-        testCaseRepository.saveAll(List.of(team1Case, team2Case));
+        testCaseRepository.saveAll(List.of(team1Case, blankTeam1Case, team2Case));
     }
 
     @Test
@@ -118,6 +133,20 @@ class WorkspaceTestCaseDetailsIntegrationTests {
                 .with(user("team1.user@example.com").roles("USER")))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/workspace?importError=Test+case+not+found"));
+    }
+
+    @Test
+    void detailsPageRendersEditableEmptyFieldsInsteadOfHidingThem() throws Exception {
+        mockMvc.perform(get("/workspace/test-cases/TC-102")
+                .with(user("team1.user@example.com").roles("USER")))
+            .andExpect(status().isOk())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("data-edit-field=\"status\"")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("data-field-display=\"status\"")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("data-edit-field=\"priority\"")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("data-field-display=\"priority\"")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("data-field-display=\"components\"")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("data-field-display=\"sprint\"")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("data-field-display=\"folder\"")));
     }
 
     @Test
@@ -267,5 +296,25 @@ class WorkspaceTestCaseDetailsIntegrationTests {
         TestCase updated = testCaseRepository.findAllWithStepsByTeamKeyAndWorkKeyIn("TEAM1", List.of("TC-101")).get(0);
         assertThat(updated.getSteps().get(0).getStepSummary()).isEqualTo("Navigate to checkout");
         assertThat(updated.getSummary()).isEqualTo("Checkout flow summary");
+    }
+
+    @Test
+    void singleCaseEditCanSetBlankPriorityViaDirectAssignment() throws Exception {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("workKeys", List.of("TC-102"));
+        payload.put("fieldValues", Map.of("priority", "Critical"));
+
+        mockMvc.perform(patch("/api/testcases/bulk-edit")
+                .with(csrf())
+                .with(user("team1.user@example.com").roles("USER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(payload)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedCaseCount").value(1))
+            .andExpect(jsonPath("$.totalReplacements").value(0));
+
+        TestCase updated = testCaseRepository.findByTeamKeyAndWorkKey("TEAM1", "TC-102").orElseThrow();
+        assertThat(updated.getPriority()).isEqualTo("Critical");
+        assertThat(updated.getUpdatedOn()).matches("\\d{4}-\\d{2}-\\d{2}");
     }
 }


### PR DESCRIPTION
Created a new FieldValue request map that allows direct editing of fields for the single edit page. This allows fields that were not set in the excel file to be assigned in the single edit