### PR TITLE
Workspace UI/UX Refactor: Sidebar, Theme System, Header Settings, Notifications, and Responsive Grid Stability

### DIFF
--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated: 2026-04-03
+Last updated: 2026-04-05
 
 ## Summary
 
@@ -60,6 +60,7 @@ Recent delivery:
 - `GET /api/folders` now reads derived paths from the folder table while keeping the existing `List<String>` response shape
 - folder APIs now support create, rename/reparent with cycle rejection, and explicit delete with conflict safeguards
 - workspace sidebar now supports New Folder, folder context-menu actions, and folder drag/reparent behavior
+- workspace theme now defaults to a softer dark gray and includes a header theme selector (`Dark Gray` / `High Contrast`) persisted in `localStorage`
 
 Primary active goals:
 

--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -61,6 +61,7 @@ Recent delivery:
 - folder APIs now support create, rename/reparent with cycle rejection, and explicit delete with conflict safeguards
 - workspace sidebar now supports New Folder, folder context-menu actions, and folder drag/reparent behavior
 - workspace theme now defaults to a softer dark gray and includes a header theme selector (`Dark Gray` / `High Contrast`) persisted in `localStorage`
+- workspace header now uses a single animated settings menu (theme selector, team code, account, logout), with account controls removed from the main header row
 
 Primary active goals:
 

--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -63,6 +63,7 @@ Recent delivery:
 - workspace theme now defaults to a softer dark gray and includes a header theme selector (`Dark Gray` / `High Contrast`) persisted in `localStorage`
 - workspace header now uses a single animated settings menu (theme selector, team code, account, logout), with account controls removed from the main header row
 - workspace notice popup can now be dismissed via both `OK` and `X`, and notice/bulk bars now visually follow the selected workspace theme
+- folder delete confirmation is now a centered modal with blue-tinted backdrop, theme-aware styling, and keyboard focus trapping
 
 Primary active goals:
 

--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -62,6 +62,7 @@ Recent delivery:
 - workspace sidebar now supports New Folder, folder context-menu actions, and folder drag/reparent behavior
 - workspace theme now defaults to a softer dark gray and includes a header theme selector (`Dark Gray` / `High Contrast`) persisted in `localStorage`
 - workspace header now uses a single animated settings menu (theme selector, team code, account, logout), with account controls removed from the main header row
+- workspace notice popup can now be dismissed via both `OK` and `X`, and notice/bulk bars now visually follow the selected workspace theme
 
 Primary active goals:
 

--- a/.context/STATE.md
+++ b/.context/STATE.md
@@ -64,6 +64,8 @@ Recent delivery:
 - workspace header now uses a single animated settings menu (theme selector, team code, account, logout), with account controls removed from the main header row
 - workspace notice popup can now be dismissed via both `OK` and `X`, and notice/bulk bars now visually follow the selected workspace theme
 - folder delete confirmation is now a centered modal with blue-tinted backdrop, theme-aware styling, and keyboard focus trapping
+- landing/login/register now use the same gray dark surface family as workspace for visual consistency
+- workspace now uses a fixed-height split-pane shell with independent sidebar/grid scrolling (page scroll disabled in workspace view)
 
 Primary active goals:
 

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -29,7 +29,7 @@ export function createWorkspaceFolderTree(options) {
     let isFolderLoading = false;
     let pendingDeletePrompt = null;
     let sidebarWidthPx = SIDEBAR_DEFAULT_WIDTH;
-    const TREE_BASE_PADDING_PX = 6;
+    const TREE_BASE_PADDING_PX = 0;
     const TREE_INDENT_STEP_PX = 12;
 
     function snapshotExpandedState(model) {
@@ -754,7 +754,7 @@ export function createWorkspaceFolderTree(options) {
         const selectedRowClasses = 'bg-[#E7FF02]/30 text-white';
         const unselectedRowClasses = 'text-white/80 hover:bg-white/5';
         const rowWrapClasses = 'select-none';
-        const rowInnerBaseClasses = 'flex items-center gap-2 py-2 pl-2 pr-2 text-sm rounded-md transition-colors w-full';
+        const rowInnerBaseClasses = 'flex items-center gap-2 py-2 pl-0 pr-2 text-sm rounded-md transition-colors w-full';
         const rowSelectButtonClasses = 'min-w-0 flex-1 flex items-center gap-2 text-left';
 
         const showAllWrap = document.createElement('div');
@@ -766,7 +766,7 @@ export function createWorkspaceFolderTree(options) {
 
         const showAllButton = document.createElement('button');
         showAllButton.type = 'button';
-        showAllButton.className = rowSelectButtonClasses;
+        showAllButton.className = rowSelectButtonClasses + ' pl-2';
         showAllButton.setAttribute('aria-label', 'Show all test cases');
         if (!selectedFolder) {
             showAllButton.setAttribute('aria-current', 'true');

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -29,6 +29,8 @@ export function createWorkspaceFolderTree(options) {
     let isFolderLoading = false;
     let pendingDeletePrompt = null;
     let sidebarWidthPx = SIDEBAR_DEFAULT_WIDTH;
+    const TREE_BASE_PADDING_PX = 6;
+    const TREE_INDENT_STEP_PX = 12;
 
     function snapshotExpandedState(model) {
         const expandedByPath = new Map();
@@ -757,7 +759,7 @@ export function createWorkspaceFolderTree(options) {
 
         const showAllWrap = document.createElement('div');
         showAllWrap.className = rowWrapClasses;
-        showAllWrap.style.paddingLeft = '12px';
+        showAllWrap.style.paddingLeft = String(TREE_BASE_PADDING_PX) + 'px';
 
         const showAllInner = document.createElement('div');
         showAllInner.className = rowInnerBaseClasses + ' ' + (selectedFolder ? unselectedRowClasses : selectedRowClasses);
@@ -765,7 +767,7 @@ export function createWorkspaceFolderTree(options) {
         const showAllButton = document.createElement('button');
         showAllButton.type = 'button';
         showAllButton.className = rowSelectButtonClasses;
-        showAllButton.setAttribute('aria-label', 'Show all files');
+        showAllButton.setAttribute('aria-label', 'Show all test cases');
         if (!selectedFolder) {
             showAllButton.setAttribute('aria-current', 'true');
         }
@@ -773,7 +775,7 @@ export function createWorkspaceFolderTree(options) {
             '<span class="shrink-0 text-white/60">' +
             '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4"><path d="M4 6h16" /><path d="M4 12h16" /><path d="M4 18h16" /></svg>' +
             '</span>' +
-            '<span class="min-w-0 truncate">Show all files <span id="wsTotalCount" class="text-white/55">(' + String(uiState.getPageState().totalCount) + ')</span></span>';
+            '<span class="min-w-0 truncate">Show all test cases</span>';
 
         if (isFolderLoading) {
             const loadingSpinner = document.createElement('span');
@@ -813,7 +815,7 @@ export function createWorkspaceFolderTree(options) {
         function renderInlineEditorRow(parentNode, depth) {
             const rowWrap = document.createElement('div');
             rowWrap.className = rowWrapClasses;
-            rowWrap.style.paddingLeft = String(12 + depth * 16) + 'px';
+            rowWrap.style.paddingLeft = String(TREE_BASE_PADDING_PX + depth * TREE_INDENT_STEP_PX) + 'px';
 
             const rowInner = document.createElement('div');
             rowInner.className = rowInnerBaseClasses + ' text-white/90 bg-white/5';
@@ -867,14 +869,14 @@ export function createWorkspaceFolderTree(options) {
             const isOpen = Boolean(hasChildren && node.expanded);
             const rowWrap = document.createElement('div');
             rowWrap.className = rowWrapClasses;
-            rowWrap.style.paddingLeft = String(12 + depth * 16) + 'px';
+            rowWrap.style.paddingLeft = String(TREE_BASE_PADDING_PX + depth * TREE_INDENT_STEP_PX) + 'px';
             rowWrap.style.position = 'relative';
 
             if (depth > 0) {
                 for (let guideLevel = 1; guideLevel <= depth; guideLevel++) {
                     const guide = document.createElement('span');
                     guide.className = 'pointer-events-none absolute top-0 bottom-0 w-px bg-white/20';
-                    guide.style.left = String(12 + (guideLevel - 1) * 16 + 8) + 'px';
+                    guide.style.left = String(TREE_BASE_PADDING_PX + (guideLevel - 1) * TREE_INDENT_STEP_PX + 8) + 'px';
                     rowWrap.appendChild(guide);
                 }
             }

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -270,7 +270,7 @@ export function createWorkspaceFolderTree(options) {
             return;
         }
 
-        const { root, resolve, onKeyDown } = pendingDeletePrompt;
+        const { root, resolve, onKeyDown, previousActiveElement } = pendingDeletePrompt;
         pendingDeletePrompt = null;
 
         if (onKeyDown) {
@@ -278,6 +278,9 @@ export function createWorkspaceFolderTree(options) {
         }
         if (root && root.parentNode) {
             root.parentNode.removeChild(root);
+        }
+        if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
+            previousActiveElement.focus();
         }
         resolve(Boolean(confirmed));
     }
@@ -288,12 +291,22 @@ export function createWorkspaceFolderTree(options) {
         }
 
         return new Promise((resolve) => {
+            const isSoftTheme = document.body?.dataset?.workspaceTheme !== 'black';
+            const previousActiveElement = document.activeElement;
             const root = document.createElement('div');
-            root.className = 'fixed right-4 top-4 z-[1400] w-[min(28rem,calc(100vw-2rem))]';
+            root.className = 'fixed inset-0 z-[1400] flex items-center justify-center p-4';
+            root.style.backgroundColor = isSoftTheme
+                ? 'rgba(20, 20, 20, 0.46)'
+                : 'rgba(0, 0, 0, 0.62)';
+            root.style.backdropFilter = 'blur(2px)';
 
             const notice = document.createElement('div');
-            notice.className = 'border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80 shadow-[0_18px_48px_rgba(0,0,0,0.55)]';
-            notice.style.borderColor = 'rgba(255, 255, 255, 0.15)';
+            notice.className = 'w-[min(32rem,calc(100vw-2rem))] border px-5 py-5 text-sm text-white/85 rounded-md shadow-[0_24px_80px_rgba(0,0,0,0.55)]';
+            notice.style.backgroundColor = isSoftTheme ? '#2b2b2b' : 'rgba(0, 0, 0, 0.95)';
+            notice.style.borderColor = 'rgba(255, 255, 255, 0.24)';
+            notice.setAttribute('role', 'dialog');
+            notice.setAttribute('aria-modal', 'true');
+            notice.setAttribute('aria-label', 'Confirm folder delete');
 
             const headingRow = document.createElement('div');
             headingRow.className = 'flex items-start justify-between gap-3';
@@ -302,7 +315,8 @@ export function createWorkspaceFolderTree(options) {
             headingWrap.className = 'min-w-0';
 
             const badge = document.createElement('span');
-            badge.className = 'font-bold text-black px-2 py-1 mr-3 bg-white/70';
+            badge.className = 'font-bold text-black px-2 py-1 mr-3';
+            badge.style.backgroundColor = '#E7FF02';
             badge.textContent = 'Confirm';
 
             const heading = document.createElement('span');
@@ -314,7 +328,7 @@ export function createWorkspaceFolderTree(options) {
             message.textContent = 'Delete "' + String(path || '') + '"? Only empty folders can be deleted.';
 
             const actions = document.createElement('div');
-            actions.className = 'mt-3 flex items-center justify-end gap-2';
+            actions.className = 'mt-5 flex items-center justify-end gap-2';
 
             const cancelButton = document.createElement('button');
             cancelButton.type = 'button';
@@ -345,22 +359,46 @@ export function createWorkspaceFolderTree(options) {
                 if (event.key === 'Escape') {
                     event.preventDefault();
                     dismissDeletePrompt(false);
+                    return;
+                }
+
+                if (event.key === 'Tab') {
+                    const focusables = [cancelButton, deleteButton];
+                    const first = focusables[0];
+                    const last = focusables[focusables.length - 1];
+
+                    if (event.shiftKey && document.activeElement === first) {
+                        event.preventDefault();
+                        last.focus();
+                        return;
+                    }
+                    if (!event.shiftKey && document.activeElement === last) {
+                        event.preventDefault();
+                        first.focus();
+                        return;
+                    }
                 }
             };
 
             pendingDeletePrompt = {
                 root,
                 resolve,
-                onKeyDown
+                onKeyDown,
+                previousActiveElement
             };
 
             document.addEventListener('keydown', onKeyDown);
 
             cancelButton.addEventListener('click', () => dismissDeletePrompt(false));
             deleteButton.addEventListener('click', () => dismissDeletePrompt(true));
+            root.addEventListener('click', (event) => {
+                if (event.target === root) {
+                    dismissDeletePrompt(false);
+                }
+            });
 
             window.requestAnimationFrame(() => {
-                deleteButton.focus();
+                cancelButton.focus();
             });
         });
     }

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -6,15 +6,17 @@ export function createWorkspaceFolderTree(options) {
     const folderEmpty = options.folderEmpty;
     const newFolderButton = options.newFolderButton;
     const sidebar = options.sidebar;
-    const sidebarToggle = options.sidebarToggle;
+    const sidebarResizeHandle = options.sidebarResizeHandle;
     const sidebarContent = options.sidebarContent;
     const sidebarTitle = options.sidebarTitle;
     const sidebarInner = options.sidebarInner;
     const sidebarHeader = options.sidebarHeader;
-    const sidebarToggleExpandedHost = options.sidebarToggleExpandedHost;
-    const sidebarToggleCollapsedHost = options.sidebarToggleCollapsedHost;
     const showNotice = options.showNotice;
     const onFolderChanged = options.onFolderChanged;
+    const SIDEBAR_DEFAULT_WIDTH = 320;
+    const SIDEBAR_MIN_OPEN_WIDTH = 48;
+    const SIDEBAR_MAX_WIDTH = 560;
+    const SIDEBAR_CLOSE_SNAP_WIDTH = 24;
 
     let folderTreeModel = createFolderTreeModel([], []);
     let folderNodeByPath = new Map();
@@ -26,6 +28,7 @@ export function createWorkspaceFolderTree(options) {
     let activeFolderDropMode = null;
     let isFolderLoading = false;
     let pendingDeletePrompt = null;
+    let sidebarWidthPx = SIDEBAR_DEFAULT_WIDTH;
 
     function snapshotExpandedState(model) {
         const expandedByPath = new Map();
@@ -74,16 +77,22 @@ export function createWorkspaceFolderTree(options) {
         }
     }
 
-    function setSidebarExpanded(expanded) {
-        uiState.setSidebarExpanded(expanded);
-        const isSidebarExpanded = uiState.isSidebarExpanded();
+    function clampSidebarWidth(widthPx) {
+        return Math.min(Math.max(widthPx, SIDEBAR_MIN_OPEN_WIDTH), SIDEBAR_MAX_WIDTH);
+    }
+
+    function applySidebarWidth(widthPx) {
+        const numericWidth = Math.max(Number(widthPx) || 0, 0);
+        const isSidebarExpanded = numericWidth > 0;
+        uiState.setSidebarExpanded(isSidebarExpanded);
 
         if (sidebar) {
             if (isSidebarExpanded) {
-                sidebar.style.width = '';
-                sidebar.style.minWidth = '';
+                sidebar.style.width = String(numericWidth) + 'px';
+                sidebar.style.minWidth = String(numericWidth) + 'px';
                 sidebar.style.borderRight = '';
-                sidebar.style.overflow = '';
+                // Keep directory content clipped so it never overlays into the grid.
+                sidebar.style.overflow = 'hidden';
             } else {
                 sidebar.style.width = '0px';
                 sidebar.style.minWidth = '0px';
@@ -102,31 +111,42 @@ export function createWorkspaceFolderTree(options) {
 
         if (sidebarInner) {
             sidebarInner.style.padding = isSidebarExpanded ? '' : '0.25rem';
+            sidebarInner.style.overflow = 'hidden';
         }
 
         if (sidebarHeader) {
             sidebarHeader.style.justifyContent = isSidebarExpanded ? '' : 'center';
         }
 
-        if (sidebarToggle) {
-            sidebarToggle.setAttribute('aria-expanded', String(isSidebarExpanded));
-            sidebarToggle.setAttribute('aria-label', isSidebarExpanded ? 'Collapse repository sidebar' : 'Expand repository sidebar');
-            sidebarToggle.style.width = '';
-            sidebarToggle.style.padding = '';
-            sidebarToggle.innerHTML = isSidebarExpanded
-                ? '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-4 h-4"><path d="M15 6l-6 6 6 6" /></svg>'
-                : '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-4 h-4"><path d="M9 6l6 6-6 6" /></svg>';
+        if (sidebarResizeHandle) {
+            sidebarResizeHandle.setAttribute('aria-valuenow', String(Math.round(numericWidth)));
+            sidebarResizeHandle.classList.toggle('bg-white/10', isSidebarExpanded);
+            sidebarResizeHandle.classList.toggle('bg-white/20', !isSidebarExpanded);
         }
 
-        if (sidebarToggleExpandedHost && sidebarToggleCollapsedHost && sidebarToggle) {
-            if (isSidebarExpanded) {
-                sidebarToggleExpandedHost.appendChild(sidebarToggle);
-                sidebarToggleCollapsedHost.classList.add('hidden');
-            } else {
-                sidebarToggleCollapsedHost.appendChild(sidebarToggle);
-                sidebarToggleCollapsedHost.classList.remove('hidden');
-            }
+        if (isSidebarExpanded) {
+            sidebarWidthPx = numericWidth;
         }
+    }
+
+    function setSidebarWidth(widthPx) {
+        const numericWidth = Number(widthPx) || 0;
+        if (numericWidth <= SIDEBAR_CLOSE_SNAP_WIDTH) {
+            applySidebarWidth(0);
+            return;
+        }
+
+        applySidebarWidth(clampSidebarWidth(numericWidth));
+    }
+
+    function setSidebarExpanded(expanded) {
+        if (expanded) {
+            const nextWidth = sidebarWidthPx > 0 ? sidebarWidthPx : SIDEBAR_DEFAULT_WIDTH;
+            setSidebarWidth(nextWidth);
+            return;
+        }
+
+        applySidebarWidth(0);
     }
 
     function createFolderTreeModel(folderNames, folderNodes) {
@@ -715,7 +735,7 @@ export function createWorkspaceFolderTree(options) {
             '<span class="shrink-0 text-white/60">' +
             '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4"><path d="M4 6h16" /><path d="M4 12h16" /><path d="M4 18h16" /></svg>' +
             '</span>' +
-            '<span class="min-w-0 truncate">Show all files</span>';
+            '<span class="min-w-0 truncate">Show all files <span id="wsTotalCount" class="text-white/55">(' + String(uiState.getPageState().totalCount) + ')</span></span>';
 
         if (isFolderLoading) {
             const loadingSpinner = document.createElement('span');
@@ -1096,9 +1116,30 @@ export function createWorkspaceFolderTree(options) {
         return folderTreeModel;
     }
 
-    if (sidebarToggle) {
-        sidebarToggle.addEventListener('click', () => {
-            setSidebarExpanded(!uiState.isSidebarExpanded());
+    if (sidebarResizeHandle && sidebar) {
+        sidebarResizeHandle.setAttribute('aria-valuemin', '0');
+        sidebarResizeHandle.setAttribute('aria-valuemax', String(SIDEBAR_MAX_WIDTH));
+        sidebarResizeHandle.addEventListener('pointerdown', (event) => {
+            if (event.button !== 0) {
+                return;
+            }
+
+            const startX = Number(event.clientX) || 0;
+            const startWidth = sidebar.getBoundingClientRect().width || 0;
+
+            const onPointerMove = (moveEvent) => {
+                const nextWidth = startWidth + ((Number(moveEvent.clientX) || 0) - startX);
+                setSidebarWidth(nextWidth);
+            };
+
+            const onPointerUp = () => {
+                document.removeEventListener('pointermove', onPointerMove);
+                document.removeEventListener('pointerup', onPointerUp);
+            };
+
+            document.addEventListener('pointermove', onPointerMove);
+            document.addEventListener('pointerup', onPointerUp);
+            event.preventDefault();
         });
     }
 

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -60,7 +60,7 @@ export function createWorkspaceFolderTree(options) {
             if (!isHorizontallyTruncated(element)) {
                 return;
             }
-            folderLabelTooltip.show(element, fullText);
+            folderLabelTooltip.show(element, fullText, { asText: true });
         };
         const hide = () => folderLabelTooltip.hide();
 
@@ -1204,6 +1204,7 @@ export function createWorkspaceFolderTree(options) {
                 return;
             }
 
+            const pointerId = event.pointerId;
             const startX = Number(event.clientX) || 0;
             const startWidth = sidebar.getBoundingClientRect().width || 0;
 
@@ -1212,13 +1213,37 @@ export function createWorkspaceFolderTree(options) {
                 setSidebarWidth(nextWidth);
             };
 
-            const onPointerUp = () => {
+            const cleanupDrag = () => {
                 document.removeEventListener('pointermove', onPointerMove);
                 document.removeEventListener('pointerup', onPointerUp);
+                document.removeEventListener('pointercancel', onPointerCancel);
+                window.removeEventListener('blur', onWindowBlur);
+                if (
+                    typeof sidebarResizeHandle.hasPointerCapture === 'function' &&
+                    typeof sidebarResizeHandle.releasePointerCapture === 'function' &&
+                    sidebarResizeHandle.hasPointerCapture(pointerId)
+                ) {
+                    sidebarResizeHandle.releasePointerCapture(pointerId);
+                }
             };
 
+            const onPointerUp = () => {
+                cleanupDrag();
+            };
+            const onPointerCancel = () => {
+                cleanupDrag();
+            };
+            const onWindowBlur = () => {
+                cleanupDrag();
+            };
+
+            if (typeof sidebarResizeHandle.setPointerCapture === 'function') {
+                sidebarResizeHandle.setPointerCapture(pointerId);
+            }
             document.addEventListener('pointermove', onPointerMove);
             document.addEventListener('pointerup', onPointerUp);
+            document.addEventListener('pointercancel', onPointerCancel);
+            window.addEventListener('blur', onWindowBlur);
             event.preventDefault();
         });
     }

--- a/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
+++ b/src/main/resources/static/js/workspace/components/workspace-folder-tree.js
@@ -1,3 +1,5 @@
+import { createWorkspaceTooltip } from './workspace-tooltip.js';
+
 export function createWorkspaceFolderTree(options) {
     const uiState = options.uiState;
     const api = options.api;
@@ -31,6 +33,42 @@ export function createWorkspaceFolderTree(options) {
     let sidebarWidthPx = SIDEBAR_DEFAULT_WIDTH;
     const TREE_BASE_PADDING_PX = 0;
     const TREE_INDENT_STEP_PX = 12;
+    const folderLabelTooltip = createWorkspaceTooltip({
+        className: 'fixed z-50 border border-white/15 bg-black/90 px-2 py-1 text-xs text-white/85',
+        maxWidth: '20rem',
+        whiteSpace: 'normal',
+        wordBreak: 'break-word'
+    });
+
+    function isHorizontallyTruncated(element) {
+        if (!element) {
+            return false;
+        }
+        return element.scrollWidth > element.clientWidth + 1;
+    }
+
+    function bindTruncationTooltip(element, text) {
+        if (!element) {
+            return;
+        }
+        const fullText = String(text || '').trim();
+        if (!fullText) {
+            return;
+        }
+
+        const show = () => {
+            if (!isHorizontallyTruncated(element)) {
+                return;
+            }
+            folderLabelTooltip.show(element, fullText);
+        };
+        const hide = () => folderLabelTooltip.hide();
+
+        element.addEventListener('mouseenter', show);
+        element.addEventListener('mouseleave', hide);
+        element.addEventListener('focusin', show);
+        element.addEventListener('focusout', hide);
+    }
 
     function snapshotExpandedState(model) {
         const expandedByPath = new Map();
@@ -748,6 +786,7 @@ export function createWorkspaceFolderTree(options) {
             return;
         }
 
+        folderLabelTooltip.hide();
         folderTree.innerHTML = '';
 
         const selectedFolder = uiState.getSelectedFolder();
@@ -930,6 +969,7 @@ export function createWorkspaceFolderTree(options) {
             const labelSpan = document.createElement('span');
             labelSpan.className = 'min-w-0 truncate';
             labelSpan.textContent = node.name;
+            bindTruncationTooltip(labelSpan, node.name);
 
             const isRenameEditing = Boolean(inlineEditorState && inlineEditorState.mode === 'rename' && inlineEditorState.targetPath === node.path);
 

--- a/src/main/resources/static/js/workspace/components/workspace-tooltip.js
+++ b/src/main/resources/static/js/workspace/components/workspace-tooltip.js
@@ -64,13 +64,18 @@ export function createWorkspaceTooltip(options) {
         tooltipEl.innerHTML = '';
     }
 
-    function show(anchorEl, html) {
+    function show(anchorEl, content, options) {
         if (!anchorEl) {
             return;
         }
 
+        const renderAsText = Boolean(options && options.asText);
         const tooltip = ensureElement();
-        tooltip.innerHTML = String(html || '');
+        if (renderAsText) {
+            tooltip.textContent = String(content || '');
+        } else {
+            tooltip.innerHTML = String(content || '');
+        }
         tooltip.style.display = 'block';
 
         const anchorRect = anchorEl.getBoundingClientRect();

--- a/src/main/resources/static/js/workspace/features/workspace-data-controller.js
+++ b/src/main/resources/static/js/workspace/features/workspace-data-controller.js
@@ -42,6 +42,9 @@ export function createWorkspaceDataController(options) {
     const selection = options.selection;
     const tbody = options.tbody;
     const totalCount = options.totalCount;
+    const getTotalCountElement = typeof options.getTotalCountElement === 'function'
+        ? options.getTotalCountElement
+        : null;
     const pageInfo = options.pageInfo;
     const prevPageButton = options.prevPageButton;
     const nextPageButton = options.nextPageButton;
@@ -97,8 +100,9 @@ export function createWorkspaceDataController(options) {
     function renderCurrentPage() {
         const pageState = uiState.getPageState();
 
-        if (totalCount) {
-            totalCount.textContent = String(pageState.totalCount);
+        const totalCountElement = getTotalCountElement ? getTotalCountElement() : totalCount;
+        if (totalCountElement) {
+            totalCountElement.textContent = '(' + String(pageState.totalCount) + ')';
         }
 
         const visibleIds = currentPageCases.map((testCase) => testCase.workKey).filter(Boolean);

--- a/src/main/resources/static/js/workspace/features/workspace-header-controls.js
+++ b/src/main/resources/static/js/workspace/features/workspace-header-controls.js
@@ -1,4 +1,5 @@
 export function bindWorkspaceHeaderControls() {
+    const FLASH_AUTO_DISMISS_MS = 5000;
     const settingsToggle = document.getElementById('workspaceSettingsToggle');
     const settingsIcon = document.getElementById('workspaceSettingsIcon');
     const settingsDropdown = document.getElementById('workspaceSettingsDropdown');
@@ -19,12 +20,10 @@ export function bindWorkspaceHeaderControls() {
         }
     }
 
-    function dismissWorkspaceFlash(button) {
-        const item = button.closest('[data-flash-item]');
+    function dismissWorkspaceFlashItem(item) {
         if (item) {
             item.classList.add('hidden');
         }
-
         const container = document.getElementById('workspaceFlashContainer');
         if (!container) {
             return;
@@ -34,6 +33,27 @@ export function bindWorkspaceHeaderControls() {
         if (visibleItems.length === 0) {
             container.classList.add('hidden');
         }
+    }
+
+    function dismissWorkspaceFlash(button) {
+        const item = button.closest('[data-flash-item]');
+        dismissWorkspaceFlashItem(item);
+    }
+
+    function scheduleWorkspaceFlashAutoDismiss() {
+        const items = Array.from(document.querySelectorAll('#workspaceFlashContainer [data-flash-item]:not(.hidden)'));
+        items.forEach((item) => {
+            if (!(item instanceof HTMLElement)) {
+                return;
+            }
+            if (item.dataset.autoDismissBound === 'true') {
+                return;
+            }
+            item.dataset.autoDismissBound = 'true';
+            window.setTimeout(() => {
+                dismissWorkspaceFlashItem(item);
+            }, FLASH_AUTO_DISMISS_MS);
+        });
     }
 
     async function copyWorkspaceTeamCode() {
@@ -119,6 +139,7 @@ export function bindWorkspaceHeaderControls() {
             dismissWorkspaceFlash(button);
         });
     });
+    scheduleWorkspaceFlashAutoDismiss();
 
     return {};
 }

--- a/src/main/resources/static/js/workspace/features/workspace-header-controls.js
+++ b/src/main/resources/static/js/workspace/features/workspace-header-controls.js
@@ -1,33 +1,21 @@
 export function bindWorkspaceHeaderControls() {
-    const accountToggle = document.getElementById('workspaceAccountToggle');
-    const account = document.getElementById('workspaceAccountDropdown');
-    const teamToggle = document.getElementById('workspaceTeamCodeToggle');
-    const team = document.getElementById('workspaceTeamCodeDropdown');
+    const settingsToggle = document.getElementById('workspaceSettingsToggle');
+    const settingsIcon = document.getElementById('workspaceSettingsIcon');
+    const settingsDropdown = document.getElementById('workspaceSettingsDropdown');
     const teamCodeValue = document.getElementById('workspaceTeamCodeValue');
     const copyButtons = Array.from(document.querySelectorAll('[data-workspace-copy-team-code]'));
     const flashDismissButtons = Array.from(document.querySelectorAll('[data-workspace-flash-dismiss]'));
 
-    function toggleWorkspaceHeaderDropdown(which) {
-        const isAccountOpen = account && !account.classList.contains('hidden');
-        const isTeamOpen = team && !team.classList.contains('hidden');
-
-        const nextAccountOpen = which === 'account' ? !isAccountOpen : false;
-        const nextTeamOpen = which === 'team' ? !isTeamOpen : false;
-
-        if (account) {
-            account.classList.toggle('hidden', !nextAccountOpen);
-            account.setAttribute('aria-hidden', String(!nextAccountOpen));
-        }
-        if (team) {
-            team.classList.toggle('hidden', !nextTeamOpen);
-            team.setAttribute('aria-hidden', String(!nextTeamOpen));
+    function setSettingsOpen(isOpen) {
+        if (!settingsDropdown || !settingsToggle) {
+            return;
         }
 
-        if (accountToggle) {
-            accountToggle.setAttribute('aria-expanded', String(nextAccountOpen));
-        }
-        if (teamToggle) {
-            teamToggle.setAttribute('aria-expanded', String(nextTeamOpen));
+        settingsDropdown.classList.toggle('hidden', !isOpen);
+        settingsDropdown.setAttribute('aria-hidden', String(!isOpen));
+        settingsToggle.setAttribute('aria-expanded', String(isOpen));
+        if (settingsIcon) {
+            settingsIcon.classList.toggle('rotate-180', isOpen);
         }
     }
 
@@ -86,12 +74,30 @@ export function bindWorkspaceHeaderControls() {
         }
     }
 
-    if (accountToggle) {
-        accountToggle.addEventListener('click', () => toggleWorkspaceHeaderDropdown('account'));
+    if (settingsToggle && settingsDropdown) {
+        settingsToggle.addEventListener('click', () => {
+            const isOpen = !settingsDropdown.classList.contains('hidden');
+            setSettingsOpen(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!(target instanceof Node)) {
+                return;
+            }
+            if (settingsDropdown.contains(target) || settingsToggle.contains(target)) {
+                return;
+            }
+            setSettingsOpen(false);
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                setSettingsOpen(false);
+            }
+        });
     }
-    if (teamToggle) {
-        teamToggle.addEventListener('click', () => toggleWorkspaceHeaderDropdown('team'));
-    }
+
     if (teamCodeValue) {
         teamCodeValue.addEventListener('click', () => {
             copyWorkspaceTeamCode();

--- a/src/main/resources/static/js/workspace/features/workspace-import-controller.js
+++ b/src/main/resources/static/js/workspace/features/workspace-import-controller.js
@@ -6,6 +6,7 @@ export function createWorkspaceImportController(options) {
     const importNoticeContainer = options.importNoticeContainer;
     const importNotice = options.importNotice;
     const importNoticeBadge = options.importNoticeBadge;
+    const importNoticeOk = options.importNoticeOk;
     const importNoticeMessage = options.importNoticeMessage;
     const importNoticeClose = options.importNoticeClose;
     const onUploadComplete = options.onUploadComplete;
@@ -45,6 +46,9 @@ export function createWorkspaceImportController(options) {
 
     if (importNoticeClose) {
         importNoticeClose.addEventListener('click', clearNotice);
+    }
+    if (importNoticeOk) {
+        importNoticeOk.addEventListener('click', clearNotice);
     }
 
     if (importBtn && importFile) {

--- a/src/main/resources/static/js/workspace/features/workspace-import-controller.js
+++ b/src/main/resources/static/js/workspace/features/workspace-import-controller.js
@@ -43,14 +43,13 @@ export function createWorkspaceImportController(options) {
         importNoticeContainer.classList.remove('hidden');
         importNoticeMessage.textContent = message;
 
+        importNoticeBadge.textContent = 'OK';
         if (isSuccess) {
             importNotice.style.borderColor = 'rgba(231, 255, 2, 0.35)';
-            importNoticeBadge.textContent = 'OK';
             importNoticeBadge.classList.remove('bg-white/70');
             importNoticeBadge.style.backgroundColor = '#E7FF02';
         } else {
             importNotice.style.borderColor = 'rgba(255, 255, 255, 0.15)';
-            importNoticeBadge.textContent = 'Error';
             importNoticeBadge.classList.add('bg-white/70');
             importNoticeBadge.style.backgroundColor = '';
         }

--- a/src/main/resources/static/js/workspace/features/workspace-import-controller.js
+++ b/src/main/resources/static/js/workspace/features/workspace-import-controller.js
@@ -1,4 +1,5 @@
 export function createWorkspaceImportController(options) {
+    const NOTICE_AUTO_DISMISS_MS = 5000;
     const api = options.api;
     const importBtn = options.importBtn;
     const importFile = options.importFile;
@@ -10,8 +11,14 @@ export function createWorkspaceImportController(options) {
     const importNoticeMessage = options.importNoticeMessage;
     const importNoticeClose = options.importNoticeClose;
     const onUploadComplete = options.onUploadComplete;
+    let noticeAutoDismissHandle = 0;
 
     function clearNotice() {
+        if (noticeAutoDismissHandle) {
+            window.clearTimeout(noticeAutoDismissHandle);
+            noticeAutoDismissHandle = 0;
+        }
+
         if (!importNoticeContainer) {
             return;
         }
@@ -25,6 +32,11 @@ export function createWorkspaceImportController(options) {
     function showNotice(type, message) {
         if (!importNoticeContainer || !importNotice || !importNoticeBadge || !importNoticeMessage || !message) {
             return;
+        }
+
+        if (noticeAutoDismissHandle) {
+            window.clearTimeout(noticeAutoDismissHandle);
+            noticeAutoDismissHandle = 0;
         }
 
         const isSuccess = type === 'success';
@@ -42,6 +54,10 @@ export function createWorkspaceImportController(options) {
             importNoticeBadge.classList.add('bg-white/70');
             importNoticeBadge.style.backgroundColor = '';
         }
+
+        noticeAutoDismissHandle = window.setTimeout(() => {
+            clearNotice();
+        }, NOTICE_AUTO_DISMISS_MS);
     }
 
     if (importNoticeClose) {

--- a/src/main/resources/static/js/workspace/features/workspace-theme-controls.js
+++ b/src/main/resources/static/js/workspace/features/workspace-theme-controls.js
@@ -1,0 +1,55 @@
+const THEME_STORAGE_KEY = 'workspace.theme';
+const THEMES = {
+    soft: 'workspace-theme-soft',
+    black: 'workspace-theme-black'
+};
+const DEFAULT_THEME = 'soft';
+
+function resolveTheme(rawValue) {
+    const value = String(rawValue || '').trim().toLowerCase();
+    return Object.prototype.hasOwnProperty.call(THEMES, value) ? value : DEFAULT_THEME;
+}
+
+function applyTheme(themeKey) {
+    const body = document.body;
+    if (!body) {
+        return;
+    }
+
+    body.classList.remove(THEMES.soft, THEMES.black);
+    body.classList.add(THEMES[themeKey]);
+    body.setAttribute('data-workspace-theme', themeKey);
+}
+
+export function bindWorkspaceThemeControls() {
+    const select = document.getElementById('wsThemeSelect');
+    const storedTheme = (() => {
+        try {
+            return window.localStorage.getItem(THEME_STORAGE_KEY);
+        } catch (e) {
+            return null;
+        }
+    })();
+
+    const initialTheme = resolveTheme(storedTheme);
+    applyTheme(initialTheme);
+
+    if (!select) {
+        return {};
+    }
+
+    select.value = initialTheme;
+    select.addEventListener('change', () => {
+        const nextTheme = resolveTheme(select.value);
+        applyTheme(nextTheme);
+        try {
+            window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+        } catch (e) {
+            // Ignore storage failures and still keep the in-memory theme.
+        }
+    });
+
+    return {
+        applyTheme
+    };
+}

--- a/src/main/resources/static/js/workspace/grid.js
+++ b/src/main/resources/static/js/workspace/grid.js
@@ -220,9 +220,9 @@ export function createGrid(tbody) {
                 '<td class="px-3 sm:px-6 py-2.5"><div class="min-w-0 flex flex-wrap gap-2" data-ws-tags="' + escHtml(encodedTags) + '" tabindex="' + tagsTabIndex + '">' + tagsCell + '</div></td>' +
                 '<td class="pl-3 pr-6 sm:pl-6 sm:pr-4 py-2.5 text-white/55"><div class="min-w-0 whitespace-nowrap">' + escHtml(updated) + '</div></td>' +
                 '<td class="px-2 sm:px-4 py-2.5 text-right">' +
-                    '<div class="inline-flex items-center gap-2" data-work-key="' + escHtml(workKey) + '">' +
-                        '<button type="button" class="ws-row-action ws-row-preview ws-interactive px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="preview" data-work-key="' + escHtml(workKey) + '" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="' + escHtml(previewElementId) + '">' + (isExpanded ? 'Hide preview' : 'Preview') + '</button>' +
-                        '<a class="ws-row-action ws-row-edit ws-interactive px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="edit" data-work-key="' + escHtml(workKey) + '" href="' + escHtml(previewUrl) + '">Edit</a>' +
+                    '<div class="inline-flex items-center gap-2 whitespace-nowrap" data-work-key="' + escHtml(workKey) + '">' +
+                        '<button type="button" class="ws-row-action ws-row-preview ws-interactive min-w-[7.2rem] whitespace-nowrap text-center px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="preview" data-work-key="' + escHtml(workKey) + '" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="' + escHtml(previewElementId) + '">' + (isExpanded ? 'Hide Preview' : 'Preview') + '</button>' +
+                        '<a class="ws-row-action ws-row-edit ws-interactive whitespace-nowrap px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="edit" data-work-key="' + escHtml(workKey) + '" href="' + escHtml(previewUrl) + '">Edit</a>' +
                     '</div>' +
                 '</td>';
 

--- a/src/main/resources/static/js/workspace/grid.js
+++ b/src/main/resources/static/js/workspace/grid.js
@@ -221,7 +221,7 @@ export function createGrid(tbody) {
                 '<td class="pl-3 pr-6 sm:pl-6 sm:pr-4 py-2.5 text-white/55"><div class="min-w-0 whitespace-nowrap">' + escHtml(updated) + '</div></td>' +
                 '<td class="px-2 sm:px-4 py-2.5 text-right">' +
                     '<div class="inline-flex items-center gap-2 whitespace-nowrap" data-work-key="' + escHtml(workKey) + '">' +
-                        '<button type="button" class="ws-row-action ws-row-preview ws-interactive min-w-[7.2rem] whitespace-nowrap text-center px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="preview" data-work-key="' + escHtml(workKey) + '" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="' + escHtml(previewElementId) + '">' + (isExpanded ? 'Hide Preview' : 'Preview') + '</button>' +
+                        '<button type="button" class="ws-row-action ws-row-preview ws-interactive w-[5.5rem] whitespace-nowrap text-center px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="preview" data-work-key="' + escHtml(workKey) + '" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="' + escHtml(previewElementId) + '">' + (isExpanded ? 'Hide Preview' : 'Preview') + '</button>' +
                         '<a class="ws-row-action ws-row-edit ws-interactive whitespace-nowrap px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="edit" data-work-key="' + escHtml(workKey) + '" href="' + escHtml(previewUrl) + '">Edit</a>' +
                     '</div>' +
                 '</td>';

--- a/src/main/resources/static/js/workspace/grid.js
+++ b/src/main/resources/static/js/workspace/grid.js
@@ -221,7 +221,7 @@ export function createGrid(tbody) {
                 '<td class="pl-3 pr-6 sm:pl-6 sm:pr-4 py-2.5 text-white/55"><div class="min-w-0 whitespace-nowrap">' + escHtml(updated) + '</div></td>' +
                 '<td class="px-2 sm:px-4 py-2.5 text-right">' +
                     '<div class="inline-flex items-center gap-2 whitespace-nowrap" data-work-key="' + escHtml(workKey) + '">' +
-                        '<button type="button" class="ws-row-action ws-row-preview ws-interactive w-[5.5rem] whitespace-nowrap text-center px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="preview" data-work-key="' + escHtml(workKey) + '" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="' + escHtml(previewElementId) + '">' + (isExpanded ? 'Hide Preview' : 'Preview') + '</button>' +
+                        '<button type="button" class="ws-row-action ws-row-preview ws-interactive whitespace-nowrap text-center px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="preview" data-work-key="' + escHtml(workKey) + '" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="' + escHtml(previewElementId) + '">' + (isExpanded ? 'Hide Preview' : 'Preview') + '</button>' +
                         '<a class="ws-row-action ws-row-edit ws-interactive whitespace-nowrap px-2.5 py-1.5 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] text-xs" data-action="edit" data-work-key="' + escHtml(workKey) + '" href="' + escHtml(previewUrl) + '">Edit</a>' +
                     '</div>' +
                 '</td>';

--- a/src/main/resources/static/js/workspace/page.js
+++ b/src/main/resources/static/js/workspace/page.js
@@ -19,7 +19,6 @@ const importBtn = document.getElementById('importBtn');
 const importFile = document.getElementById('importFile');
 const importForm = document.getElementById('importForm');
 const tbody = document.getElementById('wsTbody');
-const totalCount = document.getElementById('wsTotalCount');
 const selectAll = document.getElementById('wsSelectAll');
 const searchInput = document.getElementById('wsSearch');
 const filterComponent = document.getElementById('wsFilterComponent');
@@ -44,13 +43,11 @@ const folderTree = document.getElementById('wsFolderTree');
 const folderLoading = document.getElementById('wsFolderLoading');
 const folderEmpty = document.getElementById('wsFolderEmpty');
 const sidebar = document.getElementById('wsSidebar');
-const sidebarToggle = document.getElementById('wsSidebarToggle');
+const sidebarResizeHandle = document.getElementById('wsSidebarResizeHandle');
 const sidebarContent = document.getElementById('wsSidebarContent');
 const sidebarTitle = document.getElementById('wsSidebarTitle');
 const sidebarInner = document.getElementById('wsSidebarInner');
 const sidebarHeader = document.getElementById('wsSidebarHeader');
-const sidebarToggleExpandedHost = document.getElementById('wsSidebarToggleExpandedHost');
-const sidebarToggleCollapsedHost = document.getElementById('wsSidebarToggleCollapsedHost');
 const newFolderButton = document.getElementById('wsNewFolderButton');
 
 const organizeModal = document.getElementById('organizeModal');
@@ -128,7 +125,7 @@ const dataController = createWorkspaceDataController({
     grid,
     selection,
     tbody,
-    totalCount,
+    getTotalCountElement: () => document.getElementById('wsTotalCount'),
     pageInfo,
     prevPageButton,
     nextPageButton,
@@ -150,13 +147,11 @@ const folderTreeController = createWorkspaceFolderTree({
     folderEmpty,
     newFolderButton,
     sidebar,
-    sidebarToggle,
+    sidebarResizeHandle,
     sidebarContent,
     sidebarTitle,
     sidebarInner,
     sidebarHeader,
-    sidebarToggleExpandedHost,
-    sidebarToggleCollapsedHost,
     showNotice: (type, message) => showNotice(type, message),
     onFolderChanged: () => {
         dataController.applyFilters({ resetPage: true });

--- a/src/main/resources/static/js/workspace/page.js
+++ b/src/main/resources/static/js/workspace/page.js
@@ -11,6 +11,7 @@ import { createWorkspaceMoveController } from './features/workspace-move-control
 import { createWorkspaceOrganizeModal } from './features/workspace-organize-modal.js';
 import { bindWorkspacePreviewControls } from './features/workspace-preview-controls.js';
 import { bindWorkspaceRowActions } from './features/workspace-row-actions.js';
+import { bindWorkspaceThemeControls } from './features/workspace-theme-controls.js';
 import { createGrid } from './grid.js';
 import { createSelection } from './selection.js';
 import { createWorkspaceUiState } from './state/workspace-ui-state.js';
@@ -236,6 +237,7 @@ createWorkspaceOrganizeModal({
 });
 
 bindWorkspaceHeaderControls();
+bindWorkspaceThemeControls();
 
 const bulkEdit = createBulkEdit({
     bulkEditButton: bulkEditOpen,

--- a/src/main/resources/static/js/workspace/page.js
+++ b/src/main/resources/static/js/workspace/page.js
@@ -37,6 +37,7 @@ const collapseAllPreviews = document.getElementById('wsCollapsePreviews');
 const importNoticeContainer = document.getElementById('importNoticeContainer');
 const importNotice = document.getElementById('importNotice');
 const importNoticeBadge = document.getElementById('importNoticeBadge');
+const importNoticeOk = document.getElementById('importNoticeOk');
 const importNoticeMessage = document.getElementById('importNoticeMessage');
 const importNoticeClose = document.getElementById('importNoticeClose');
 
@@ -181,7 +182,8 @@ importController = createWorkspaceImportController({
     importForm,
     importNoticeContainer,
     importNotice,
-    importNoticeBadge,
+    importNoticeBadge: importNoticeBadge || importNoticeOk,
+    importNoticeOk,
     importNoticeMessage,
     importNoticeClose,
     onUploadComplete: async () => {

--- a/src/main/resources/templates/landing.html
+++ b/src/main/resources/templates/landing.html
@@ -9,7 +9,7 @@
 	<link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@500;600;700;900&display=swap" rel="stylesheet">
 </head>
 
-<body class="bg-black text-white">
+<body class="bg-[#1E1E1E] text-white">
 	<div class="min-h-screen">
 		<div class="max-w-5xl mx-auto px-8 py-16">
 			<header class="flex items-center justify-between gap-6">
@@ -111,7 +111,7 @@
 
 					<div class="mt-12 grid grid-cols-1 lg:grid-cols-2 gap-8">
 						<!-- Left: The pain -->
-						<section class="border border-white/10 bg-black p-8">
+						<section class="border border-white/10 bg-[#262626] p-8">
 							<div class="flex items-center justify-between gap-4">
 								<h4 class="text-xl font-bold text-white/75">The Old Way</h4>
 								<span class="text-white/40 text-sm">Rigid • Manual • Capped</span>
@@ -122,7 +122,7 @@
 
 							<div class="mt-7 border border-white/10 bg-white/5 p-6">
 								<p class="text-white/40 text-xs uppercase tracking-wider">Example</p>
-								<div class="mt-3 border border-white/10 p-4">
+								<div class="mt-3 border border-white/10 bg-[#2B2B2B] p-4">
 									<div class="flex items-center justify-between text-white/40 text-xs">
 										<span>Bulk delete</span>
 										<span class="text-white/40">100-item cap reached</span>
@@ -164,7 +164,7 @@
 
 							<div class="mt-7 border border-white/10 p-6" style="border-color: rgba(231, 255, 2, 0.25); background-color: rgba(231, 255, 2, 0.06);">
 								<p class="text-black text-xs uppercase tracking-wider font-bold" style="color: #E7FF02;">Workspace preview</p>
-								<div class="mt-3 border border-white/10 bg-black p-4">
+								<div class="mt-3 border border-white/10 bg-[#242424] p-4">
 									<div class="flex items-center justify-between text-xs">
 										<span class="text-white/60">Selected</span>
 										<span style="color: #E7FF02;" class="font-bold">1,247</span>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -7,9 +7,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@900&display=swap" rel="stylesheet">
 </head>
-<body class="bg-black">
+<body class="bg-[#1E1E1E] text-white">
     <div class="min-h-screen flex items-center justify-center">
-        <div class="w-full max-w-md px-8">
+        <div class="w-full max-w-md px-8 py-8 border border-white/10 bg-[#242424]">
             <div class="mb-12 text-center">
                 <h1 class="text-3xl tracking-tight text-white mb-2 uppercase" style="font-family: 'Work Sans', sans-serif; font-weight: 900;">
                     TestStream
@@ -51,7 +51,7 @@
                         name="email" 
                         required
                         autocomplete="email"
-                        class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
+                        class="w-full px-4 py-3 bg-[#2B2B2B] text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
                         placeholder="your@email.com"
                     />
                 </div>
@@ -66,7 +66,7 @@
                         name="password"
                         required
                         autocomplete="current-password"
-                        class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
+                        class="w-full px-4 py-3 bg-[#2B2B2B] text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
                         placeholder="••••••••"
                     />
                 </div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -9,7 +9,7 @@
 </head>
 <body class="bg-[#1E1E1E] text-white">
     <div class="min-h-screen flex items-center justify-center">
-        <div class="w-full max-w-md px-8 py-8 border border-white/10 bg-[#242424]">
+        <div class="w-full max-w-md px-8 py-8 border border-white/15">
             <div class="mb-12 text-center">
                 <h1 class="text-3xl tracking-tight text-white mb-2 uppercase" style="font-family: 'Work Sans', sans-serif; font-weight: 900;">
                     TestStream

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -9,7 +9,7 @@
 </head>
 <body class="bg-[#1E1E1E] text-white">
 	<div class="min-h-screen flex items-center justify-center py-16">
-		<div class="w-full max-w-md px-8 py-6 border border-white/10 bg-[#242424]">
+		<div class="w-full max-w-md px-8 py-6 border border-white/15">
 			<div class="mb-12 text-center">
 				<h1 class="text-3xl tracking-tight text-white mb-2 uppercase" style="font-family: 'Work Sans', sans-serif; font-weight: 900;">
 					TestStream

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -7,9 +7,9 @@
 	<script src="https://cdn.tailwindcss.com"></script>
 	<link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@900&display=swap" rel="stylesheet">
 </head>
-<body class="bg-black">
+<body class="bg-[#1E1E1E] text-white">
 	<div class="min-h-screen flex items-center justify-center py-16">
-		<div class="w-full max-w-md px-8 py-6">
+		<div class="w-full max-w-md px-8 py-6 border border-white/10 bg-[#242424]">
 			<div class="mb-12 text-center">
 				<h1 class="text-3xl tracking-tight text-white mb-2 uppercase" style="font-family: 'Work Sans', sans-serif; font-weight: 900;">
 					TestStream
@@ -39,7 +39,7 @@
 						required
 						autocomplete="email"
 						th:value="${email}"
-						class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
+						class="w-full px-4 py-3 bg-[#2B2B2B] text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
 						placeholder="your@email.com"
 					/>
 					<p th:if="${fieldErrors != null and fieldErrors['email'] != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors['email']}"></p>
@@ -55,7 +55,7 @@
 						name="password"
 						required
 						autocomplete="new-password"
-						class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
+						class="w-full px-4 py-3 bg-[#2B2B2B] text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
 						placeholder="••••••••"
 					/>
 					<p class="text-white/50 text-xs mt-2">Use at least 8 characters.</p>
@@ -72,7 +72,7 @@
 						name="confirmPassword"
 						required
 						autocomplete="new-password"
-						class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
+						class="w-full px-4 py-3 bg-[#2B2B2B] text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
 						placeholder="••••••••"
 					/>
 					<p th:if="${fieldErrors != null and fieldErrors['confirmPassword'] != null}" class="text-red-500 text-xs mt-2" th:text="${fieldErrors['confirmPassword']}"></p>
@@ -88,7 +88,7 @@
 						id="teamCode"
 						name="teamCode"
 						th:value="${teamCode}"
-						class="w-full px-4 py-3 bg-black text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
+						class="w-full px-4 py-3 bg-[#2B2B2B] text-white border border-white/30 focus:border-[#E7FF02] focus:outline-none transition-colors placeholder:text-white/40"
 						placeholder="ABC123"
 					/>
 					<p class="text-white/50 text-xs mt-2">Leave blank to create a new team.</p>

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -69,8 +69,7 @@
 			background-color: var(--ws-soft-control) !important;
 		}
 
-		body.workspace-theme-soft #workspaceAccountDropdown,
-		body.workspace-theme-soft #workspaceTeamCodeDropdown {
+		body.workspace-theme-soft #workspaceSettingsDropdown {
 			background-color: var(--ws-soft-dropdown) !important;
 		}
 

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -73,6 +73,13 @@
 			background-color: var(--ws-soft-dropdown) !important;
 		}
 
+		body.workspace-theme-soft #importNotice,
+		body.workspace-theme-soft #workspaceFlashContainer [data-flash-item],
+		body.workspace-theme-soft #bulkBarCard {
+			background-color: #2b2b2b !important;
+			border-color: rgba(255, 255, 255, 0.22) !important;
+		}
+
 		body.workspace-theme-soft #wsGridFrame,
 		body.workspace-theme-soft #wsWorkspaceHeader,
 		body.workspace-theme-soft #wsGridTable .border-b,
@@ -93,6 +100,12 @@
 
 		body.workspace-theme-black .bg-black {
 			background-color: #000000 !important;
+		}
+
+		body.workspace-theme-black #importNotice,
+		body.workspace-theme-black #workspaceFlashContainer [data-flash-item],
+		body.workspace-theme-black #bulkBarCard {
+			background-color: rgba(0, 0, 0, 0.95) !important;
 		}
 
 		#wsWorkspaceHeader {

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -149,11 +149,40 @@
 		.ws-preview-card {
 			border-top: 1px solid rgba(255, 255, 255, 0.08);
 		}
+
+		/* Subtle, fixed-width sidebar scrollbar (no oversized hover growth). */
+		#wsSidebarContent {
+			scrollbar-width: thin;
+			scrollbar-color: rgba(163, 163, 163, 0.45) transparent;
+		}
+
+		#wsSidebarContent::-webkit-scrollbar {
+			width: 8px;
+		}
+
+		#wsSidebarContent::-webkit-scrollbar-track {
+			background: transparent;
+		}
+
+		#wsSidebarContent::-webkit-scrollbar-thumb {
+			background-color: rgba(163, 163, 163, 0.45);
+			border-radius: 999px;
+			border: 2px solid transparent;
+			background-clip: padding-box;
+		}
+
+		#wsSidebarContent:hover::-webkit-scrollbar {
+			width: 8px;
+		}
+
+		#wsSidebarContent:hover::-webkit-scrollbar-thumb {
+			background-color: rgba(163, 163, 163, 0.62);
+		}
 	</style>
 </head>
 
-<body class="bg-black text-white workspace-theme-soft">
-	<div class="min-h-screen">
+<body class="bg-black text-white workspace-theme-soft overflow-hidden">
+	<div class="h-dvh min-h-screen flex flex-col overflow-hidden">
 		<th:block th:replace="~{workspace/_header :: header}"></th:block>
 		<th:block th:replace="~{workspace/_notices :: notices}"></th:block>
 		<th:block th:replace="~{workspace/_main :: mainContent}"></th:block>

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -32,8 +32,7 @@
 			box-shadow: inset 0 2px 0 rgba(231, 255, 2, 0.95);
 		}
 
-		/* Stronger grid-only borders for the test-case table. */
-		#wsGridTopBar {
+		#wsWorkspaceHeader {
 			border-bottom-color: rgba(255, 255, 255, 0.38) !important;
 		}
 

--- a/src/main/resources/templates/workspace.html
+++ b/src/main/resources/templates/workspace.html
@@ -32,6 +32,70 @@
 			box-shadow: inset 0 2px 0 rgba(231, 255, 2, 0.95);
 		}
 
+		body.workspace-theme-soft {
+			--ws-soft-page: #1e1e1e;
+			--ws-soft-header: #242424;
+			--ws-soft-sidebar: #2a2a2a;
+			--ws-soft-grid: #232323;
+			--ws-soft-footer: #262626;
+			--ws-soft-control: #303030;
+			--ws-soft-dropdown: #2d2d2d;
+			--ws-soft-border-strong: rgba(255, 255, 255, 0.30);
+			--ws-soft-border-muted: rgba(255, 255, 255, 0.18);
+			background-color: var(--ws-soft-page);
+			color: rgba(255, 255, 255, 0.96);
+		}
+
+		body.workspace-theme-soft #wsWorkspaceHeader {
+			background-color: var(--ws-soft-header) !important;
+		}
+
+		body.workspace-theme-soft #wsSidebar {
+			background-color: var(--ws-soft-sidebar) !important;
+		}
+
+		body.workspace-theme-soft #wsGridFrame {
+			background-color: var(--ws-soft-grid);
+		}
+
+		body.workspace-theme-soft #wsGridFooter {
+			background-color: var(--ws-soft-footer);
+		}
+
+		body.workspace-theme-soft input.bg-black,
+		body.workspace-theme-soft select.bg-black,
+		body.workspace-theme-soft div.bg-black,
+		body.workspace-theme-soft nav.bg-black {
+			background-color: var(--ws-soft-control) !important;
+		}
+
+		body.workspace-theme-soft #workspaceAccountDropdown,
+		body.workspace-theme-soft #workspaceTeamCodeDropdown {
+			background-color: var(--ws-soft-dropdown) !important;
+		}
+
+		body.workspace-theme-soft #wsGridFrame,
+		body.workspace-theme-soft #wsWorkspaceHeader,
+		body.workspace-theme-soft #wsGridTable .border-b,
+		body.workspace-theme-soft #wsTbody .ws-row,
+		body.workspace-theme-soft #wsTbody .ws-preview-row {
+			border-color: var(--ws-soft-border-strong) !important;
+		}
+
+		body.workspace-theme-soft #wsSidebar,
+		body.workspace-theme-soft #wsGridFooter {
+			border-color: var(--ws-soft-border-muted) !important;
+		}
+
+		body.workspace-theme-black {
+			background-color: #000000;
+			color: rgba(255, 255, 255, 0.96);
+		}
+
+		body.workspace-theme-black .bg-black {
+			background-color: #000000 !important;
+		}
+
 		#wsWorkspaceHeader {
 			border-bottom-color: rgba(255, 255, 255, 0.38) !important;
 		}
@@ -76,7 +140,7 @@
 	</style>
 </head>
 
-<body class="bg-black text-white">
+<body class="bg-black text-white workspace-theme-soft">
 	<div class="min-h-screen">
 		<th:block th:replace="~{workspace/_header :: header}"></th:block>
 		<th:block th:replace="~{workspace/_notices :: notices}"></th:block>

--- a/src/main/resources/templates/workspace/_bulk-bar.html
+++ b/src/main/resources/templates/workspace/_bulk-bar.html
@@ -4,7 +4,7 @@
 	<th:block th:fragment="bulkBar">
 		<div id="bulkBar" class="fixed left-0 right-0 bottom-0 z-40 hidden">
 			<div class="w-full px-6 sm:px-8 pb-6">
-				<div class="border border-white/10 bg-black/95 backdrop-blur p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+				<div id="bulkBarCard" class="border border-white/10 bg-black/95 backdrop-blur p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
 					style="border-color: rgba(231, 255, 2, 0.25);">
 					<div class="flex items-center gap-3">
 						<div class="w-2 h-2 rounded-full" style="background-color: #E7FF02;"></div>

--- a/src/main/resources/templates/workspace/_header.html
+++ b/src/main/resources/templates/workspace/_header.html
@@ -51,6 +51,13 @@
 							Export
 						</a>
 					</div>
+					<div class="flex items-center gap-2">
+						<label for="wsThemeSelect" class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Theme</label>
+						<select id="wsThemeSelect" class="bg-black border border-white/20 px-3 py-2 text-xs text-white/80 focus:outline-none focus:border-[#E7FF02]">
+							<option value="soft">Dark Gray</option>
+							<option value="black">High Contrast</option>
+						</select>
+					</div>
 
 					<div class="flex items-center gap-3">
 						<div class="hidden sm:flex items-start gap-4">

--- a/src/main/resources/templates/workspace/_header.html
+++ b/src/main/resources/templates/workspace/_header.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 	<th:block th:fragment="header">
-		<header class="border-b border-white/10">
+		<header id="wsWorkspaceHeader" class="border-b border-white/10">
 			<div class="w-full px-6 sm:px-8 py-5 flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
 				<div class="flex-1 min-w-0">
 					<div class="flex flex-col sm:flex-row sm:items-center gap-3">

--- a/src/main/resources/templates/workspace/_header.html
+++ b/src/main/resources/templates/workspace/_header.html
@@ -111,7 +111,7 @@
 							</div>
 
 							<div class="mt-4 pt-4 border-t border-white/10">
-								<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Account</p>
+								<p id="workspaceAccountToggle" class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Account</p>
 								<p class="mt-1 text-sm text-white/80 break-words" th:text="${userEmail != null ? userEmail : 'Signed in'}">Signed in</p>
 							</div>
 

--- a/src/main/resources/templates/workspace/_header.html
+++ b/src/main/resources/templates/workspace/_header.html
@@ -15,7 +15,7 @@
 							</div>
 						</div>
 
-						<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:w-[34rem]">
+						<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 flex-1">
 							<div>
 								<label class="block text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Component</label>
 								<select id="wsFilterComponent" class="mt-2 w-full bg-black border border-white/15 px-3 py-3 text-sm text-white/85 focus:outline-none focus:border-[#E7FF02]">
@@ -50,97 +50,79 @@
 						<a th:href="@{/workspace/export}" class="px-4 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-sm">
 							Export
 						</a>
-					</div>
-					<div class="flex items-center gap-2">
-						<label for="wsThemeSelect" class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Theme</label>
-						<select id="wsThemeSelect" class="bg-black border border-white/20 px-3 py-2 text-xs text-white/80 focus:outline-none focus:border-[#E7FF02]">
-							<option value="soft">Dark Gray</option>
-							<option value="black">High Contrast</option>
-						</select>
-					</div>
+					
+					<div class="relative">
+						<button
+							type="button"
+							id="workspaceSettingsToggle"
+							class="w-[46px] h-[38px] p-0 inline-flex items-center justify-center leading-none border border-white/20 hover:border-[#E7FF02] transition-colors text-sm"
+							aria-haspopup="true"
+							aria-controls="workspaceSettingsDropdown"
+							aria-expanded="false"
+							aria-label="Workspace settings"
+						>
+							<svg id="workspaceSettingsIcon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 90" fill="none" class="block w-5 h-5 origin-center transform-gpu transition-transform duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] pointer-events-none">
+								<path fill="#A3A3A3" d="M 52.1 90 H 37.9 c -2.867 0 -5.2 -2.333 -5.2 -5.2 v -2.114 c 0 -0.329 -0.191 -0.634 -0.454 -0.725 c -1.482 -0.511 -2.955 -1.122 -4.375 -1.816 c -0.246 -0.118 -0.576 -0.046 -0.802 0.18 l -1.516 1.516 c -0.981 0.982 -2.288 1.523 -3.677 1.523 c -1.389 0 -2.695 -0.541 -3.677 -1.524 L 8.16 71.799 c -2.027 -2.027 -2.027 -5.326 0 -7.354 l 1.516 -1.516 c 0.223 -0.223 0.299 -0.56 0.181 -0.8 c -0.695 -1.423 -1.307 -2.895 -1.818 -4.377 C 7.947 57.49 7.643 57.3 7.314 57.3 H 5.2 c -2.867 0 -5.2 -2.333 -5.2 -5.2 V 37.9 c 0 -2.867 2.333 -5.2 5.2 -5.2 h 2.115 c 0.329 0 0.633 -0.19 0.724 -0.454 c 0.513 -1.483 1.124 -2.956 1.817 -4.374 c 0.12 -0.246 0.046 -0.576 -0.181 -0.802 L 8.16 25.555 c -2.027 -2.028 -2.027 -5.327 0 -7.354 L 18.201 8.159 c 0.982 -0.982 2.288 -1.522 3.677 -1.522 c 1.389 0 2.695 0.541 3.677 1.522 l 1.516 1.517 c 0.224 0.223 0.559 0.3 0.801 0.18 c 1.418 -0.693 2.891 -1.305 4.375 -1.818 C 32.51 7.947 32.7 7.643 32.7 7.314 V 5.2 c 0 -2.867 2.333 -5.2 5.2 -5.2 h 14.2 c 2.867 0 5.2 2.333 5.2 5.2 v 2.115 c 0 0.329 0.19 0.633 0.453 0.724 c 1.482 0.512 2.954 1.124 4.375 1.818 c 0.247 0.118 0.575 0.045 0.802 -0.181 l 1.516 -1.516 c 2.027 -2.027 5.326 -2.027 7.354 0 L 81.84 18.2 c 2.027 2.028 2.027 5.327 0 7.354 l -1.516 1.516 c -0.227 0.227 -0.301 0.556 -0.181 0.802 c 0.695 1.42 1.307 2.893 1.818 4.376 c 0.09 0.262 0.395 0.452 0.724 0.452 H 84.8 c 2.867 0 5.2 2.333 5.2 5.2 V 52.1 c 0 2.867 -2.333 5.2 -5.2 5.2 h -2.114 c -0.329 0 -0.634 0.19 -0.725 0.454 c -0.51 1.478 -1.121 2.95 -1.815 4.373 c -0.119 0.244 -0.044 0.58 0.179 0.803 l 1.516 1.516 c 2.027 2.027 2.027 5.326 0 7.354 L 71.799 81.84 c -0.982 0.982 -2.288 1.523 -3.677 1.523 c -1.39 0 -2.696 -0.542 -3.678 -1.525 l -1.514 -1.513 c -0.228 -0.226 -0.557 -0.302 -0.803 -0.182 c -1.42 0.695 -2.893 1.307 -4.376 1.818 c -0.262 0.09 -0.452 0.395 -0.452 0.724 V 84.8 C 57.3 87.667 54.967 90 52.1 90 z M 39.7 83 h 10.6 v -0.314 c 0 -3.322 2.076 -6.272 5.167 -7.34 c 1.216 -0.42 2.422 -0.921 3.588 -1.491 c 2.936 -1.434 6.481 -0.822 8.824 1.521 l 0.243 0.242 l 7.495 -7.495 l -0.242 -0.243 c -2.345 -2.344 -2.955 -5.891 -1.519 -8.825 c 0.569 -1.166 1.07 -2.373 1.488 -3.585 c 1.068 -3.093 4.019 -5.169 7.341 -5.169 H 83 V 39.7 h -0.314 c -3.322 0 -6.272 -2.076 -7.34 -5.167 c -0.42 -1.216 -0.921 -2.422 -1.491 -3.588 c -1.434 -2.936 -0.823 -6.482 1.521 -8.825 l 0.242 -0.243 l -7.495 -7.495 l -0.243 0.243 c -2.344 2.344 -5.89 2.953 -8.824 1.52 c -1.166 -0.57 -2.373 -1.071 -3.587 -1.491 c -3.091 -1.067 -5.168 -4.017 -5.168 -7.34 V 7 H 39.7 v 0.314 c 0 3.323 -2.077 6.272 -5.168 7.34 c -1.217 0.42 -2.424 0.922 -3.587 1.491 c -2.936 1.434 -6.481 0.823 -8.825 -1.52 l -0.243 -0.243 l -7.495 7.495 l 0.243 0.243 c 2.343 2.344 2.954 5.89 1.52 8.825 c -0.568 1.163 -1.07 2.37 -1.49 3.587 c -1.068 3.092 -4.018 5.168 -7.34 5.168 H 7 v 10.6 h 0.314 c 3.323 0 6.272 2.077 7.34 5.168 c 0.419 1.214 0.921 2.421 1.491 3.588 c 1.435 2.933 0.824 6.479 -1.52 8.823 l -0.243 0.243 l 7.496 7.495 l 0.242 -0.242 c 2.344 -2.346 5.891 -2.954 8.826 -1.52 c 1.164 0.568 2.37 1.07 3.585 1.489 c 3.092 1.068 5.168 4.019 5.168 7.341 V 83 z M 45.028 70.402 c -6.738 0 -13.204 -2.652 -17.991 -7.439 c -5.265 -5.265 -7.947 -12.561 -7.359 -20.016 c 0.97 -12.296 10.974 -22.3 23.27 -23.27 c 7.457 -0.588 14.751 2.095 20.016 7.359 c 5.265 5.266 7.947 12.561 7.36 20.017 c -0.971 12.297 -10.975 22.3 -23.271 23.27 l 0 0 C 46.376 70.376 45.701 70.402 45.028 70.402 z M 44.969 26.598 c -0.489 0 -0.979 0.02 -1.471 0.058 c -8.899 0.702 -16.14 7.943 -16.842 16.843 c -0.427 5.41 1.516 10.7 5.331 14.515 s 9.1 5.761 14.516 5.331 l 0 0 c 8.899 -0.701 16.141 -7.941 16.843 -16.842 c 0.427 -5.41 -1.517 -10.701 -5.331 -14.516 C 54.546 28.519 49.857 26.598 44.969 26.598 z" />
+							</svg>
+						</button>
 
-					<div class="flex items-center gap-3">
-						<div class="hidden sm:flex items-start gap-4">
-							<div class="relative text-right min-w-0">
-								<button
-									type="button"
-									class="text-xs uppercase tracking-wider text-white/45 hover:text-[#E7FF02] transition-colors select-none"
-									style="font-family: 'Work Sans', sans-serif; font-weight: 700;"
-									data-workspace-dropdown-toggle="account"
-									aria-haspopup="true"
-									aria-controls="workspaceAccountDropdown"
-									aria-expanded="false"
-									id="workspaceAccountToggle"
-								>
-									Account <span aria-hidden="true" class="text-white/45"></span>
-								</button>
-								<div
-									id="workspaceAccountDropdown"
-									class="hidden absolute right-0 mt-2 z-50 w-64 border border-white/20 bg-black px-4 py-3 text-left"
-									role="dialog"
-									aria-label="Account details"
-									aria-hidden="true"
-								>
-									<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Signed in as</p>
-									<p class="mt-1 text-sm text-white/80 break-words" th:text="${userEmail != null ? userEmail : 'Signed in'}">Signed in</p>
-								</div>
+						<div
+							id="workspaceSettingsDropdown"
+							class="hidden absolute right-0 mt-2 z-50 w-[19rem] border border-white/20 bg-black px-4 py-4 text-left"
+							role="dialog"
+							aria-label="Workspace settings"
+							aria-hidden="true"
+						>
+							<div>
+								<label for="wsThemeSelect" class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Theme</label>
+								<select id="wsThemeSelect" class="mt-2 w-full bg-black border border-white/20 px-3 py-2 text-sm text-white/80 focus:outline-none focus:border-[#E7FF02]">
+									<option value="soft">Dark Gray</option>
+									<option value="black">High Contrast</option>
+								</select>
 							</div>
 
-							<div class="relative text-right min-w-0" th:if="${teamKey != null}">
-								<button
-									type="button"
-									class="text-xs uppercase tracking-wider text-white/45 hover:text-[#E7FF02] transition-colors select-none"
-									style="font-family: 'Work Sans', sans-serif; font-weight: 700;"
-									data-workspace-dropdown-toggle="team"
-									aria-haspopup="true"
-									aria-controls="workspaceTeamCodeDropdown"
-									aria-expanded="false"
-									id="workspaceTeamCodeToggle"
-								>
-									Team code <span aria-hidden="true" class="text-white/45"></span>
-								</button>
-								<div
-									id="workspaceTeamCodeDropdown"
-									class="hidden absolute right-0 mt-2 z-50 w-64 border border-white/20 bg-black px-4 py-3 text-left"
-									role="dialog"
-									aria-label="Team code"
-									aria-hidden="true"
-								>
-									<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Team code</p>
-									<div class="mt-2 flex items-center justify-between gap-2">
-										<div
-											id="workspaceTeamCodeValue"
-											class="font-mono text-sm text-white/80 tracking-widest cursor-pointer select-text transition-colors hover:text-white"
-											th:text="${teamKey}"
-											title="Copy to clipboard"
-											role="button"
-											tabindex="0"
-										>
-											TEAMCODE
-										</div>
-										<button
-											type="button"
-											class="shrink-0 p-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors"
-											aria-label="Copy team code"
-											title="Copy to clipboard"
-											data-workspace-copy-team-code
-										>
-											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4">
-												<rect x="9" y="9" width="10" height="10" rx="1"></rect>
-												<rect x="5" y="5" width="10" height="10" rx="1"></rect>
-											</svg>
-										</button>
+							<div class="mt-4 pt-4 border-t border-white/10" th:if="${teamKey != null}">
+								<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Team code</p>
+								<div class="mt-2 flex items-center justify-between gap-2">
+									<div
+										id="workspaceTeamCodeValue"
+										class="font-mono text-sm text-white/80 tracking-widest cursor-pointer select-text transition-colors hover:text-white"
+										th:text="${teamKey}"
+										title="Copy to clipboard"
+										role="button"
+										tabindex="0"
+									>
+										TEAMCODE
 									</div>
-									<div class="text-xs text-white/45 mt-2" id="workspaceCopyTeamCodeStatus" aria-live="polite"></div>
+									<button
+										type="button"
+										class="shrink-0 p-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors"
+										aria-label="Copy team code"
+										title="Copy to clipboard"
+										data-workspace-copy-team-code
+									>
+										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4">
+											<rect x="9" y="9" width="10" height="10" rx="1"></rect>
+											<rect x="5" y="5" width="10" height="10" rx="1"></rect>
+										</svg>
+									</button>
 								</div>
+								<div class="text-xs text-white/45 mt-2" id="workspaceCopyTeamCodeStatus" aria-live="polite"></div>
 							</div>
+
+							<div class="mt-4 pt-4 border-t border-white/10">
+								<p class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Account</p>
+								<p class="mt-1 text-sm text-white/80 break-words" th:text="${userEmail != null ? userEmail : 'Signed in'}">Signed in</p>
+							</div>
+
+							<form class="mt-4 pt-4 border-t border-white/10" th:action="@{/logout}" method="post">
+								<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+								<button type="submit" class="w-full px-4 py-2 text-black font-bold hover:opacity-80 transition-opacity text-sm" style="background-color: #E7FF02;">
+									Logout
+								</button>
+							</form>
 						</div>
-						<form th:action="@{/logout}" method="post">
-							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-							<button type="submit" class="px-4 py-2 text-black font-bold hover:opacity-80 transition-opacity text-sm" style="background-color: #E7FF02;">
-								Logout
-							</button>
-						</form>
+					</div>
 					</div>
 				</div>
 			</div>

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -4,8 +4,8 @@
 	<th:block th:fragment="mainContent">
 		<main class="w-full px-0 sm:px-0">
 			<div class="flex min-h-[calc(100vh-12rem)]">
-				<aside id="wsSidebar" class="w-[18rem] sm:w-[20rem] border-r border-white/10 bg-black shrink-0">
-					<div id="wsSidebarInner" class="px-6 py-5">
+				<aside id="wsSidebar" class="w-[18rem] sm:w-[20rem] border-r border-white/10 bg-black shrink-0 self-stretch min-h-0 flex flex-col">
+					<div id="wsSidebarInner" class="px-6 py-5 flex-1 min-h-0 flex flex-col">
 						<div id="wsSidebarHeader" class="flex items-center justify-between gap-3">
 							<button
 								id="wsNewFolderButton"
@@ -19,7 +19,7 @@
 								<span id="wsTotalCount" class="text-white/70" th:text="${testCaseCount != null ? testCaseCount : '-'}">-</span>
 							</p>
 						</div>
-						<div id="wsSidebarContent" class="mt-4" aria-label="Folder tree">
+						<div id="wsSidebarContent" class="mt-4 flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-1" aria-label="Folder tree">
 							<div id="wsFolderLoading" class="hidden text-xs text-white/45" aria-hidden="true">Loading folders...</div>
 							<div id="wsFolderEmpty" class="hidden text-xs text-white/45">No folders found.</div>
 							<nav id="wsFolderTree" class="mt-2 space-y-1"></nav>

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -2,8 +2,8 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 	<th:block th:fragment="mainContent">
-		<main class="w-full px-0 sm:px-0">
-			<div class="flex min-h-[calc(100vh-12rem)]">
+		<main class="w-full px-0 sm:px-0 flex-1 min-h-0 flex flex-col">
+			<div class="flex flex-1 min-h-0">
 				<aside id="wsSidebar" class="w-[18rem] sm:w-[20rem] border-r border-white/10 bg-black shrink-0 self-stretch min-h-0 flex flex-col">
 					<div id="wsSidebarInner" class="px-6 py-5 flex-1 min-h-0 flex flex-col">
 						<div id="wsSidebarHeader" class="flex items-center justify-between gap-3">
@@ -34,8 +34,8 @@
 					aria-orientation="vertical"
 				></div>
 
-				<section class="flex-1 min-w-0">
-					<div id="wsGridFrame" class="overflow-x-hidden">
+				<section class="flex-1 min-w-0 min-h-0 flex flex-col">
+					<div id="wsGridFrame" class="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
 						<table id="wsGridTable" class="w-full table-fixed text-sm">
 							<thead class="text-white/50">
 								<tr class="border-b border-white/10">

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -60,7 +60,7 @@
 					</div>
 				</section>
 			</div>
-			<div class="px-6 sm:px-8 py-4 border-t border-white/10 flex items-center justify-between gap-3">
+			<div id="wsGridFooter" class="px-6 sm:px-8 py-4 border-t border-white/10 flex items-center justify-between gap-3">
 				<p id="wsPageInfo" class="text-xs text-white/45">Page 1 of 1</p>
 				<div class="flex items-center gap-2">
 					<button id="wsCollapsePreviews" type="button" class="hidden px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-[11px] uppercase tracking-wider text-white/70">

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -3,25 +3,6 @@
 <body>
 	<th:block th:fragment="mainContent">
 		<main class="w-full px-0 sm:px-0">
-			<div id="wsGridTopBar" class="px-6 sm:px-8 py-6 border-b border-white/10">
-				<div class="flex items-center justify-between gap-6">
-					<div class="flex items-start gap-3 min-w-0">
-						<div id="wsSidebarToggleCollapsedHost" class="hidden shrink-0"></div>
-						<div class="min-w-0">
-							<h1 class="text-base uppercase tracking-wider text-white/70" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Test cases</h1>
-							<p class="text-xs text-white/45 mt-1">Click row body to select. Preview expands inline under each test case.</p>
-						</div>
-					</div>
-					<div class="text-right">
-						<p class="text-xs text-white/45">Total</p>
-						<p id="wsTotalCount" class="text-sm text-white/70" th:text="${testCaseCount != null ? testCaseCount : '-'}">-</p>
-						<button id="wsCollapsePreviews" type="button" class="hidden mt-2 px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-[11px] uppercase tracking-wider text-white/70">
-							Collapse all previews
-						</button>
-					</div>
-				</div>
-			</div>
-
 			<div class="flex min-h-[calc(100vh-12rem)]">
 				<aside id="wsSidebar" class="w-[18rem] sm:w-[20rem] border-r border-white/10 bg-black shrink-0">
 					<div id="wsSidebarInner" class="px-6 py-5">
@@ -36,20 +17,6 @@
 									New Folder
 								</button>
 							</div>
-							<div id="wsSidebarToggleExpandedHost" class="shrink-0">
-								<button
-									id="wsSidebarToggle"
-									type="button"
-									class="shrink-0 h-10 w-10 flex items-center justify-center border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-white/70"
-									aria-label="Collapse repository sidebar"
-									aria-controls="wsSidebar"
-									aria-expanded="true"
-								>
-									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="w-4 h-4">
-										<path d="M15 6l-6 6 6 6" />
-									</svg>
-								</button>
-							</div>
 						</div>
 						<div id="wsSidebarContent" class="mt-4" aria-label="Folder tree">
 							<div id="wsFolderLoading" class="hidden text-xs text-white/45" aria-hidden="true">Loading folders...</div>
@@ -58,6 +25,13 @@
 						</div>
 					</div>
 				</aside>
+				<div
+					id="wsSidebarResizeHandle"
+					class="w-2 shrink-0 cursor-col-resize bg-white/10 hover:bg-[#E7FF02]/70 transition-colors"
+					role="separator"
+					aria-label="Resize directory sidebar"
+					aria-orientation="vertical"
+				></div>
 
 				<section class="flex-1 min-w-0">
 					<div id="wsGridFrame" class="overflow-x-hidden">
@@ -89,6 +63,9 @@
 			<div class="px-6 sm:px-8 py-4 border-t border-white/10 flex items-center justify-between gap-3">
 				<p id="wsPageInfo" class="text-xs text-white/45">Page 1 of 1</p>
 				<div class="flex items-center gap-2">
+					<button id="wsCollapsePreviews" type="button" class="hidden px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-[11px] uppercase tracking-wider text-white/70">
+						Collapse all previews
+					</button>
 					<button id="wsPrevPage" type="button" class="px-3 py-2 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs disabled:opacity-40 disabled:cursor-not-allowed">
 						Previous
 					</button>

--- a/src/main/resources/templates/workspace/_main.html
+++ b/src/main/resources/templates/workspace/_main.html
@@ -7,16 +7,17 @@
 				<aside id="wsSidebar" class="w-[18rem] sm:w-[20rem] border-r border-white/10 bg-black shrink-0">
 					<div id="wsSidebarInner" class="px-6 py-5">
 						<div id="wsSidebarHeader" class="flex items-center justify-between gap-3">
-							<div class="flex items-center gap-2 min-w-0">
-								<p id="wsSidebarTitle" class="text-xs uppercase tracking-wider text-white/45" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">Directory</p>
-								<button
-									id="wsNewFolderButton"
-									type="button"
-									class="px-2 py-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-[10px] uppercase tracking-wider text-white/75"
-								>
-									New Folder
-								</button>
-							</div>
+							<button
+								id="wsNewFolderButton"
+								type="button"
+								class="px-2 py-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-[10px] uppercase tracking-wider text-white/75"
+							>
+								New Folder
+							</button>
+							<p id="wsSidebarTitle" class="text-[11px] uppercase tracking-wider text-white/45 whitespace-nowrap" style="font-family: 'Work Sans', sans-serif; font-weight: 700;">
+								Test cases:
+								<span id="wsTotalCount" class="text-white/70" th:text="${testCaseCount != null ? testCaseCount : '-'}">-</span>
+							</p>
 						</div>
 						<div id="wsSidebarContent" class="mt-4" aria-label="Folder tree">
 							<div id="wsFolderLoading" class="hidden text-xs text-white/45" aria-hidden="true">Loading folders...</div>

--- a/src/main/resources/templates/workspace/_notices.html
+++ b/src/main/resources/templates/workspace/_notices.html
@@ -37,7 +37,9 @@
 			<div id="importNotice" class="border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80">
 				<div class="flex items-start justify-between gap-3">
 					<div class="min-w-0">
-						<span id="importNoticeBadge" class="font-bold text-black px-2 py-1 mr-3 bg-white/70">Error</span>
+						<button id="importNoticeOk" type="button" class="font-bold text-black px-2 py-1 mr-3 bg-white/70 border border-transparent hover:border-[#E7FF02] transition-colors" aria-label="Acknowledge notification">
+							OK
+						</button>
 						<span id="importNoticeMessage" class="whitespace-pre-line">Import status.</span>
 					</div>
 					<button id="importNoticeClose" type="button" aria-label="Dismiss notification" class="shrink-0 px-2 py-1 border border-white/20 hover:border-[#E7FF02] hover:text-[#E7FF02] transition-colors text-xs leading-none">

--- a/src/main/resources/templates/workspace/_notices.html
+++ b/src/main/resources/templates/workspace/_notices.html
@@ -2,8 +2,8 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 	<th:block th:fragment="notices">
-		<div id="workspaceFlashContainer" class="px-6 sm:px-8 pt-5 space-y-3" th:if="${importSuccessMessage != null or importErrorMessage != null}">
-			<div data-flash-item th:if="${importSuccessMessage != null}" class="border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80" style="border-color: rgba(231, 255, 2, 0.35);">
+		<div id="workspaceFlashContainer" class="fixed top-4 left-1/2 -translate-x-1/2 z-[1300] w-[min(42rem,calc(100vw-2rem))] space-y-3 pointer-events-none" th:if="${importSuccessMessage != null or importErrorMessage != null}">
+			<div data-flash-item th:if="${importSuccessMessage != null}" class="pointer-events-auto border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80" style="border-color: rgba(231, 255, 2, 0.35);">
 				<div class="flex items-start justify-between gap-3">
 					<div class="min-w-0">
 						<span class="font-bold text-black px-2 py-1 mr-3" style="background-color: #E7FF02;">OK</span>
@@ -17,7 +17,7 @@
 					</button>
 				</div>
 			</div>
-			<div data-flash-item th:if="${importErrorMessage != null}" class="border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80">
+			<div data-flash-item th:if="${importErrorMessage != null}" class="pointer-events-auto border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80">
 				<div class="flex items-start justify-between gap-3">
 					<div class="min-w-0">
 						<span class="font-bold text-black px-2 py-1 mr-3 bg-white/70">Error</span>
@@ -33,8 +33,8 @@
 			</div>
 		</div>
 
-		<div id="importNoticeContainer" class="px-6 sm:px-8 pt-5 hidden" aria-live="polite">
-			<div id="importNotice" class="border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80">
+		<div id="importNoticeContainer" class="fixed top-4 left-1/2 -translate-x-1/2 z-[1300] w-[min(42rem,calc(100vw-2rem))] hidden pointer-events-none" aria-live="polite">
+			<div id="importNotice" class="pointer-events-auto border border-white/10 bg-black/95 px-4 py-3 text-sm text-white/80">
 				<div class="flex items-start justify-between gap-3">
 					<div class="min-w-0">
 						<button id="importNoticeOk" type="button" class="font-bold text-black px-2 py-1 mr-3 bg-white/70 border border-transparent hover:border-[#E7FF02] transition-colors" aria-label="Acknowledge notification">

--- a/src/test/java/com/formswim/teststream/workspace/WorkspaceFilteringIntegrationTests.java
+++ b/src/test/java/com/formswim/teststream/workspace/WorkspaceFilteringIntegrationTests.java
@@ -178,7 +178,21 @@ class WorkspaceFilteringIntegrationTests {
             .andExpect(content().string(containsString("<option value=\"Fail\">Fail</option>")))
             .andExpect(content().string(containsString("id=\"organizeModal\"")))
             .andExpect(content().string(containsString("id=\"drawer\"")))
+            .andExpect(content().string(containsString("id=\"workspaceSettingsToggle\"")))
+            .andExpect(content().string(containsString("id=\"wsSidebarResizeHandle\"")))
             .andExpect(content().string(containsString("id=\"workspaceAccountToggle\"")));
+    }
+
+    @Test
+    void workspacePageRendersServerFlashNoticeHooksWhenMessagesProvided() throws Exception {
+        mockMvc.perform(get("/workspace")
+                .with(user("team1.user@example.com").roles("USER"))
+                .param("importSuccess", "Upload applied"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("workspace"))
+            .andExpect(content().string(containsString("id=\"workspaceFlashContainer\"")))
+            .andExpect(content().string(containsString("data-workspace-flash-dismiss")))
+            .andExpect(content().string(containsString("Upload applied")));
     }
 
     @Test


### PR DESCRIPTION
closes #62 & #63 
**MAJOR UI/UX changes to the workspace**

## Summary
This PR delivers a full workspace UI refinement focused on usability, visual consistency, and modular frontend architecture.  
It removes unused grid chrome, improves directory/sidebar behavior, introduces theme controls, standardizes notifications/modals, and tightens responsive behavior for table actions.

## What Changed

### 1. Workspace layout + shell behavior
- Removed the old top grid intro bar (`Test cases / Click row body... / Total` block).
- Moved grid + directory area directly under the header.
- Converted workspace into a fixed-height split-pane shell:
  - Independent vertical scrolling for directory and grid.
  - Workspace page scroll disabled to avoid long-page drift UX.
- Added strong visual divider alignment between header and grid.
- Improved adaptive sizing so panes better fit viewport dimensions.

<img width="1692" height="1099" alt="image" src="https://github.com/user-attachments/assets/b3f2c45b-6b2c-4b0c-9e16-d0e07a13a27a" />


### 2. Directory sidebar UX
- Removed sidebar collapse/expand arrow controls.
- Added draggable sidebar resize handle.
- Sidebar can be dragged closed and reopened by dragging back out.
- Added close snap behavior and clipping/overflow rules to prevent controls/text overlapping into the grid.
- Sidebar content is vertically scrollable when folder tree is long.
- Folder tree rows adjusted for tighter left alignment and better spacing.
- “Show all test cases” alignment/padding refined.
- Added subtle truncation tooltip behavior for folder labels.

<img width="528" height="930" alt="image" src="https://github.com/user-attachments/assets/77cf9cca-40cb-4b19-b354-6ad3dbc817d7" />


### 3. Sidebar header/content cleanup
- Reworked sidebar top row:
  - `New Folder` button at left.
  - `Test cases: (N)` count moved into header row.
- Updated total count rendering to show in parens and stay in sync with filters/pagination.

<img width="306" height="92" alt="image" src="https://github.com/user-attachments/assets/8aa4be39-c042-4ce9-ace5-aaaba019004a" />


### 4. Header controls modernization
- Replaced separate account/team controls with a single settings dropdown menu.
- Added settings gear button with smooth spin-state animation.
- Settings dropdown now includes:
  - Theme selector
  - Team code + copy action
  - Account info
  - Logout action
- Search/filter region expanded to use reclaimed header space.

<img width="550" height="428" alt="image" src="https://github.com/user-attachments/assets/979206c6-dc76-4e80-98e6-77253d851b03" />


### 5. Theme system
- Added modular theme control module with `localStorage` persistence.
- Added two workspace themes:
  - `Dark Gray` (default, multi-shade component surfaces)
  - `High Contrast` (near-black)
- Applied theme-aware styling to:
  - Header
  - Sidebar
  - Grid frame/footer
  - Dropdowns/controls
  - Notifications/toasts
  - Bulk edit bar
  - Confirm modals
- Updated landing/login/register surfaces to align with gray dark theme direction.

<img width="1669" height="982" alt="image" src="https://github.com/user-attachments/assets/778b5588-c8ae-43ae-8ddf-e037618e49f2" />

_Jet black theme. (Grey is the default)_

### 6. Notifications/toasts
- Moved notices to top-center toast style.
- **Added auto-dismiss behavior (5s)**. 
- Added dismiss by both:
  - `OK` action button
  - `X` close button
- Ensured notice styling follows selected workspace theme.
- Kept dismiss button label stable as `OK` for consistent behavior.

<img width="1498" height="806" alt="image" src="https://github.com/user-attachments/assets/2688b799-cef0-4218-a1b2-bd91efef5ca3" />


### 7. Confirm delete folder modal
- Replaced corner prompt style with centered modal dialog.
- Added dim backdrop for focus.
- Added theme-aware visual styling.
- Added keyboard handling/focus trap behavior (Escape/Tab loop).
- Added restore-focus behavior when dialog closes.
- Added backdrop click to cancel.

<img width="1361" height="905" alt="image" src="https://github.com/user-attachments/assets/9e13ca2d-178d-4003-9e5a-fd6c85f9af5e" />


### 8. Grid/table interaction fixes
- Updated row action button rendering to avoid inconsistent growth/jumping.
- Standardized Preview button behavior for stable sizing.
- Final tuning made Preview button skinnier while preserving non-wrap stability and alignment.
- Capitalization consistency improved (`Hide Preview`).

## Files Touched (In case conflicts easy to compare)
- Workspace templates:
  - `templates/workspace.html`
  - `templates/workspace/_header.html`
  - `templates/workspace/_main.html`
  - `templates/workspace/_notices.html`
  - `templates/workspace/_bulk-bar.html`
- Workspace frontend modules:
  - `static/js/workspace/page.js`
  - `static/js/workspace/grid.js`
  - `static/js/workspace/components/workspace-folder-tree.js`
  - `static/js/workspace/features/workspace-header-controls.js`
  - `static/js/workspace/features/workspace-import-controller.js`
  - `static/js/workspace/features/workspace-data-controller.js`
  - `static/js/workspace/features/workspace-theme-controls.js` (new)
- Auth/landing templates:
  - `templates/landing.html`
  - `templates/login.html`
  - `templates/register.html`
- Context/state update:
  - `.context/STATE.md`

## Testing / Verification
- Manual verification performed for:
  - Sidebar drag resize/open/close
  - Sidebar vertical scroll behavior
  - Folder tree alignment + truncation tooltip
  - Theme switch and persistence
  - Header settings dropdown interactions
  - Toast dismiss (`OK` + `X`) and auto-dismiss timing
  - Delete folder confirmation modal focus behavior
